### PR TITLE
pyFileStream and pyEncryptedStream with statements

### DIFF
--- a/Python/Stream/pyEncryptedStream.cpp
+++ b/Python/Stream/pyEncryptedStream.cpp
@@ -48,8 +48,8 @@ static PyObject* pyEncryptedStream_open(pyEncryptedStream* self, PyObject* args)
             PyErr_SetString(PyExc_IOError, "Error opening file");
             return NULL;
         }
-        Py_INCREF(Py_None);
-        return Py_None;
+        Py_INCREF(self);
+        return (PyObject*)self;
     } catch (...) {
         PyErr_SetString(PyExc_IOError, "Error opening file");
         return NULL;
@@ -107,6 +107,17 @@ static PyObject* pyEncryptedStream_IsFileEncrypted(PyObject*, PyObject* args) {
     return PyBool_FromLong(result ? 1 : 0);
 }
 
+static PyObject* pyEncryptedStream__enter__(PyObject* self) {
+    Py_INCREF(self);
+    return self;
+}
+
+static PyObject* pyEncryptedStream__exit__(pyEncryptedStream* self, PyObject* args) {
+    self->fThis->close();
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
 static PyMethodDef pyEncryptedStream_Methods[] = {
     { "open", (PyCFunction)pyEncryptedStream_open, METH_VARARGS,
       "Params: filename, mode, encryption\n"
@@ -125,6 +136,8 @@ static PyMethodDef pyEncryptedStream_Methods[] = {
       "(static)\n"
       "Params: filename\n"
       "Tests whether the specified file is encrypted" },
+    { "__enter__", (PyCFunction)pyEncryptedStream__enter__, METH_NOARGS, NULL },
+    { "__exit__", (PyCFunction)pyEncryptedStream__exit__, METH_VARARGS, NULL },
     { NULL, NULL, 0, NULL }
 };
 

--- a/Python/Stream/pyFileStream.cpp
+++ b/Python/Stream/pyFileStream.cpp
@@ -45,8 +45,8 @@ static PyObject* pyFileStream_open(pyFileStream* self, PyObject* args) {
             PyErr_SetString(PyExc_IOError, "Error opening file");
             return NULL;
         }
-        Py_INCREF(Py_None);
-        return Py_None;
+        Py_INCREF(self);
+        return (PyObject*)self;
     } catch (...) {
         PyErr_SetString(PyExc_IOError, "Error opening file");
         return NULL;
@@ -59,6 +59,17 @@ static PyObject* pyFileStream_close(pyFileStream* self) {
     return Py_None;
 }
 
+static PyObject* pyFileStream__enter__(PyObject* self) {
+    Py_INCREF(self);
+    return self;
+}
+
+static PyObject* pyFileStream__exit__(pyFileStream* self, PyObject* args) {
+    self->fThis->close();
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
 static PyMethodDef pyFileStream_Methods[] = {
     { "open", (PyCFunction)pyFileStream_open, METH_VARARGS,
       "Params: filename, mode\n"
@@ -66,6 +77,8 @@ static PyMethodDef pyFileStream_Methods[] = {
       "Mode is: fmRead, fmWrite, fmReadWrite, fmCreate" },
     { "close", (PyCFunction)pyFileStream_close, METH_NOARGS,
       "Closes the active file, if it is open" },
+    { "__enter__", (PyCFunction)pyFileStream__enter__, METH_NOARGS, NULL },
+    { "__exit__", (PyCFunction)pyFileStream__exit__, METH_VARARGS, NULL },
     { NULL, NULL, 0, NULL }
 };
 


### PR DESCRIPTION
This implements the `__enter__` and `__exit__` methods required for` with` context management support. This implementation matches what I saw in Python 3.4's iobase.c.

In case you're unfamiliar, this allows us to write nice, pythonic code...
```python
with plEncryptedStream(pvMoul).open("sample.age", fmWrite, plEncryptedStream.kEncXtea) as moo:
    moo.writeLine("something")
```
instead of a `try`... `finally` thing.