### PR TITLE
Following Deledrius' Plasma enhancment for loading PNGs

### DIFF
--- a/core/Vault/plVaultNode.h
+++ b/core/Vault/plVaultNode.h
@@ -51,7 +51,7 @@ namespace plVault {
     };
 
     enum ImageTypes {
-        kNone, kJPEG
+        kNone, kJPEG, kPNG
     };
 
     enum NodePermissions {


### PR DESCRIPTION
from the vault, add corresponding type id support to libhsplasma
