### PR TITLE
Also find Python installed as a framework on Mac OS X

### DIFF
--- a/cmake/FindPython.cmake
+++ b/cmake/FindPython.cmake
@@ -115,12 +115,16 @@ EXECUTE_PROCESS(COMMAND "${PYTHON_EXECUTABLE}" # maybe there's a simpler way to 
   "-c" "import distutils.sysconfig; import sys; import os; sys.stdout.write(distutils.sysconfig.get_config_var('LIBDIR'))"
   OUTPUT_VARIABLE _PYTHON_LIBRARY_PATH
 )
+EXECUTE_PROCESS(COMMAND "${PYTHON_EXECUTABLE}" # maybe there's a simpler way to do this? I haven't found it yet
+  "-c" "import distutils.sysconfig; import sys; import os; sys.stdout.write(distutils.sysconfig.get_config_var('PYTHONFRAMEWORKPREFIX') or '')"
+  OUTPUT_VARIABLE _PYTHON_FRAMEWORK_PATH
+)
 EXECUTE_PROCESS(COMMAND "${PYTHON_EXECUTABLE}"
   "-c" "import distutils.sysconfig; import sys; sys.stdout.write(distutils.sysconfig.get_python_inc())"
   OUTPUT_VARIABLE PYTHON_INCLUDE_DIR
 )
 
-FIND_FILE(PYTHON_LIBRARY ${_PYTHON_LIBRARY_NAME} PATHS ${_PYTHON_LIBRARY_PATH} NO_DEFAULT_PATH)
+FIND_FILE(PYTHON_LIBRARY ${_PYTHON_LIBRARY_NAME} PATHS ${_PYTHON_LIBRARY_PATH} ${_PYTHON_FRAMEWORK_PATH} NO_DEFAULT_PATH)
 FIND_FILE(PYTHON_HEADER "Python.h" PATHS ${PYTHON_INCLUDE_DIR} NO_DEFAULT_PATH)
 
 


### PR DESCRIPTION
This is something I’ve had lying around for a long time. It enables building with the Python 2.7 framework from MacPorts on Mac OS X 10.6 for me, and judging from the commit message I also tested it with other versions at the time.
