### PR TITLE
Fix improper rotation results when reading Havok physicals

### DIFF
--- a/core/PRP/Physics/plGenericPhysical.cpp
+++ b/core/PRP/Physics/plGenericPhysical.cpp
@@ -403,7 +403,7 @@ void plGenericPhysical::IReadHKPhysical(hsStream* S, plResManager* mgr) {
     float rad = S->readFloat();
     hsVector3 axis;
     axis.read(S);
-    fRot = hsQuat(axis.X, axis.Y, axis.Z, rad);
+    fRot = hsQuat(rad, axis);
 
     unsigned int hMemberGroup, hReportGroup, hCollideGroup;
     fMass = S->readFloat();


### PR DESCRIPTION
Wrong constructor was being used here which resulted in incorrect rotational positioning.

Found this when converting Ages from Path of the Shell format to MOULa format.

Thanks to Hoikas tracking this one down!
