### PR TITLE
Race condition when using pnThreadedSocket

### DIFF
--- a/net/auth/pnAuthClient.cpp
+++ b/net/auth/pnAuthClient.cpp
@@ -328,8 +328,6 @@ pnAuthClient::pnAuthClient(plResManager* mgr, bool deleteMsgs, bool threaded)
 
 pnAuthClient::~pnAuthClient()
 {
-    if (fSock != NULL)
-        fSock->close();
     delete fIface;
     delete fDispatch;
     delete fSock;
@@ -370,8 +368,6 @@ ENetError pnAuthClient::connect(int sockFd)
 
 void pnAuthClient::disconnect()
 {
-    if (fSock != NULL)
-        fSock->close();
     delete fIface;
     delete fDispatch;
     delete fSock;

--- a/net/file/pnFileClient.cpp
+++ b/net/file/pnFileClient.cpp
@@ -190,8 +190,6 @@ pnFileClient::pnFileClient(bool threaded) : fSock(NULL), fThreaded(threaded), fD
 
 pnFileClient::~pnFileClient()
 {
-    if (fSock != NULL)
-        fSock->close();
     delete fIface;
     delete fDispatch;
     delete fSock;
@@ -224,8 +222,6 @@ ENetError pnFileClient::connect(int sockFd)
 
 void pnFileClient::disconnect()
 {
-    if (fSock != NULL)
-        fSock->close();
     delete fIface;
     delete fDispatch;
     delete fSock;

--- a/net/game/pnGameClient.cpp
+++ b/net/game/pnGameClient.cpp
@@ -90,8 +90,6 @@ pnGameClient::pnGameClient(plResManager* mgr, bool deleteMsgs, bool threaded)
 
 pnGameClient::~pnGameClient()
 {
-    if (fSock != NULL)
-        fSock->close();
     delete fIface;
     delete fDispatch;
     delete fSock;
@@ -138,8 +136,6 @@ ENetError pnGameClient::connect(int sockFd)
 
 void pnGameClient::disconnect()
 {
-    if (fSock != NULL)
-        fSock->close();
     delete fIface;
     delete fDispatch;
     delete fSock;

--- a/net/gate/pnGateKeeperClient.cpp
+++ b/net/gate/pnGateKeeperClient.cpp
@@ -64,8 +64,6 @@ pnGateKeeperClient::pnGateKeeperClient(bool threaded) : fSock(NULL), fThreaded(t
 
 pnGateKeeperClient::~pnGateKeeperClient()
 {
-    if (fSock != NULL)
-        fSock->close();
     delete fIface;
     delete fDispatch;
     delete fSock;
@@ -106,8 +104,6 @@ ENetError pnGateKeeperClient::connect(int sockFd)
 
 void pnGateKeeperClient::disconnect()
 {
-    if (fSock != NULL)
-        fSock->close();
     delete fIface;
     delete fDispatch;
     delete fSock;

--- a/net/pnSocketInterface.cpp
+++ b/net/pnSocketInterface.cpp
@@ -42,7 +42,7 @@ class pnThreadHelper : public hsThread {
 public:
     pnThreadHelper(pnSocket* sock, pnDispatcher* dispatch);
     virtual ~pnThreadHelper();
-    void stop() { fRunning = false; }
+    void stop();
 
 private:
     virtual void run();
@@ -68,6 +68,14 @@ void pnThreadHelper::run()
         // close the socket if anything fails
         if (!fReceiver->dispatch(fSock))
             fSock->close();
+    }
+}
+
+void pnThreadHelper::stop()
+{ 
+    if (!isFinished()) {
+        fRunning = false; 
+        wait(); 
     }
 }
 


### PR DESCRIPTION
When using threaded dispatch, pnThreadHelper instance can be deleted (by pnThreadedSocket destructor called from disconnect() method or pnClient destructor) before thread working on it finished. Additionally, socket can be closed (or even deleted) while helper thread is still in dispatch() method.
