### PR TITLE
Try harder to get matching versions of python libraries and interpreter

### DIFF
--- a/Python/CMakeLists.txt
+++ b/Python/CMakeLists.txt
@@ -1,5 +1,10 @@
 find_package(PythonLibs REQUIRED)
-find_package(PythonInterp REQUIRED)
+find_package(PythonInterp "${PYTHONLIBS_VERSION_STRING}" REQUIRED)
+# make sure the versions match
+if (NOT "${PYTHONLIBS_VERSION_STRING}" STREQUAL "${PYTHON_VERSION_STRING}")
+    message(FATAL_ERROR "Versions of Python libraries (${PYTHONLIBS_VERSION_STRING}) and Python interpreter (${PYTHON_VERSION_STRING}) do not match. Please configure the paths manually.")
+endif()
+
 
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
     set(CMAKE_CXX_FLAGS "-fno-strict-aliasing ${CMAKE_CXX_FLAGS}")


### PR DESCRIPTION
This also adds a check whether we succeed. It fixes issue #47 on my system.

There is however still an opportunity for failure: The PythonLibs version becomes the minimal required version for PythonInterp. If PythonLibs chooses a small version of the libraries, PythonInterp could decide that a larger version is just as good. That doesn't happen on my system with both 2.7 and 3.4 installed. I also found no good way to fix it. At least cmake can detect this case now.
