### PR TITLE
Clamp restitution values to valid range.

### DIFF
--- a/core/PRP/Physics/plGenericPhysical.cpp
+++ b/core/PRP/Physics/plGenericPhysical.cpp
@@ -649,6 +649,10 @@ void plGenericPhysical::IWriteODEPhysical(hsStream* S, plResManager* mgr) {
 void plGenericPhysical::IWritePXPhysical(hsStream* S, plResManager* mgr) {
     S->writeFloat(fMass);
     S->writeFloat(fFriction);
+    if (fRestitution < 0)
+        fRestitution = 0;
+    if (fRestitution > 1)
+        fRestitution = 1;
     S->writeFloat(fRestitution);
     S->writeByte(fBounds);
     S->writeByte(plPXSimDefs::toGroup(fMemberGroup, fCollideGroup));


### PR DESCRIPTION
Fixes the bug previously worked around by https://github.com/H-uru/Plasma/pull/347

As discussed in that PR, PyPRP exports restitution values which are invalid for PhysX physicals.  This change ensures that the library doesn't just pass along these bad values.