### PR TITLE
Allow user-specified G values for encryption keys

### DIFF
--- a/net/auth/pnAuthClient.cpp
+++ b/net/auth/pnAuthClient.cpp
@@ -400,7 +400,7 @@ ENetError pnAuthClient::performConnect()
         pnBigInteger N(fKeyN, 64, fLittleEndianKeys);
         pnBigInteger b = pnBigInteger::Random(512);
         clientSeed = X.PowMod(b, N);
-        pnBigInteger serverSeed = pnBigInteger(41).PowMod(b, N);
+        pnBigInteger serverSeed = pnBigInteger(fKeyG).PowMod(b, N);
         serverSeed.getData(y_data, 64);
     }
 

--- a/net/auth/pnAuthClient.h
+++ b/net/auth/pnAuthClient.h
@@ -47,11 +47,12 @@ class PLASMANET_DLL pnAuthClient : public pnClient {
 public:
     pnAuthClient(plResManager* mgr, bool deleteMsgs = true, bool threaded = true)
         : fSock(NULL), fResMgr(mgr), fDeleteMsgs(deleteMsgs), fThreaded(threaded),
-          fDispatch(NULL) { }
+          fKeyG(41), fDispatch(NULL) { }
     virtual ~pnAuthClient();
 
     void setKeys(const unsigned char* keyX, const unsigned char* keyN,
                  bool littleEndian = true);
+    void setKeyG(int g) { fKeyG = g; }
     void setClientInfo(uint32_t buildId, uint32_t buildType, uint32_t branchId,
                        const plUuid& productId);
     virtual ENetError connect(const char* host, short port = 14617);
@@ -215,6 +216,7 @@ private:
     unsigned char fKeyX[64];
     unsigned char fKeyN[64];
     bool fLittleEndianKeys;
+    int fKeyG;
 
     class Dispatch : public pnDispatcher {
     public:

--- a/net/game/pnGameClient.cpp
+++ b/net/game/pnGameClient.cpp
@@ -163,7 +163,7 @@ ENetError pnGameClient::performConnect()
         pnBigInteger N(fKeyN, 64, fLittleEndianKeys);
         pnBigInteger b = pnBigInteger::Random(512);
         clientSeed = X.PowMod(b, N);
-        pnBigInteger serverSeed = pnBigInteger(73).PowMod(b, N);
+        pnBigInteger serverSeed = pnBigInteger(fKeyG).PowMod(b, N);
         serverSeed.getData(y_data, 64);
     }
 

--- a/net/game/pnGameClient.h
+++ b/net/game/pnGameClient.h
@@ -27,12 +27,13 @@
 class PLASMANET_DLL pnGameClient : public pnClient {
 public:
     pnGameClient(plResManager* mgr, bool deleteMsgs = true, bool threaded = true)
-        : fSock(NULL), fResMgr(mgr), fThreaded(threaded), fDeleteMsgs(deleteMsgs),
-          fDispatch(NULL) { }
+        : fSock(NULL), fResMgr(mgr), fThreaded(threaded), fKeyG(73),
+          fDeleteMsgs(deleteMsgs), fDispatch(NULL) { }
     virtual ~pnGameClient();
 
     void setKeys(const unsigned char* keyX, const unsigned char* keyN,
                  bool littleEndian = true);
+    void setKeyG(int g) { fKeyG = g; }
     void setClientInfo(uint32_t buildId, uint32_t buildType, uint32_t branchId,
                        const plUuid& productId);
     void setJoinInfo(const plUuid& accountId, const plUuid& ageId);
@@ -72,6 +73,7 @@ private:
     unsigned char fKeyX[64];
     unsigned char fKeyN[64];
     bool fLittleEndianKeys;
+    int fKeyG;
     bool fDeleteMsgs;
 
     class Dispatch : public pnDispatcher {

--- a/net/gate/pnGateKeeperClient.cpp
+++ b/net/gate/pnGateKeeperClient.cpp
@@ -131,7 +131,7 @@ ENetError pnGateKeeperClient::performConnect()
         pnBigInteger N(fKeyN, 64, fLittleEndianKeys);
         pnBigInteger b = pnBigInteger::Random(512);
         clientSeed = X.PowMod(b, N);
-        pnBigInteger serverSeed = pnBigInteger(4).PowMod(b, N);
+        pnBigInteger serverSeed = pnBigInteger(fKeyG).PowMod(b, N);
         serverSeed.getData(y_data, 64);
     }
 

--- a/net/gate/pnGateKeeperClient.h
+++ b/net/gate/pnGateKeeperClient.h
@@ -27,11 +27,12 @@
 class PLASMANET_DLL pnGateKeeperClient : public pnClient {
 public:
     pnGateKeeperClient(bool threaded = true)
-         : fSock(NULL), fThreaded(threaded), fDispatch(NULL) { }
+         : fSock(NULL), fThreaded(threaded), fKeyG(4), fDispatch(NULL) { }
     virtual ~pnGateKeeperClient();
 
     void setKeys(const unsigned char* keyX, const unsigned char* keyN,
                  bool littleEndian = true);
+    void setKeyG(int g) { fKeyG = g; }
     void setClientInfo(uint32_t buildId, uint32_t buildType, uint32_t branchId,
                        const plUuid& productId);
     virtual ENetError connect(const char* host, short port = 14617);
@@ -65,6 +66,7 @@ private:
     unsigned char fKeyX[64];
     unsigned char fKeyN[64];
     bool fLittleEndianKeys;
+    int fKeyG;
 
     class Dispatch : public pnDispatcher {
     public:


### PR DESCRIPTION
There is no real reason to use other generator (G) values than the previously hardcoded default ones (4, 41, 73), but some shards (notably Minkata) do.
