### PR TITLE
GeoSpan + RT Lights

### DIFF
--- a/core/PRP/Geometry/plDrawableSpans.cpp
+++ b/core/PRP/Geometry/plDrawableSpans.cpp
@@ -790,7 +790,12 @@ void plDrawableSpans::composeGeometry(bool clearspans, bool calcbounds) {
         icicle.setWorldToLocal(span->getWorldToLocal());
         icicle.setMaterialIdx(mat_idx);
         icicle.setGroupIdx(groups[format].second);
-        icicle.setProps(plSpan::deswizzleGeoFlags(span->getProps()));
+        uint32_t props = plSpan::deswizzleGeoFlags(span->getProps());
+        if (span->getPermaLights().size() > 0)
+            props |= plSpan::kPropHasPermaLights;
+        if (span->getPermaProjs().size() > 0)
+            props |= plSpan::kPropHasPermaProjs;
+        icicle.setProps(props);
         icicle.setBaseMatrix(span->getBaseMatrix());
         icicle.setFogEnvironment(span->getFogEnvironment());
         icicle.setLocalBounds(span->getLocalBounds());
@@ -802,6 +807,8 @@ void plDrawableSpans::composeGeometry(bool clearspans, bool calcbounds) {
         icicle.setWaterHeight(span->getWaterHeight());
         icicle.setPenBoneIdx(span->getPenBoneIdx());
         icicle.setNumMatrices(span->getNumMatrices());
+        icicle.setPermaLights(span->getPermaLights());
+        icicle.setPermaProjs(span->getPermaProjs());
         addIcicle(icicle);
     }
 
@@ -834,6 +841,8 @@ void plDrawableSpans::decomposeGeometry(bool clearcolors) {
         span->setMaxBoneIdx(icicle->getMaxBoneIdx());
         span->setWaterHeight(icicle->getWaterHeight());
         span->setPenBoneIdx(icicle->getPenBoneIdx());
+        span->setPermaLights(icicle->getPermaLights());
+        span->setPermaProjs(icicle->getPermaProjs());
 
         span->setFormat(group->getFormat());
 

--- a/core/PRP/Geometry/plGeometrySpan.h
+++ b/core/PRP/Geometry/plGeometrySpan.h
@@ -23,6 +23,7 @@
 #include "PRP/Region/hsBounds.h"
 #include "Sys/hsColor.h"
 #include "Math/hsGeometry3.h"
+#include "PRP/KeyedObject/plKey.h"
 
 class PLASMA_DLL plGeometrySpan {
 public:
@@ -98,6 +99,9 @@ protected:
 
     unsigned int numInstanceRefs;
 
+    std::vector<plKey> fPermaLights;
+    std::vector<plKey> fPermaProjs;
+
 public:
     plGeometrySpan() :fFormat(0), fNumMatrices(0), fBaseMatrix(0), fLocalUVWChans(0),
         fMaxBoneIdx(0), fPenBoneIdx(0), fMinDist(0.f), fMaxDist(0.f), fWaterHeight(0.f),
@@ -148,6 +152,20 @@ public:
     void setLocalUVWChans(unsigned int chans) { fLocalUVWChans = chans; }
     void setMaxBoneIdx(unsigned int idx) { fMaxBoneIdx = idx; }
     void setPenBoneIdx(unsigned int idx) { fPenBoneIdx = idx; }
+
+    const std::vector<plKey>& getPermaLights() const { return fPermaLights; }
+    std::vector<plKey>& getPermaLights() { return fPermaLights; }
+    void setPermaLights(const std::vector<plKey>& lights) { fPermaLights = lights; }
+    void addPermaLight(plKey light) { fPermaLights.push_back(light); }
+    void delPermaLight(size_t idx) { fPermaLights.erase(fPermaLights.begin() + idx); }
+    void clearPermaLights() { fPermaLights.clear(); }
+
+    const std::vector<plKey>& getPermaProjs() const { return fPermaProjs; }
+    std::vector<plKey>& getPermaProjs() { return fPermaProjs; }
+    void setPermaProjs(const std::vector<plKey>& lights) { fPermaProjs = lights; }
+    void addPermaProj(plKey light) { fPermaProjs.push_back(light); }
+    void delPermaProj(size_t idx) { fPermaProjs.erase(fPermaProjs.begin() + idx); }
+    void clearPermaProjs() { fPermaProjs.clear(); }
 };
 
 #endif

--- a/core/PRP/Geometry/plSpan.h
+++ b/core/PRP/Geometry/plSpan.h
@@ -145,12 +145,14 @@ public:
 
     const std::vector<plKey>& getPermaLights() const { return fPermaLights; }
     std::vector<plKey>& getPermaLights() { return fPermaLights; }
+    void setPermaLights(const std::vector<plKey>& lights) { fPermaLights = lights; }
     void addPermaLight(plKey light) { fPermaLights.push_back(light); }
     void delPermaLight(size_t idx) { fPermaLights.erase(fPermaLights.begin() + idx); }
     void clearPermaLights() { fPermaLights.clear(); }
 
     const std::vector<plKey>& getPermaProjs() const { return fPermaProjs; }
     std::vector<plKey>& getPermaProjs() { return fPermaProjs; }
+    void setPermaProjs(const std::vector<plKey>& lights) { fPermaProjs = lights; }
     void addPermaProj(plKey proj) { fPermaProjs.push_back(proj); }
     void delPermaProj(size_t idx) { fPermaProjs.erase(fPermaProjs.begin() + idx); }
     void clearPermaProjs() { fPermaProjs.clear(); }


### PR DESCRIPTION
`plGeometrySpan` now knows about the PermaLights and PermaProjections, just like the actual spans do. This includes Python bindings and compose/decompose support. I know that this is not 1:1 with what Plasma does, but it's easier IME to deal with RT lights here instead of after the fact.