### PR TITLE
Fix vcol color space issue

### DIFF
--- a/core/PRP/Geometry/plVertCoder.cpp
+++ b/core/PRP/Geometry/plVertCoder.cpp
@@ -130,9 +130,9 @@ void plVertCoder::IDecodeNormal(hsStream* S, unsigned char*& dest) {
 
 void plVertCoder::IDecodeColor(hsStream* S, unsigned char*& dest) {
     IDecodeByte(S, 0, dest);
-    IDecodeByte(S, 3, dest);
-    IDecodeByte(S, 2, dest);
     IDecodeByte(S, 1, dest);
+    IDecodeByte(S, 2, dest);
+    IDecodeByte(S, 3, dest);
     dest += sizeof(unsigned int);
 }
 
@@ -231,9 +231,9 @@ void plVertCoder::IEncodeNormal(hsStream* S, const unsigned char*& src) {
 void plVertCoder::IEncodeColor(hsStream* S, unsigned int vertsLeft,
                                const unsigned char*& src, unsigned int stride) {
     IEncodeByte(S, vertsLeft, 0, src, stride);
-    IEncodeByte(S, vertsLeft, 3, src, stride);
-    IEncodeByte(S, vertsLeft, 2, src, stride);
     IEncodeByte(S, vertsLeft, 1, src, stride);
+    IEncodeByte(S, vertsLeft, 2, src, stride);
+    IEncodeByte(S, vertsLeft, 3, src, stride);
     src += sizeof(unsigned int);
 }
 


### PR DESCRIPTION
This fixes an issue with vertex color encoding/decoding introduced by 5d4496e. The colors were swapped in what appears to be an attempt to replicate some unused debug bit shifting. Probably under the assumption that input data is RGBA (Plasma expects BGRA). However input data is assumed to be BGRA, as that is what `hsColor32` uses under the hood.

This issue was not noticed when testing transfused ages (which had previous issues with green vertex colors) because the bug was introduced in both the encode and decode routines, which means there was actually no net change to ages that were simply read in and written out.