### PR TITLE
Sitting Modifiers and Cursors

### DIFF
--- a/Python/CMakeLists.txt
+++ b/Python/CMakeLists.txt
@@ -145,6 +145,7 @@ set(PRP_AVTR_SRCS
     PRP/Avatar/pyScalarControllerChannel.cpp
     PRP/Avatar/pyScalarSDLChannel.cpp
     PRP/Avatar/pyScalarTimeScale.cpp
+    PRP/Avatar/pySittingModifier.cpp
     PRP/Avatar/pySoundVolumeApplicator.cpp
     PRP/Avatar/pySpotInnerApplicator.cpp
     PRP/Avatar/pySpotOuterApplicator.cpp
@@ -155,6 +156,7 @@ set(PRP_AVTR_HDRS
     PRP/Avatar/pyAGChannel.h
     PRP/Avatar/pyATCAnim.h
     PRP/Avatar/pyMultistageBehMod.h
+    PRP/Avatar/pySittingModifier.h
 )
 
 set(PRP_COND_SRCS

--- a/Python/CMakeLists.txt
+++ b/Python/CMakeLists.txt
@@ -279,6 +279,7 @@ set(PRP_MSG_SRCS
     PRP/Message/pyContainedEventData.cpp
     PRP/Message/pyControlKeyEventData.cpp
     PRP/Message/pyCoopEventData.cpp
+    PRP/Message/pyCursorChangeMsg.cpp
     PRP/Message/pyEventCallbackMsg.cpp
     PRP/Message/pyEventData.cpp
     PRP/Message/pyFacingEventData.cpp
@@ -295,6 +296,7 @@ set(PRP_MSG_SRCS
 )
 set(PRP_MSG_HDRS
     PRP/Message/pyArmatureEffectMsg.h
+    PRP/Message/pyCursorChangeMsg.h
     PRP/Message/pyEventCallbackMsg.h
     PRP/Message/pyEventData.h
     PRP/Message/pyLinkToAgeMsg.h

--- a/Python/Module.cpp
+++ b/Python/Module.cpp
@@ -44,6 +44,7 @@
 #include "PRP/Avatar/pyATCAnim.h"
 #include "PRP/Avatar/pyClothingItem.h"
 #include "PRP/Avatar/pyMultistageBehMod.h"
+#include "PRP/Avatar/pySittingModifier.h"
 #include "PRP/Audio/pyAudible.h"
 #include "PRP/Audio/pySoundBuffer.h"
 #include "PRP/ConditionalObject/pyActivatorConditionalObject.h"
@@ -532,6 +533,7 @@ PyMODINIT_FUNC initPyHSPlasma() {
     PyModule_AddObject(module, "plVolumeSensorConditionalObjectNoArbitration", Init_pyVolumeSensorConditionalObjectNoArbitration_Type());
     PyModule_AddObject(module, "plModifier", Init_pyModifier_Type());
     PyModule_AddObject(module, "plSingleModifier", Init_pySingleModifier_Type());
+    PyModule_AddObject(module, "plSittingModifier", Init_pySittingModifier_Type());
     PyModule_AddObject(module, "plDetectorModifier", Init_pyDetectorModifier_Type());
     PyModule_AddObject(module, "plPickingDetector", Init_pyPickingDetector_Type());
     PyModule_AddObject(module, "plCollisionDetector", Init_pyCollisionDetector_Type());

--- a/Python/Module.cpp
+++ b/Python/Module.cpp
@@ -72,6 +72,7 @@
 #include "PRP/Light/pyLightInfo.h"
 #include "PRP/Light/pyShadowMaster.h"
 #include "PRP/Message/pyArmatureEffectMsg.h"
+#include "PRP/Message/pyCursorChangeMsg.h"
 #include "PRP/Message/pyEventCallbackMsg.h"
 #include "PRP/Message/pyEventData.h"
 #include "PRP/Message/pyLinkToAgeMsg.h"
@@ -613,6 +614,7 @@ PyMODINIT_FUNC initPyHSPlasma() {
     PyModule_AddObject(module, "plConstAccelEaseCurve", Init_pyConstAccelEaseCurve_Type());
     PyModule_AddObject(module, "plAnimTimeConvert", Init_pyAnimTimeConvert_Type());
     PyModule_AddObject(module, "plMessage", Init_pyMessage_Type());
+    PyModule_AddObject(module, "plCursorChangeMsg", Init_pyCursorChangeMsg_Type());
     PyModule_AddObject(module, "plEventCallbackMsg", Init_pyEventCallbackMsg_Type());
     PyModule_AddObject(module, "plResponderEnableMsg", Init_pyResponderEnableMsg_Type());
     PyModule_AddObject(module, "plAGApplicator", Init_pyAGApplicator_Type());

--- a/Python/PRP/Avatar/pySittingModifier.cpp
+++ b/Python/PRP/Avatar/pySittingModifier.cpp
@@ -1,0 +1,203 @@
+/* This file is part of HSPlasma.
+ *
+ * HSPlasma is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * HSPlasma is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with HSPlasma.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <PyPlasma.h>
+#include <PRP/Avatar/plSittingModifier.h>
+#include "pySittingModifier.h"
+#include "PRP/Modifier/pyModifier.h"
+#include "PRP/KeyedObject/pyKey.h"
+
+extern "C" {
+
+static PyObject* pySittingModifier_new(PyTypeObject* type, PyObject* args, PyObject* kwds) {
+    pySittingModifier* self = (pySittingModifier*)type->tp_alloc(type, 0);
+    if (self != NULL) {
+        self->fThis = new plSittingModifier();
+        self->fPyOwned = true;
+    }
+    return (PyObject*)self;
+}
+
+static PyObject* pySittingModifier_addNotifyKey(pySittingModifier* self, PyObject* args) {
+    PyObject* key;
+    if (!(PyArg_ParseTuple(args, "O", &key) && pyKey_Check(key))) {
+        PyErr_SetString(PyExc_TypeError, "addNotifyKey expects a plKey");
+        return NULL;
+    }
+    self->fThis->addNotifyKey(*((pyKey*)key)->fThis);
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+static PyObject* pySittingModifier_clearNotifyKeys(pySittingModifier* self) {
+    self->fThis->clearNotifyKeys();
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+static PyObject* pySittingModifier_delNotifyKey(pySittingModifier* self, PyObject* args) {
+    Py_ssize_t idx;
+    if (!PyArg_ParseTuple(args, "n", &idx)) {
+        PyErr_SetString(PyExc_TypeError, "delNotifyKey expects an int");
+        return NULL;
+    }
+    self->fThis->delNotifyKey((size_t)idx);
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+static PyMethodDef pySittingModifier_Methods[] = {
+    { "addNotifyKey", (PyCFunction)pySittingModifier_addNotifyKey, METH_VARARGS,
+      "Params: key\n"
+      "Adds a LogicMod notify key" },
+    { "clearNotifyKeys", (PyCFunction)pySittingModifier_clearNotifyKeys, METH_NOARGS,
+      "Removes all LogicMod notify keys" },
+    { "delNotifyKey", (PyCFunction)pySittingModifier_delNotifyKey, METH_VARARGS,
+      "Params: idx\n"
+      "Removes a LogicMod notify key" },
+    { NULL, NULL, 0, NULL }
+};
+
+static PyObject* pySittingModifier_getMiscFlags(pySittingModifier* self, void*) {
+    return PyInt_FromLong(self->fThis->getMiscFlags());
+}
+
+static PyObject* pySittingModifier_getNotifyKeys(pySittingModifier* self, void*) {
+    PyObject* keys = PyTuple_New(self->fThis->getNotifyKeys().size());
+    for (size_t i = 0; i < self->fThis->getNotifyKeys().size(); ++i)
+        PyTuple_SET_ITEM(keys, i, pyKey_FromKey(self->fThis->getNotifyKeys()[i]));
+    return keys;
+}
+
+static int pySittingModifier_setMiscFlags(pySittingModifier* self, PyObject* value, void*) {
+    if (value == NULL || !PyInt_Check(value)) {
+        PyErr_SetString(PyExc_TypeError, "miscFlags should be an int");
+        return -1;
+    }
+    self->fThis->setMiscFlags((uint8_t)PyInt_AsLong(value));
+    return 0;
+}
+
+static int pySittingModifier_setNotifyKeys(pySittingModifier* self, PyObject* value, void*) {
+    PyErr_SetString(PyExc_RuntimeError, "To add notifyKeys, use addNotifyKey()");
+    return -1;
+}
+
+static PyGetSetDef pySittingModifier_GetSet[] = {
+    { _pycs("miscFlags"), (getter)pySittingModifier_getMiscFlags, (setter)pySittingModifier_setMiscFlags, NULL, NULL },
+    { _pycs("notifyKeys"), (getter)pySittingModifier_getNotifyKeys, (setter)pySittingModifier_setNotifyKeys, NULL, NULL },
+    { NULL, NULL, NULL, NULL, NULL }
+};
+
+PyTypeObject pySittingModifier_Type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "PyHSPlasma.plSittingModifier",     /* tp_name */
+    sizeof(pySittingModifier),          /* tp_basicsize */
+    0,                                  /* tp_itemsize */
+
+    NULL,                               /* tp_dealloc */
+    NULL,                               /* tp_print */
+    NULL,                               /* tp_getattr */
+    NULL,                               /* tp_setattr */
+    NULL,                               /* tp_compare */
+    NULL,                               /* tp_repr */
+    NULL,                               /* tp_as_number */
+    NULL,                               /* tp_as_sequence */
+    NULL,                               /* tp_as_mapping */
+    NULL,                               /* tp_hash */
+    NULL,                               /* tp_call */
+    NULL,                               /* tp_str */
+    NULL,                               /* tp_getattro */
+    NULL,                               /* tp_setattro */
+    NULL,                               /* tp_as_buffer */
+
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
+    "plSittingModifier wrapper",        /* tp_doc */
+
+    NULL,                               /* tp_traverse */
+    NULL,                               /* tp_clear */
+    NULL,                               /* tp_richcompare */
+    0,                                  /* tp_weaklistoffset */
+    NULL,                               /* tp_iter */
+    NULL,                               /* tp_iternext */
+
+    pySittingModifier_Methods,          /* tp_methods */
+    NULL,                               /* tp_members */
+    pySittingModifier_GetSet,           /* tp_getset */
+    NULL,                               /* tp_base */
+    NULL,                               /* tp_dict */
+    NULL,                               /* tp_descr_get */
+    NULL,                               /* tp_descr_set */
+    0,                                  /* tp_dictoffset */
+
+    NULL,                               /* tp_init */
+    NULL,                               /* tp_alloc */
+    pySittingModifier_new,              /* tp_new */
+    NULL,                               /* tp_free */
+    NULL,                               /* tp_is_gc */
+
+    NULL,                               /* tp_bases */
+    NULL,                               /* tp_mro */
+    NULL,                               /* tp_cache */
+    NULL,                               /* tp_subclasses */
+    NULL,                               /* tp_weaklist */
+
+    NULL,                               /* tp_del */
+    TP_VERSION_TAG_INIT                 /* tp_version_tag */
+    TP_FINALIZE_INIT                    /* tp_finalize */
+};
+
+PyObject* Init_pySittingModifier_Type() {
+    pySittingModifier_Type.tp_base = &pySingleModifier_Type;
+    if (PyType_Ready(&pySittingModifier_Type) < 0)
+        return NULL;
+
+    PyDict_SetItemString(pySittingModifier_Type.tp_dict, "kApproachFront",
+                         PyInt_FromLong(plSittingModifier::kApproachFront));
+    PyDict_SetItemString(pySittingModifier_Type.tp_dict, "kApproachLeft",
+                         PyInt_FromLong(plSittingModifier::kApproachLeft));
+    PyDict_SetItemString(pySittingModifier_Type.tp_dict, "kApproachRight",
+                         PyInt_FromLong(plSittingModifier::kApproachRight));
+    PyDict_SetItemString(pySittingModifier_Type.tp_dict, "kApproachRear",
+                         PyInt_FromLong(plSittingModifier::kApproachRear));
+    PyDict_SetItemString(pySittingModifier_Type.tp_dict, "kApproachMask",
+                         PyInt_FromLong(plSittingModifier::kApproachMask));
+    PyDict_SetItemString(pySittingModifier_Type.tp_dict, "kDisableForward",
+                         PyInt_FromLong(plSittingModifier::kDisableForward));
+
+    Py_INCREF(&pySittingModifier_Type);
+    return (PyObject*)&pySittingModifier_Type;
+}
+
+int pySittingModifier_Check(PyObject* obj) {
+    if (obj->ob_type == &pySittingModifier_Type
+        || PyType_IsSubtype(obj->ob_type, &pySittingModifier_Type))
+        return 1;
+    return 0;
+}
+
+PyObject* pySittingModifier_FromSittingModifier(class plSittingModifier* obj) {
+    if (obj == NULL) {
+        Py_INCREF(Py_None);
+        return Py_None;
+    }
+    pySittingModifier* py = PyObject_New(pySittingModifier, &pySittingModifier_Type);
+    py->fThis = obj;
+    py->fPyOwned = false;
+    return (PyObject*)py;
+}
+
+};

--- a/Python/PRP/Avatar/pySittingModifier.h
+++ b/Python/PRP/Avatar/pySittingModifier.h
@@ -1,0 +1,35 @@
+/* This file is part of HSPlasma.
+ *
+ * HSPlasma is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * HSPlasma is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with HSPlasma.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _PY_SITTINGMODIFIER_H
+#define _PY_SITTINGMODIFIER_H
+
+extern "C" {
+
+typedef struct {
+    PyObject_HEAD
+    class plSittingModifier* fThis;
+    bool fPyOwned;
+} pySittingModifier;
+
+extern PyTypeObject pySittingModifier_Type;
+PyObject* Init_pySittingModifier_Type();
+int pySittingModifier_Check(PyObject* obj);
+PyObject* pySittingModifier_FromSittingModifier(class plSittingModifier* obj);
+
+}
+
+#endif

--- a/Python/PRP/Message/pyCursorChangeMsg.cpp
+++ b/Python/PRP/Message/pyCursorChangeMsg.cpp
@@ -1,0 +1,177 @@
+/* This file is part of HSPlasma.
+ *
+ * HSPlasma is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * HSPlasma is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with HSPlasma.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <PyPlasma.h>
+#include <PRP/Message/plCursorChangeMsg.h>
+#include "pyCursorChangeMsg.h"
+#include "pyMessage.h"
+
+extern "C" {
+
+static PyObject* pyCursorChangeMsg_new(PyTypeObject* type, PyObject* args, PyObject* kwds) {
+    pyCursorChangeMsg* self = (pyCursorChangeMsg*)type->tp_alloc(type, 0);
+    if (self != NULL) {
+        self->fThis = new plCursorChangeMsg();
+        self->fPyOwned = true;
+    }
+    return (PyObject*)self;
+}
+
+static PyObject* pyCursorChangeMsg_getType(pyCursorChangeMsg* self, void*) {
+    return PyInt_FromLong(self->fThis->getType());
+}
+
+static PyObject* pyCursorChangeMsg_getPriority(pyCursorChangeMsg* self, void*) {
+    return PyInt_FromLong(self->fThis->getPriority());
+}
+
+static int pyCursorChangeMsg_setType(pyCursorChangeMsg* self, PyObject* value, void*) {
+    if (value == NULL || !PyInt_Check(value)) {
+        PyErr_SetString(PyExc_TypeError, "type should be an int");
+        return -1;
+    }
+    self->fThis->setType(PyInt_AsLong(value));
+    return 0;
+}
+
+static int pyCursorChangeMsg_setPriority(pyCursorChangeMsg* self, PyObject* value, void*) {
+    if (value == NULL || !PyInt_Check(value)) {
+        PyErr_SetString(PyExc_TypeError, "priority should be an int");
+        return -1;
+    }
+    self->fThis->setPriority(PyInt_AsLong(value));
+    return 0;
+}
+
+static PyGetSetDef pyCursorChangeMsg_GetSet[] = {
+    { _pycs("type"), (getter)pyCursorChangeMsg_getType, (setter)pyCursorChangeMsg_setType, NULL, NULL },
+    { _pycs("priority"), (getter)pyCursorChangeMsg_getPriority, (setter)pyCursorChangeMsg_setPriority, NULL, NULL },
+    { NULL, NULL, NULL, NULL, NULL }
+};
+
+PyTypeObject pyCursorChangeMsg_Type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "PyHSPlasma.plCursorChangeMsg",     /* tp_name */
+    sizeof(pyCursorChangeMsg),          /* tp_basicsize */
+    0,                                  /* tp_itemsize */
+
+    NULL,                               /* tp_dealloc */
+    NULL,                               /* tp_print */
+    NULL,                               /* tp_getattr */
+    NULL,                               /* tp_setattr */
+    NULL,                               /* tp_compare */
+    NULL,                               /* tp_repr */
+    NULL,                               /* tp_as_number */
+    NULL,                               /* tp_as_sequence */
+    NULL,                               /* tp_as_mapping */
+    NULL,                               /* tp_hash */
+    NULL,                               /* tp_call */
+    NULL,                               /* tp_str */
+    NULL,                               /* tp_getattro */
+    NULL,                               /* tp_setattro */
+    NULL,                               /* tp_as_buffer */
+
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
+    "plCursorChangeMsg wrapper",              /* tp_doc */
+
+    NULL,                               /* tp_traverse */
+    NULL,                               /* tp_clear */
+    NULL,                               /* tp_richcompare */
+    0,                                  /* tp_weaklistoffset */
+    NULL,                               /* tp_iter */
+    NULL,                               /* tp_iternext */
+
+    NULL,                               /* tp_methods */
+    NULL,                               /* tp_members */
+    pyCursorChangeMsg_GetSet,           /* tp_getset */
+    NULL,                               /* tp_base */
+    NULL,                               /* tp_dict */
+    NULL,                               /* tp_descr_get */
+    NULL,                               /* tp_descr_set */
+    0,                                  /* tp_dictoffset */
+
+    NULL,                               /* tp_init */
+    NULL,                               /* tp_alloc */
+    pyCursorChangeMsg_new,              /* tp_new */
+    NULL,                               /* tp_free */
+    NULL,                               /* tp_is_gc */
+
+    NULL,                               /* tp_bases */
+    NULL,                               /* tp_mro */
+    NULL,                               /* tp_cache */
+    NULL,                               /* tp_subclasses */
+    NULL,                               /* tp_weaklist */
+
+    NULL,                               /* tp_del */
+    TP_VERSION_TAG_INIT                 /* tp_version_tag */
+    TP_FINALIZE_INIT                    /* tp_finalize */
+};
+
+PyObject* Init_pyCursorChangeMsg_Type() {
+    pyCursorChangeMsg_Type.tp_base = &pyMessage_Type;
+    if (PyType_Ready(&pyCursorChangeMsg_Type) < 0)
+        return NULL;
+
+    PyDict_SetItemString(pyCursorChangeMsg_Type.tp_dict, "kNoChange",
+                         PyInt_FromLong(plCursorChangeMsg::kNoChange));
+    PyDict_SetItemString(pyCursorChangeMsg_Type.tp_dict, "kCursorUp",
+                         PyInt_FromLong(plCursorChangeMsg::kCursorUp));
+    PyDict_SetItemString(pyCursorChangeMsg_Type.tp_dict, "kCursorLeft",
+                         PyInt_FromLong(plCursorChangeMsg::kCursorLeft));
+    PyDict_SetItemString(pyCursorChangeMsg_Type.tp_dict, "kCursorRight",
+                         PyInt_FromLong(plCursorChangeMsg::kCursorRight));
+    PyDict_SetItemString(pyCursorChangeMsg_Type.tp_dict, "kCursorDown",
+                         PyInt_FromLong(plCursorChangeMsg::kCursorDown));
+    PyDict_SetItemString(pyCursorChangeMsg_Type.tp_dict, "kCursorPoised",
+                         PyInt_FromLong(plCursorChangeMsg::kCursorPoised));
+    PyDict_SetItemString(pyCursorChangeMsg_Type.tp_dict, "kCursorClicked",
+                         PyInt_FromLong(plCursorChangeMsg::kCursorClicked));
+    PyDict_SetItemString(pyCursorChangeMsg_Type.tp_dict, "kCursorUnClicked",
+                         PyInt_FromLong(plCursorChangeMsg::kCursorUnClicked));
+    PyDict_SetItemString(pyCursorChangeMsg_Type.tp_dict, "kCursorHidden",
+                         PyInt_FromLong(plCursorChangeMsg::kCursorHidden));
+    PyDict_SetItemString(pyCursorChangeMsg_Type.tp_dict, "kCursorOpen",
+                         PyInt_FromLong(plCursorChangeMsg::kCursorOpen));
+    PyDict_SetItemString(pyCursorChangeMsg_Type.tp_dict, "kCursorGrab",
+                         PyInt_FromLong(plCursorChangeMsg::kCursorGrab));
+    PyDict_SetItemString(pyCursorChangeMsg_Type.tp_dict, "kCursorArrow",
+                         PyInt_FromLong(plCursorChangeMsg::kCursorArrow));
+    PyDict_SetItemString(pyCursorChangeMsg_Type.tp_dict, "kNullCursor",
+                         PyInt_FromLong(plCursorChangeMsg::kNullCursor));
+
+    Py_INCREF(&pyCursorChangeMsg_Type);
+    return (PyObject*)&pyCursorChangeMsg_Type;
+}
+
+int pyCursorChangeMsg_Check(PyObject* obj) {
+    if (obj->ob_type == &pyCursorChangeMsg_Type
+        || PyType_IsSubtype(obj->ob_type, &pyCursorChangeMsg_Type))
+        return 1;
+    return 0;
+}
+
+PyObject* pyCursorChangeMsg_FromCursorChangeMsg(class plCursorChangeMsg* atc) {
+    if (atc == NULL) {
+        Py_INCREF(Py_None);
+        return Py_None;
+    }
+    pyCursorChangeMsg* pyobj = PyObject_New(pyCursorChangeMsg, &pyCursorChangeMsg_Type);
+    pyobj->fThis = atc;
+    pyobj->fPyOwned = false;
+    return (PyObject*)pyobj;
+}
+
+}

--- a/Python/PRP/Message/pyCursorChangeMsg.h
+++ b/Python/PRP/Message/pyCursorChangeMsg.h
@@ -1,0 +1,35 @@
+/* This file is part of HSPlasma.
+ *
+ * HSPlasma is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * HSPlasma is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with HSPlasma.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _PYCURSORCHANGEMSG_H
+#define _PYCURSORCHANGEMSG_H
+
+extern "C" {
+
+typedef struct {
+    PyObject_HEAD
+    class plCursorChangeMsg* fThis;
+    bool fPyOwned;
+} pyCursorChangeMsg;
+
+extern PyTypeObject pyCursorChangeMsg_Type;
+PyObject* Init_pyCursorChangeMsg_Type();
+int pyCursorChangeMsg_Check(PyObject* obj);
+PyObject* pyCursorChangeMsg_FromCursorChangeMsg(class plCursorChangeMsg* msg);
+
+}
+
+#endif

--- a/Python/PRP/pyCreatableConvert.cpp
+++ b/Python/PRP/pyCreatableConvert.cpp
@@ -92,6 +92,7 @@
 #include "PRP/Message/plAvSeekMsg.h"
 #include "PRP/Message/plAvTaskMsg.h"
 #include "PRP/Message/plClimbMsg.h"
+#include "PRP/Message/plCursorChangeMsg.h"
 #include "PRP/Message/plEnableMsg.h"
 #include "PRP/Message/plExcludeRegionMsg.h"
 #include "PRP/Message/plInputIfaceMgrMsg.h"
@@ -200,6 +201,7 @@
 #include "PRP/Light/pyLightInfo.h"
 #include "PRP/Light/pyShadowMaster.h"
 #include "PRP/Message/pyArmatureEffectMsg.h"
+#include "PRP/Message/pyCursorChangeMsg.h"
 #include "PRP/Message/pyEventCallbackMsg.h"
 #include "PRP/Message/pyMessage.h"
 #include "PRP/Message/pyMsgForwarder.h"
@@ -783,6 +785,7 @@ PyObject* ICreate(plCreatable* pCre)
         case kAgeLinkStruct: return pyAgeLinkStruct_FromAgeLinkStruct(plAgeLinkStruct::Convert(pCre));
         case kAgeInfoStruct: return pyAgeInfoStruct_FromAgeInfoStruct(plAgeInfoStruct::Convert(pCre));
         case kArmatureEffectStateMsg: return pyArmatureEffectStateMsg_FromArmatureEffectStateMsg(plArmatureEffectStateMsg::Convert(pCre));
+        case kCursorChangeMsg: return pyCursorChangeMsg_FromCursorChangeMsg(plCursorChangeMsg::Convert(pCre));
         default:
             // many messages are not implemented, make sure they are at least a plMessage
             if (dynamic_cast<plMessage*>(pCre)) return pyMessage_FromMessage(plMessage::Convert(pCre));

--- a/Python/PRP/pyCreatableConvert.cpp
+++ b/Python/PRP/pyCreatableConvert.cpp
@@ -177,6 +177,7 @@
 #include "PRP/Avatar/pyAGChannel.h"
 #include "PRP/Avatar/pyATCAnim.h"
 #include "PRP/Avatar/pyMultistageBehMod.h"
+#include "PRP/Avatar/pySittingModifier.h"
 #include "PRP/Audio/pyAudible.h"
 #include "PRP/Audio/pySoundBuffer.h"
 #include "PRP/ConditionalObject/pyActivatorConditionalObject.h"
@@ -410,7 +411,7 @@ plCreatable* IConvert(pyCreatable* pCre)
     //else if (Py_TYPE(pCre) == &pyGUITextBoxMod_Type) return dynamic_cast<plCreatable*>(reinterpret_cast<pfGUITextBoxMod*>(pCre->fThis));
     //else if (Py_TYPE(pCre) == &pyGUIEditBoxMod_Type) return dynamic_cast<plCreatable*>(reinterpret_cast<pfGUIEditBoxMod*>(pCre->fThis));
     else if (Py_TYPE(pCre) == &pyDynamicTextMap_Type) return dynamic_cast<plCreatable*>(reinterpret_cast<plDynamicTextMap*>(pCre->fThis));
-    //else if (Py_TYPE(pCre) == &pySittingModifier_Type) return dynamic_cast<plCreatable*>(reinterpret_cast<plSittingModifier*>(pCre->fThis));
+    else if (Py_TYPE(pCre) == &pySittingModifier_Type) return dynamic_cast<plCreatable*>(reinterpret_cast<plSittingModifier*>(pCre->fThis));
     //else if (Py_TYPE(pCre) == &pyGUIUpDownPairMod_Type) return dynamic_cast<plCreatable*>(reinterpret_cast<pfGUIUpDownPairMod*>(pCre->fThis));
     //else if (Py_TYPE(pCre) == &pyGUIValueCtrl_Type) return dynamic_cast<plCreatable*>(reinterpret_cast<pfGUIValueCtrl*>(pCre->fThis));
     //else if (Py_TYPE(pCre) == &pyGUIKnobCtrl_Type) return dynamic_cast<plCreatable*>(reinterpret_cast<pfGUIKnobCtrl*>(pCre->fThis));
@@ -682,6 +683,7 @@ PyObject* ICreate(plCreatable* pCre)
         case kDynamicEnvMap: return pyDynamicEnvMap_FromDynamicEnvMap(plDynamicEnvMap::Convert(pCre));
         case kDynamicCamMap: return pyDynamicCamMap_FromDynamicCamMap(plDynamicCamMap::Convert(pCre));
         case kDynamicTextMap: return pyDynamicTextMap_FromDynamicTextMap(plDynamicTextMap::Convert(pCre));
+        case kSittingModifier: return pySittingModifier_FromSittingModifier(plSittingModifier::Convert(pCre));
         case kAGAnim: return pyAGAnim_FromAGAnim(plAGAnim::Convert(pCre));
         case kAgeGlobalAnim: return pyAgeGlobalAnim_FromAgeGlobalAnim(plAgeGlobalAnim::Convert(pCre));
         case kATCAnim: return pyATCAnim_FromATCAnim(plATCAnim::Convert(pCre));

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -309,6 +309,7 @@ set(PRP_MSG_SRCS
     PRP/Message/plCameraMsg.cpp
     PRP/Message/plClimbMsg.cpp
     PRP/Message/plConsoleMsg.cpp
+    PRP/Message/plCursorChangeMsg.cpp
     PRP/Message/plEnableMsg.cpp
     PRP/Message/plEventCallbackMsg.cpp
     PRP/Message/plExcludeRegionMsg.cpp
@@ -345,6 +346,7 @@ set(PRP_MSG_HDRS
     PRP/Message/plCameraMsg.h
     PRP/Message/plClimbMsg.h
     PRP/Message/plConsoleMsg.h
+    PRP/Message/plCursorChangeMsg.h
     PRP/Message/plEnableMsg.h
     PRP/Message/plEventCallbackMsg.h
     PRP/Message/plExcludeRegionMsg.h

--- a/core/PRP/Avatar/plSittingModifier.h
+++ b/core/PRP/Avatar/plSittingModifier.h
@@ -47,6 +47,16 @@ public:
 protected:
     virtual void IPrcWrite(pfPrcHelper* prc);
     virtual void IPrcParse(const pfPrcTag* tag, plResManager* mgr);
+
+public:
+    uint8_t getMiscFlags() const { return fMiscFlags; }
+    void setMiscFlags(uint8_t value) { fMiscFlags = value; }
+
+    const std::vector<plKey>& getNotifyKeys() const { return fNotifyKeys; }
+    std::vector<plKey>& getNotifyKeys() { return fNotifyKeys; }
+    void addNotifyKey(plKey notify) { fNotifyKeys.push_back(notify); }
+    void delNotifyKey(size_t idx) { fNotifyKeys.erase(fNotifyKeys.begin() + idx); }
+    void clearNotifyKeys() { fNotifyKeys.clear(); }
 };
 
 #endif

--- a/core/PRP/Message/plCursorChangeMsg.cpp
+++ b/core/PRP/Message/plCursorChangeMsg.cpp
@@ -1,0 +1,46 @@
+/* This file is part of HSPlasma.
+ *
+ * HSPlasma is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * HSPlasma is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with HSPlasma.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "plCursorChangeMsg.h"
+
+void plCursorChangeMsg::read(hsStream* S, plResManager* mgr) {
+    plMessage::read(S, mgr);
+    fType = S->readInt();
+    fPriority = S->readInt();
+}
+
+void plCursorChangeMsg::write(hsStream* S, plResManager* mgr) {
+    plMessage::write(S, mgr);
+    S->writeInt(fType);
+    S->writeInt(fPriority);
+}
+
+void plCursorChangeMsg::IPrcWrite(pfPrcHelper* prc) {
+    plMessage::IPrcWrite(prc);
+    prc->startTag("CursorChange");
+    prc->writeParam("Type", fType);
+    prc->writeParam("Priority", fPriority);
+    prc->endTag(true);
+}
+
+void plCursorChangeMsg::IPrcParse(const pfPrcTag* tag, plResManager* mgr) {
+    if (tag->getName() == "CursorChange") {
+        fType = tag->getParam("Type", "0").toInt();
+        fPriority = tag->getParam("Priority", "0").toInt();
+    } else {
+        plMessage::IPrcParse(tag, mgr);
+    }
+}

--- a/core/PRP/Message/plCursorChangeMsg.h
+++ b/core/PRP/Message/plCursorChangeMsg.h
@@ -1,0 +1,54 @@
+/* This file is part of HSPlasma.
+ *
+ * HSPlasma is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * HSPlasma is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with HSPlasma.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _PLCURSORCHANGEMSG_H
+#define _PLCURSORCHANGEMSG_H
+
+#include "plMessage.h"
+
+class PLASMA_DLL plCursorChangeMsg : public plMessage {
+    CREATABLE(plCursorChangeMsg, kCursorChangeMsg, plMessage)
+
+public:
+    enum {
+        kNoChange, kCursorUp, kCursorLeft, kCursorRight,
+        kCursorDown, kCursorPoised, kCursorClicked, kCursorUnClicked,
+        kCursorHidden, kCursorOpen, kCursorGrab, kCursorArrow,
+        kNullCursor
+    };
+
+protected:
+    int fType, fPriority;
+
+public:
+    plCursorChangeMsg() : fType(kNoChange), fPriority(0) { }
+
+    virtual void read(hsStream* S, plResManager* mgr);
+    virtual void write(hsStream* S, plResManager* mgr);
+
+protected:
+    virtual void IPrcWrite(pfPrcHelper* prc);
+    virtual void IPrcParse(const pfPrcTag* tag, plResManager* mgr);
+
+public:
+    int getType() const { return fType; }
+    int getPriority() const { return fPriority; }
+
+    void setType(int value) { fType = value; }
+    void setPriority(int value) { fPriority = value; }
+};
+
+#endif

--- a/core/ResManager/plFactory.cpp
+++ b/core/ResManager/plFactory.cpp
@@ -92,6 +92,7 @@
 #include "PRP/Message/plAvSeekMsg.h"
 #include "PRP/Message/plAvTaskMsg.h"
 #include "PRP/Message/plClimbMsg.h"
+#include "PRP/Message/plCursorChangeMsg.h"
 #include "PRP/Message/plEnableMsg.h"
 #include "PRP/Message/plExcludeRegionMsg.h"
 #include "PRP/Message/plInputIfaceMgrMsg.h"
@@ -794,7 +795,7 @@ plCreatable* plFactory::Create(short typeIdx) {
         //case kClothingUpdateBCMsg: return new plClothingUpdateBCMsg();
         case kNotifyMsg: return new plNotifyMsg();
         //case kFakeOutMsg: return new plFakeOutMsg();
-        //case kCursorChangeMsg: return new plCursorChangeMsg();
+        case kCursorChangeMsg: return new plCursorChangeMsg();
         //case kNodeChangeMsg: return new plNodeChangeMsg();
         //case kAvEnableMsg: return new plAvEnableMsg();
         //case kLinkCallbackMsg: return new plLinkCallbackMsg();


### PR DESCRIPTION
This implements everything needed to have an epic sitting modifier in Python. As a bonus, plCursorChangeMsg is now implemented, which contains the enum for the cursor states. AFAIK, these shouldn't be in any Cyan age.