### PR TITLE
Add load callbacks, modifier targets and CI parents

### DIFF
--- a/core/PRP/KeyedObject/plKey.cpp
+++ b/core/PRP/KeyedObject/plKey.cpp
@@ -84,6 +84,34 @@ void plKeyData::UnRef() {
     }
 }
 
+void plKeyData::setObj(class hsKeyedObject* obj) {
+    if (obj == fObjPtr)
+        return;
+
+    if (fObjPtr != NULL && !fObjPtr->isStub())
+        throw hsBadParamException(__FILE__, __LINE__, "Trying to change already loaded object");
+
+    fObjPtr = obj;
+
+    if (obj && !obj->isStub()) {
+        for (auto it = fCallbacks.begin(); it != fCallbacks.end(); it++)
+            (*it)(obj);
+
+        fCallbacks.clear();
+    }
+}
+
+void plKeyData::deleteObj() {
+    delete fObjPtr;
+    fObjPtr = 0;
+}
+
+void plKeyData::addCallback(const AfterLoadCallback& callback) {
+    if (fObjPtr != NULL)
+        callback(fObjPtr);
+    else
+        fCallbacks.push_back(callback);
+}
 
 /* plKey */
 plKey::plKey() : fKeyData(NULL) { }

--- a/core/PRP/KeyedObject/plKey.h
+++ b/core/PRP/KeyedObject/plKey.h
@@ -18,6 +18,8 @@
 #define _PLKEY_H
 
 #include "plUoid.h"
+#include <functional>
+#include <vector>
 
 #define GET_KEY_OBJECT(key, classname) \
     ((key.Exists() && key.isLoaded()) \
@@ -58,7 +60,10 @@ public:
      */
     ~plKeyData() { }
 
+    typedef std::function<void (hsKeyedObject*)> AfterLoadCallback;
 private:
+    std::vector<AfterLoadCallback> fCallbacks;
+
     uint32_t Ref() { return ++fRefCnt; }
     void UnRef();
     friend class plKey;
@@ -136,7 +141,10 @@ public:
     class hsKeyedObject* getObj() { return fObjPtr; }
 
     /** Sets the object referenced by this key. */
-    void setObj(class hsKeyedObject* obj) { fObjPtr = obj; }
+    void setObj(class hsKeyedObject* obj);
+
+    /** Delete object referenced by this key. */
+    void deleteObj();
 
     /** Returns the Class Index of the object referenced by this key */
     short getType() const { return fUoid.getType(); }
@@ -222,6 +230,15 @@ public:
      * is done automatically by the plResManager when writing pages.
      */
     void setObjSize(uint32_t size) { fObjSize = size; }
+
+    /**
+     * Add callback to be called after referenced object is loaded. 
+     * Callbacks added after object load will be executed immediately.
+     */
+    void addCallback(const AfterLoadCallback& callback);
+
+     /** Remove all callbacks, without executing */
+    void clearCallbacks() { fCallbacks.clear(); }
 };
 
 /**

--- a/core/PRP/Modifier/plModifier.cpp
+++ b/core/PRP/Modifier/plModifier.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "plModifier.h"
+#include <algorithm>
 
 /* plSingleModifier */
 void plSingleModifier::read(hsStream* S, plResManager* mgr) {
@@ -71,4 +72,13 @@ void plMultiModifier::IPrcParse(const pfPrcTag* tag, plResManager* mgr) {
     } else {
         plSynchedObject::IPrcParse(tag, mgr);
     }
+}
+
+void plMultiModifier::removeTarget(plKey target) {
+    auto it = std::find(fTargets.begin(), fTargets.end(), target);
+
+    if (it == fTargets.end())
+        throw hsBadParamException(__FILE__, __LINE__, "Trying to remove invalid target");
+
+    fTargets.erase(it);
 }

--- a/core/PRP/Modifier/plModifier.h
+++ b/core/PRP/Modifier/plModifier.h
@@ -23,6 +23,19 @@
 
 class PLASMA_DLL plModifier : public virtual plSynchedObject {
     CREATABLE(plModifier, kModifier, plSynchedObject)
+
+public:
+    /** Get number of targets (scene objects) referenced by this modifier */
+    virtual size_t getTargetsCount() const { return 0; }
+
+    /** Get key of n-th referenced target */
+    virtual plKey getTarget(size_t /*pos*/) const { return plKey(); }
+
+    /** Add referenced scene object */
+    virtual void addTarget(plKey /*target*/) {}
+
+    /** Remove scene object from target list */
+    virtual void removeTarget(plKey /*target*/) {}
 };
 
 
@@ -31,6 +44,7 @@ class PLASMA_DLL plSingleModifier : public virtual plModifier {
 
 protected:
     hsBitVector fFlags;
+    plKey fTarget;
 
 public:
     virtual void read(hsStream* S, plResManager* mgr);
@@ -43,6 +57,11 @@ protected:
 public:
     bool getFlag(size_t flag) const { return fFlags.get(flag); }
     void setFlag(size_t flag, bool value) { fFlags.set(flag, value); }
+
+    virtual size_t getTargetsCount() const { return fTarget.Exists()?1:0; }
+    virtual plKey getTarget(size_t /*pos*/) const { return fTarget; }
+    virtual void addTarget(plKey target) { fTarget = target; };
+    virtual void removeTarget(plKey /*target*/) { fTarget = plKey(); }
 };
 
 
@@ -51,6 +70,7 @@ class PLASMA_DLL plMultiModifier : public virtual plModifier {
 
 protected:
     hsBitVector fFlags;
+    std::vector<plKey> fTargets;
 
 public:
     virtual void read(hsStream* S, plResManager* mgr);
@@ -63,6 +83,11 @@ protected:
 public:
     bool getFlag(size_t flag) const { return fFlags.get(flag); }
     void setFlag(size_t flag, bool value) { fFlags.set(flag, value); }
+
+    virtual size_t getTargetsCount() const { return fTargets.size(); }
+    virtual plKey getTarget(size_t pos) const { return fTargets.at(pos); };
+    virtual void addTarget(plKey target) { fTargets.push_back(target); };
+    virtual void removeTarget(plKey target);
 };
 
 

--- a/core/PRP/Object/plCoordinateInterface.h
+++ b/core/PRP/Object/plCoordinateInterface.h
@@ -24,17 +24,21 @@
 class PLASMA_DLL plCoordinateInterface : public virtual plObjInterface {
     CREATABLE(plCoordinateInterface, kCoordinateInterface, plObjInterface)
 
+
 public:
     enum plCoordinateProperties {
         kDisable, kCanEverDelayTransform, kDelayedTransformEval, kNumProps
     };
 
-public:
+private:
     hsMatrix44 fLocalToParent;
     hsMatrix44 fParentToLocal;
     hsMatrix44 fLocalToWorld;
     hsMatrix44 fWorldToLocal;
     hsTArray<plKey> fChildren;
+    plKey fParent;
+
+    void setParentCallback(hsKeyedObject* ko);
 
 public:
     plCoordinateInterface();
@@ -62,6 +66,12 @@ public:
     void addChild(plKey child) { fChildren.append(child); }
     void delChild(size_t idx) { fChildren.remove(idx); }
     void clearChildren() { fChildren.clear(); }
+
+    /** Set parent coordinate interface */
+    void setParent(plKey parent) { fParent = parent; }
+
+    /** Get parent coordinate interface */
+    plKey getParent() const { return fParent; }
 };
 
 #endif

--- a/core/PRP/Object/plSceneObject.h
+++ b/core/PRP/Object/plSceneObject.h
@@ -23,6 +23,7 @@
 class PLASMA_DLL plSceneObject : public virtual plSynchedObject {
     CREATABLE(plSceneObject, kSceneObject, plSynchedObject)
 
+    void addTarget (hsKeyedObject* obj);
 public:
     plKey fDrawIntf, fSimIntf, fCoordIntf, fAudioIntf;
     hsTArray<plKey> fInterfaces, fModifiers;
@@ -57,9 +58,11 @@ public:
 
     const hsTArray<plKey>& getModifiers() const { return fModifiers; }
     hsTArray<plKey>& getModifiers() { return fModifiers; }
-    void addModifier(plKey intf) { fModifiers.append(intf); }
-    void delModifier(size_t idx) { fModifiers.remove(idx); }
-    void clearModifiers() { fModifiers.clear(); }
+    void addModifier(plKey intf);
+    void delModifier(size_t idx);
+    void clearModifiers();
+
+    virtual ~plSceneObject();
 };
 
 #endif

--- a/core/PRP/Particle/plParticleSystem.cpp
+++ b/core/PRP/Particle/plParticleSystem.cpp
@@ -34,7 +34,7 @@ plParticleSystem::~plParticleSystem() {
 }
 
 void plParticleSystem::read(hsStream* S, plResManager* mgr) {
-    plSynchedObject::read(S, mgr);
+    plModifier::read(S, mgr);
 
     fMaterial = mgr->readKey(S);
     setAmbientCtl(plController::Convert(mgr->ReadCreatable(S)));

--- a/core/PRP/Particle/plParticleSystem.h
+++ b/core/PRP/Particle/plParticleSystem.h
@@ -17,12 +17,12 @@
 #ifndef _PLPARTICLESYSTEM_H
 #define _PLPARTICLESYSTEM_H
 
-#include "PRP/Object/plSynchedObject.h"
+#include "PRP/Modifier/plModifier.h"
 #include "PRP/Animation/plController.h"
 #include "plParticleEmitter.h"
 
-class PLASMA_DLL plParticleSystem : public virtual plSynchedObject {
-    CREATABLE(plParticleSystem, kParticleSystem, plSynchedObject)
+class PLASMA_DLL plParticleSystem : public virtual plModifier {
+    CREATABLE(plParticleSystem, kParticleSystem, plModifier)
 
 public:
     enum EffectType {

--- a/core/ResManager/plKeyCollector.cpp
+++ b/core/ResManager/plKeyCollector.cpp
@@ -69,8 +69,7 @@ void plKeyCollector::del(plKey key) {
     if (keys[key->getLocation()].empty())
         keys.erase(key->getLocation());
     if (key.Exists() && key.isLoaded()) {
-        delete key->getObj();
-        key->setObj(NULL);
+        key->deleteObj();
     }
 }
 
@@ -79,10 +78,8 @@ void plKeyCollector::delAll(const plLocation& loc) {
     std::map<short, std::vector<plKey> >::iterator it = locList.begin();
     while (it != locList.end()) {
         for (std::vector<plKey>::iterator i2 = it->second.begin(); i2 != it->second.end(); i2++) {
-            if ((*i2).Exists() && (*i2).isLoaded()) {
-                delete (*i2)->getObj();
-                (*i2)->setObj(0);
-            }
+            if (i2->Exists() && i2->isLoaded())
+                (*i2)->deleteObj();
         }
         it++;
     }

--- a/core/ResManager/plResManager.cpp
+++ b/core/ResManager/plResManager.cpp
@@ -60,6 +60,12 @@ plKey plResManager::readKey(hsStream* S) {
     }
 }
 
+plKey plResManager::readKeyNotify(hsStream* S,  const plKeyData::AfterLoadCallback& callback) {
+    plKey key = readKey(S);
+    key->addCallback(callback);
+    return key;
+}
+
 plKey plResManager::readUoid(hsStream* S) {
     if (getVer() != S->getVer())
         throw hsVersionMismatchException(__FILE__, __LINE__);
@@ -107,6 +113,12 @@ plKey plResManager::prcParseKey(const pfPrcTag* tag) {
     if (k.Exists())
         return AddKey(k);
     return k;
+}
+
+plKey plResManager::prcParseKeyNotify(const pfPrcTag* tag, const plKeyData::AfterLoadCallback& callback) {
+    plKey key = prcParseKey(tag);
+    key->addCallback(callback);
+    return key;
 }
 
 hsKeyedObject* plResManager::getObject(plKey key) {
@@ -545,18 +557,15 @@ unsigned int plResManager::ReadObjects(hsStream* S, const plLocation& loc) {
                 plDebug::Error("Failed reading %s: %s",
                                kList[j]->toString().cstr(), e.what());
                 plDebug::Error("Failure on line %s:%d", e.File(), e.Line());
-                delete kList[j]->getObj();
-                kList[j]->setObj(NULL);
+                kList[j]->deleteObj();
             } catch (const std::exception& e) {
                 plDebug::Error("Failed reading %s: %s",
                                kList[j]->toString().cstr(), e.what());
-                delete kList[j]->getObj();
-                kList[j]->setObj(NULL);
+                kList[j]->deleteObj();
             } catch (...) {
                 plDebug::Error("Undefined error reading %s",
                                kList[j]->toString().cstr());
-                delete kList[j]->getObj();
-                kList[j]->setObj(NULL);
+                kList[j]->deleteObj();
             }
             delete subStream;
         }

--- a/core/ResManager/plResManager.h
+++ b/core/ResManager/plResManager.h
@@ -102,6 +102,12 @@ public:
     /** Read a plKey and register it with the ResManager */
     plKey readKey(hsStream* S);
 
+    /** 
+     * Read a plKey, register it with the ResManager and add callback
+     * \param callback Callback to be called after object referenced by this key is loaded
+     */
+    plKey readKeyNotify(hsStream* S, const plKeyData::AfterLoadCallback& callback);
+
     /** Read a raw plKey from a stream (no "exists" bool for Uru streams) */
     plKey readUoid(hsStream* S);
 
@@ -119,6 +125,12 @@ public:
 
     /** Parse the PRC tag as a plKey and register it with the ResManager */
     plKey prcParseKey(const pfPrcTag* tag);
+
+    /** 
+     * Parse the PRC tag as a plKey, register it with the ResManager and add callback
+     * \param callback Callback to be called after object referenced by this key is parsed
+     */
+    plKey prcParseKeyNotify(const pfPrcTag* tag, const plKeyData::AfterLoadCallback& callback);
 
     /**
      * Find and return the object referenced by key, or NULL if the key


### PR DESCRIPTION
Allow keys to have callbacks, that will be called after referenced object is loaded. With this change it is possible to create list of plModifer targets automatically, after referencing plSceneObjects are read (previously, only scene object had list of referenced modifiers).
