### PR TITLE
Add FileDownloadChunk callback called after sending ack

### DIFF
--- a/net/auth/pnAuthClient.cpp
+++ b/net/auth/pnAuthClient.cpp
@@ -217,6 +217,9 @@ bool pnAuthClient::Dispatch::dispatch(pnSocket* sock)
                         msgbuf[2].fUint, msgbuf[3].fUint, msgbuf[4].fUint,
                         msgbuf[5].fData);
         fReceiver->sendFileDownloadChunkAck(msgbuf[0].fUint);
+        fReceiver->onFileDownloadChunkPostAck(msgbuf[0].fUint, (ENetError)msgbuf[1].fUint,
+                        msgbuf[2].fUint, msgbuf[3].fUint, msgbuf[4].fUint,
+                        msgbuf[5].fData);
         break;
     case kAuth2Cli_KickedOff:
         fReceiver->onKickedOff(msgbuf[0].fUint);
@@ -1271,6 +1274,11 @@ void pnAuthClient::onFileDownloadChunk(uint32_t transId, ENetError result,
 {
     plDebug::Warning("Warning: Ignoring Auth2Cli_FileDownloadChunk");
 }
+
+void pnAuthClient::onFileDownloadChunkPostAck(uint32_t transId, ENetError result,
+                        uint32_t totalSize, uint32_t chunkOffset, size_t chunkSize,
+                        const unsigned char* chunkData)
+{ }
 
 void pnAuthClient::onKickedOff(uint32_t reason)
 {

--- a/net/auth/pnAuthClient.h
+++ b/net/auth/pnAuthClient.h
@@ -184,6 +184,9 @@ public:
     virtual void onFileDownloadChunk(uint32_t transId, ENetError result,
                     uint32_t totalSize, uint32_t chunkOffset, size_t chunkSize,
                     const unsigned char* chunkData);
+    virtual void onFileDownloadChunkPostAck(uint32_t transId, ENetError result,
+                    uint32_t totalSize, uint32_t chunkOffset, size_t chunkSize,
+                    const unsigned char* chunkData);
     virtual void onKickedOff(uint32_t reason);
     virtual void onPublicAgeList(uint32_t transId, ENetError result,
                     size_t count, const pnNetAgeInfo* ages);


### PR DESCRIPTION
The current pnAuthClient::onFileDownloadChunk callback is called before sending the acknowledge message to the server. This callback is typically used to send the next command to the server. Some servers (notably MOSS) don’t like it if you request a new file before acknowledging receipt of the previous one. To handle that, the callback should be called after sending the ack message. To avoid disrupting functionality of existing library users, the existing onFileDownloadChunk method is left alone and a new additional method pnAuthClient::onFileDownloadChunkPostAck is introduced.
