### PR TITLE
PyHSPlasma Animation Improvements

### DIFF
--- a/Python/CMakeLists.txt
+++ b/Python/CMakeLists.txt
@@ -101,6 +101,7 @@ set(PRP_AVTR_SRCS
     PRP/Avatar/pyAGAnimBink.cpp
     PRP/Avatar/pyAGApplicator.cpp
     PRP/Avatar/pyAGChannel.cpp
+    PRP/Avatar/pyAGModifier.cpp
     PRP/Avatar/pyATCAnim.cpp
     PRP/Avatar/pyATCChannel.cpp
     PRP/Avatar/pyAgeGlobalAnim.cpp
@@ -154,6 +155,7 @@ set(PRP_AVTR_HDRS
     PRP/Avatar/pyAGAnim.h
     PRP/Avatar/pyAGApplicator.h
     PRP/Avatar/pyAGChannel.h
+    PRP/Avatar/pyAGModifier.h
     PRP/Avatar/pyATCAnim.h
     PRP/Avatar/pyMultistageBehMod.h
     PRP/Avatar/pySittingModifier.h

--- a/Python/CMakeLists.txt
+++ b/Python/CMakeLists.txt
@@ -101,6 +101,7 @@ set(PRP_AVTR_SRCS
     PRP/Avatar/pyAGAnimBink.cpp
     PRP/Avatar/pyAGApplicator.cpp
     PRP/Avatar/pyAGChannel.cpp
+    PRP/Avatar/pyAGMasterMod.cpp
     PRP/Avatar/pyAGModifier.cpp
     PRP/Avatar/pyATCAnim.cpp
     PRP/Avatar/pyATCChannel.cpp
@@ -155,6 +156,7 @@ set(PRP_AVTR_HDRS
     PRP/Avatar/pyAGAnim.h
     PRP/Avatar/pyAGApplicator.h
     PRP/Avatar/pyAGChannel.h
+    PRP/Avatar/pyAGMasterMod.h
     PRP/Avatar/pyAGModifier.h
     PRP/Avatar/pyATCAnim.h
     PRP/Avatar/pyMultistageBehMod.h

--- a/Python/Module.cpp
+++ b/Python/Module.cpp
@@ -41,6 +41,7 @@
 #include "PRP/Avatar/pyAGAnim.h"
 #include "PRP/Avatar/pyAGApplicator.h"
 #include "PRP/Avatar/pyAGChannel.h"
+#include "PRP/Avatar/pyAGModifier.h"
 #include "PRP/Avatar/pyATCAnim.h"
 #include "PRP/Avatar/pyClothingItem.h"
 #include "PRP/Avatar/pyMultistageBehMod.h"
@@ -533,6 +534,7 @@ PyMODINIT_FUNC initPyHSPlasma() {
     PyModule_AddObject(module, "plVolumeSensorConditionalObject", Init_pyVolumeSensorConditionalObject_Type());
     PyModule_AddObject(module, "plVolumeSensorConditionalObjectNoArbitration", Init_pyVolumeSensorConditionalObjectNoArbitration_Type());
     PyModule_AddObject(module, "plModifier", Init_pyModifier_Type());
+    PyModule_AddObject(module, "plAGModifier", Init_pyAGModifier_Type());
     PyModule_AddObject(module, "plSingleModifier", Init_pySingleModifier_Type());
     PyModule_AddObject(module, "plSittingModifier", Init_pySittingModifier_Type());
     PyModule_AddObject(module, "plDetectorModifier", Init_pyDetectorModifier_Type());

--- a/Python/Module.cpp
+++ b/Python/Module.cpp
@@ -41,6 +41,7 @@
 #include "PRP/Avatar/pyAGAnim.h"
 #include "PRP/Avatar/pyAGApplicator.h"
 #include "PRP/Avatar/pyAGChannel.h"
+#include "PRP/Avatar/pyAGMasterMod.h"
 #include "PRP/Avatar/pyAGModifier.h"
 #include "PRP/Avatar/pyATCAnim.h"
 #include "PRP/Avatar/pyClothingItem.h"
@@ -536,6 +537,7 @@ PyMODINIT_FUNC initPyHSPlasma() {
     PyModule_AddObject(module, "plModifier", Init_pyModifier_Type());
     PyModule_AddObject(module, "plAGModifier", Init_pyAGModifier_Type());
     PyModule_AddObject(module, "plSingleModifier", Init_pySingleModifier_Type());
+    PyModule_AddObject(module, "plAGMasterMod", Init_pyAGMasterMod_Type());
     PyModule_AddObject(module, "plSittingModifier", Init_pySittingModifier_Type());
     PyModule_AddObject(module, "plDetectorModifier", Init_pyDetectorModifier_Type());
     PyModule_AddObject(module, "plPickingDetector", Init_pyPickingDetector_Type());

--- a/Python/PRP/Animation/pyCompoundController.cpp
+++ b/Python/PRP/Animation/pyCompoundController.cpp
@@ -37,15 +37,15 @@ static PyObject* pyCompoundController_new(PyTypeObject* type, PyObject* args, Py
 }
 
 static PyObject* pyCompoundController_getX(pyCompoundController* self, void*) {
-    return pyController_FromController(self->fThis->getXController());
+    return ICreate(self->fThis->getXController());
 }
 
 static PyObject* pyCompoundController_getY(pyCompoundController* self, void*) {
-    return pyController_FromController(self->fThis->getYController());
+    return ICreate(self->fThis->getYController());
 }
 
 static PyObject* pyCompoundController_getZ(pyCompoundController* self, void*) {
-    return pyController_FromController(self->fThis->getZController());
+    return ICreate(self->fThis->getZController());
 }
 
 static int pyCompoundController_setX(pyCompoundController* self, PyObject* value, void*) {

--- a/Python/PRP/Animation/pyCompoundController.cpp
+++ b/Python/PRP/Animation/pyCompoundController.cpp
@@ -90,7 +90,13 @@ static int pyCompoundController_setZ(pyCompoundController* self, PyObject* value
     return 0;
 }
 
+static PyObject* pyCompoundController_convertToTMController(pyCompoundController* self) {
+    return pyTMController_FromTMController(self->fThis->convertToTMController());
+}
+
 static PyMethodDef pyCompoundController_Methods[] = {
+    { "convertToTMController", (PyCFunction)pyCompoundController_convertToTMController, METH_NOARGS,
+      "Converts this controller to a plTMController" },
     { NULL, NULL, 0, NULL }
 };
 

--- a/Python/PRP/Animation/pyCompoundPosController.cpp
+++ b/Python/PRP/Animation/pyCompoundPosController.cpp
@@ -38,15 +38,15 @@ static PyObject* pyCompoundPosController_new(PyTypeObject* type, PyObject* args,
 }
 
 static PyObject* pyCompoundPosController_getX(pyCompoundPosController* self, void*) {
-    return pyScalarController_FromScalarController(self->fThis->getX());
+    return ICreate(self->fThis->getX());
 }
 
 static PyObject* pyCompoundPosController_getY(pyCompoundPosController* self, void*) {
-    return pyScalarController_FromScalarController(self->fThis->getY());
+    return ICreate(self->fThis->getY());
 }
 
 static PyObject* pyCompoundPosController_getZ(pyCompoundPosController* self, void*) {
-    return pyScalarController_FromScalarController(self->fThis->getZ());
+    return ICreate(self->fThis->getZ());
 }
 
 static int pyCompoundPosController_setX(pyCompoundPosController* self, PyObject* value, void*) {

--- a/Python/PRP/Animation/pyCompoundRotController.cpp
+++ b/Python/PRP/Animation/pyCompoundRotController.cpp
@@ -38,15 +38,15 @@ static PyObject* pyCompoundRotController_new(PyTypeObject* type, PyObject* args,
 }
 
 static PyObject* pyCompoundRotController_getX(pyCompoundRotController* self, void*) {
-    return pyScalarController_FromScalarController(self->fThis->getX());
+    return ICreate(self->fThis->getX());
 }
 
 static PyObject* pyCompoundRotController_getY(pyCompoundRotController* self, void*) {
-    return pyScalarController_FromScalarController(self->fThis->getY());
+    return  ICreate(self->fThis->getY());
 }
 
 static PyObject* pyCompoundRotController_getZ(pyCompoundRotController* self, void*) {
-    return pyScalarController_FromScalarController(self->fThis->getZ());
+    return  ICreate(self->fThis->getZ());
 }
 
 static int pyCompoundRotController_setX(pyCompoundRotController* self, PyObject* value, void*) {

--- a/Python/PRP/Animation/pyLeafController.cpp
+++ b/Python/PRP/Animation/pyLeafController.cpp
@@ -129,7 +129,6 @@ static int pyLeafController_setEaseControllers(pyLeafController* self, PyObject*
             PyErr_SetString(PyExc_TypeError, "easeControllers should be a list of plEaseControllers");
             return -1;
         }
-        ((pyEaseController*)itm)->fPyOwned = false;
         controllers[i] = ((pyEaseController*)itm)->fThis;
     }
     IConvertController(self)->setEaseControllers(controllers);

--- a/Python/PRP/Animation/pyLeafController.cpp
+++ b/Python/PRP/Animation/pyLeafController.cpp
@@ -68,7 +68,6 @@ static PyObject* pyLeafController_setKeys(pyLeafController* self, PyObject* args
             PyErr_SetString(PyExc_TypeError, "setKeys expects a list of hsKeyFrames and an int");
             return NULL;
         }
-        ((pyKeyFrame*)itm)->fPyOwned = false;
         keys[i] = ((pyKeyFrame*)itm)->fThis;
     }
     IConvertController(self)->setKeys(keys, type);

--- a/Python/PRP/Animation/pyLeafController.cpp
+++ b/Python/PRP/Animation/pyLeafController.cpp
@@ -21,6 +21,10 @@
 #include "pyKeys.h"
 #include "PRP/pyCreatable.h"
 
+static plLeafController* IConvertController(pyLeafController* self) {
+    return plLeafController::Convert(IConvert((pyCreatable*)self));
+}
+
 extern "C" {
 
 static int pyLeafController___init__(pyLeafController* self, PyObject* args, PyObject* kwds) {
@@ -39,11 +43,11 @@ static PyObject* pyLeafController_new(PyTypeObject* type, PyObject* args, PyObje
 }
 
 static PyObject* pyLeafController_hasKeys(pyLeafController* self) {
-    return PyBool_FromLong(self->fThis->hasKeys() ? 1 : 0);
+    return PyBool_FromLong(IConvertController(self)->hasKeys() ? 1 : 0);
 }
 
 static PyObject* pyLeafController_hasEaseControllers(pyLeafController* self) {
-    return PyBool_FromLong(self->fThis->hasEaseControllers() ? 1 : 0);
+    return PyBool_FromLong(IConvertController(self)->hasEaseControllers() ? 1 : 0);
 }
 
 static PyObject* pyLeafController_setKeys(pyLeafController* self, PyObject* args) {
@@ -67,25 +71,25 @@ static PyObject* pyLeafController_setKeys(pyLeafController* self, PyObject* args
         ((pyKeyFrame*)itm)->fPyOwned = false;
         keys[i] = ((pyKeyFrame*)itm)->fThis;
     }
-    self->fThis->setKeys(keys, type);
+    IConvertController(self)->setKeys(keys, type);
     Py_INCREF(Py_None);
     return Py_None;
 }
 
 static PyObject* pyLeafController_ExpandToKeyController(pyLeafController* self) {
-    return pyLeafController_FromLeafController(self->fThis->ExpandToKeyController());
+    return ICreate(IConvertController(self)->ExpandToKeyController());
 }
 
 static PyObject* pyLeafController_CompactToLeafController(pyLeafController* self) {
-    return pyLeafController_FromLeafController(self->fThis->CompactToLeafController());
+    return pyLeafController_FromLeafController(IConvertController(self)->CompactToLeafController());
 }
 
 static PyObject* pyLeafController_getType(pyLeafController* self, void*) {
-    return PyInt_FromLong(self->fThis->getType());
+    return PyInt_FromLong(IConvertController(self)->getType());
 }
 
 static PyObject* pyLeafController_getKeys(pyLeafController* self, void*) {
-    const std::vector<hsKeyFrame*>& keys = self->fThis->getKeys();
+    const std::vector<hsKeyFrame*>& keys = IConvertController(self)->getKeys();
     PyObject* list = PyList_New(keys.size());
     for (size_t i=0; i<keys.size(); i++)
         PyList_SET_ITEM(list, i, pyKeyFrame_FromKeyFrame(keys[i]));
@@ -93,7 +97,7 @@ static PyObject* pyLeafController_getKeys(pyLeafController* self, void*) {
 }
 
 static PyObject* pyLeafController_getEaseControllers(pyLeafController* self, void*) {
-    const std::vector<plEaseController*>& controllers = self->fThis->getEaseControllers();
+    const std::vector<plEaseController*>& controllers = IConvertController(self)->getEaseControllers();
     PyObject* list = PyList_New(controllers.size());
     for (size_t i=0; i<controllers.size(); i++)
         PyList_SET_ITEM(list, i, pyEaseController_FromEaseController(controllers[i]));
@@ -129,7 +133,7 @@ static int pyLeafController_setEaseControllers(pyLeafController* self, PyObject*
         ((pyEaseController*)itm)->fPyOwned = false;
         controllers[i] = ((pyEaseController*)itm)->fThis;
     }
-    self->fThis->setEaseControllers(controllers);
+    IConvertController(self)->setEaseControllers(controllers);
     return 0;
 }
 

--- a/Python/PRP/Animation/pyTMController.cpp
+++ b/Python/PRP/Animation/pyTMController.cpp
@@ -93,7 +93,13 @@ static int pyTMController_setScale(pyTMController* self, PyObject* value, void*)
     return 0;
 }
 
+static PyObject* pyTMController_convertToCompoundController(pyTMController* self) {
+    return pyCompoundController_FromCompoundController(self->fThis->convertToCompoundController());
+}
+
 static PyMethodDef pyTMController_Methods[] = {
+    { "convertToCompoundController", (PyCFunction)pyTMController_convertToCompoundController, METH_NOARGS,
+      "Converts this controller to a plCompoundController" },
     { NULL, NULL, 0, NULL }
 };
 

--- a/Python/PRP/Animation/pyTMController.cpp
+++ b/Python/PRP/Animation/pyTMController.cpp
@@ -40,15 +40,15 @@ static PyObject* pyTMController_new(PyTypeObject* type, PyObject* args, PyObject
 }
 
 static PyObject* pyTMController_getPos(pyTMController* self, void*) {
-    return pyPosController_FromPosController(self->fThis->getPosController());
+    return ICreate(self->fThis->getPosController());
 }
 
 static PyObject* pyTMController_getRot(pyTMController* self, void*) {
-    return pyRotController_FromRotController(self->fThis->getRotController());
+    return ICreate(self->fThis->getRotController());
 }
 
 static PyObject* pyTMController_getScale(pyTMController* self, void*) {
-    return pyScaleController_FromScaleController(self->fThis->getScaleController());
+    return ICreate(self->fThis->getScaleController());
 }
 
 static int pyTMController_setPos(pyTMController* self, PyObject* value, void*) {

--- a/Python/PRP/Avatar/pyAGAnim.cpp
+++ b/Python/PRP/Avatar/pyAGAnim.cpp
@@ -21,6 +21,10 @@
 #include "PRP/pyCreatable.h"
 #include "PRP/Object/pySynchedObject.h"
 
+static plAGAnim* IConvertAnim(pyAGAnim* self) {
+    return plAGAnim::Convert(IConvert((pyCreatable*)self));
+}
+
 extern "C" {
 
 static PyObject* pyAGAnim_new(PyTypeObject* type, PyObject* args, PyObject* kwds) {
@@ -33,7 +37,7 @@ static PyObject* pyAGAnim_new(PyTypeObject* type, PyObject* args, PyObject* kwds
 }
 
 static PyObject* pyAGAnim_clearApps(pyAGAnim* self) {
-    self->fThis->clearApplicators();
+    IConvertAnim(self)->clearApplicators();
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -48,7 +52,7 @@ static PyObject* pyAGAnim_addApplicator(pyAGAnim* self, PyObject* args) {
         PyErr_SetString(PyExc_TypeError, "addApplicator expects a plAGApplicator");
         return NULL;
     }
-    self->fThis->addApplicator(app->fThis);
+    IConvertAnim(self)->addApplicator(app->fThis);
     app->fPyOwned = false;
     Py_INCREF(Py_None);
     return Py_None;
@@ -60,31 +64,32 @@ static PyObject* pyAGAnim_delApplicator(pyAGAnim* self, PyObject* args) {
         PyErr_SetString(PyExc_TypeError, "delApplicator expects an int");
         return NULL;
     }
-    self->fThis->delApplicator(idx);
+    IConvertAnim(self)->delApplicator(idx);
     Py_INCREF(Py_None);
     return Py_None;
 }
 
 static PyObject* pyAGAnim_getBlend(pyAGAnim* self, void*) {
-    return PyFloat_FromDouble(self->fThis->getBlend());
+    return PyFloat_FromDouble(IConvertAnim(self)->getBlend());
 }
 
 static PyObject* pyAGAnim_getStart(pyAGAnim* self, void*) {
-    return PyFloat_FromDouble(self->fThis->getStart());
+    return PyFloat_FromDouble(IConvertAnim(self)->getStart());
 }
 
 static PyObject* pyAGAnim_getEnd(pyAGAnim* self, void*) {
-    return PyFloat_FromDouble(self->fThis->getEnd());
+    return PyFloat_FromDouble(IConvertAnim(self)->getEnd());
 }
 
 static PyObject* pyAGAnim_getName(pyAGAnim* self, void*) {
-    return PlStr_To_PyStr(self->fThis->getName());
+    return PlStr_To_PyStr(IConvertAnim(self)->getName());
 }
 
 static PyObject* pyAGAnim_getApps(pyAGAnim* self, void*) {
-    PyObject* list = PyList_New(self->fThis->getApplicators().size());
-    for (size_t i=0; i<self->fThis->getApplicators().size(); i++)
-        PyList_SET_ITEM(list, i, pyAGApplicator_FromAGApplicator(self->fThis->getApplicators()[i]));
+    plAGAnim* anim = IConvertAnim(self);
+    PyObject* list = PyList_New(anim->getApplicators().size());
+    for (size_t i=0; i < anim->getApplicators().size(); i++)
+        PyList_SET_ITEM(list, i, pyAGApplicator_FromAGApplicator(anim->getApplicators()[i]));
     return list;
 }
 
@@ -93,7 +98,7 @@ static int pyAGAnim_setBlend(pyAGAnim* self, PyObject* value, void*) {
         PyErr_SetString(PyExc_TypeError, "blend should be a float");
         return -1;
     }
-    self->fThis->setBlend(PyFloat_AsDouble(value));
+    IConvertAnim(self)->setBlend(PyFloat_AsDouble(value));
     return 0;
 }
 
@@ -102,7 +107,7 @@ static int pyAGAnim_setStart(pyAGAnim* self, PyObject* value, void*) {
         PyErr_SetString(PyExc_TypeError, "start should be a float");
         return -1;
     }
-    self->fThis->setStart(PyFloat_AsDouble(value));
+    IConvertAnim(self)->setStart(PyFloat_AsDouble(value));
     return 0;
 }
 
@@ -111,7 +116,7 @@ static int pyAGAnim_setEnd(pyAGAnim* self, PyObject* value, void*) {
         PyErr_SetString(PyExc_TypeError, "end should be a float");
         return -1;
     }
-    self->fThis->setEnd(PyFloat_AsDouble(value));
+    IConvertAnim(self)->setEnd(PyFloat_AsDouble(value));
     return 0;
 }
 
@@ -120,7 +125,7 @@ static int pyAGAnim_setName(pyAGAnim* self, PyObject* value, void*) {
         PyErr_SetString(PyExc_TypeError, "name should be a string");
         return -1;
     }
-    self->fThis->setName(PyStr_To_PlStr(value));
+    IConvertAnim(self)->setName(PyStr_To_PlStr(value));
     return 0;
 }
 

--- a/Python/PRP/Avatar/pyAGApplicator.cpp
+++ b/Python/PRP/Avatar/pyAGApplicator.cpp
@@ -20,6 +20,10 @@
 #include "pyAGChannel.h"
 #include "PRP/pyCreatable.h"
 
+static plAGApplicator* IConvertApplicator(pyAGApplicator* self) {
+    return plAGApplicator::Convert(IConvert((pyCreatable*)self));
+}
+
 extern "C" {
 
 static PyObject* pyAGApplicator_new(PyTypeObject* type, PyObject* args, PyObject* kwds) {
@@ -28,27 +32,27 @@ static PyObject* pyAGApplicator_new(PyTypeObject* type, PyObject* args, PyObject
 }
 
 static PyObject* pyAGApplicator_getChannel(pyAGApplicator* self, void*) {
-    return pyAGChannel_FromAGChannel(self->fThis->getChannel());
+    return ICreate(IConvertApplicator(self)->getChannel());
 }
 
 static PyObject* pyAGApplicator_getEnabled(pyAGApplicator* self, void*) {
-    return PyBool_FromLong(self->fThis->isEnabled() ? 1 : 0);
+    return PyBool_FromLong(IConvertApplicator(self)->isEnabled() ? 1 : 0);
 }
 
 static PyObject* pyAGApplicator_getChannelName(pyAGApplicator* self, void*) {
-    return PlStr_To_PyStr(self->fThis->getChannelName());
+    return PlStr_To_PyStr(IConvertApplicator(self)->getChannelName());
 }
 
 static int pyAGApplicator_setChannel(pyAGApplicator* self, PyObject* value, void*) {
     if (value == NULL) {
-        self->fThis->setChannel(NULL);
+        IConvertApplicator(self)->setChannel(NULL);
         return 0;
     }
     if (!pyAGChannel_Check(value)) {
         PyErr_SetString(PyExc_TypeError, "channel should be a plAGChannel");
         return -1;
     }
-    self->fThis->setChannel(((pyAGChannel*)value)->fThis);
+    IConvertApplicator(self)->setChannel(((pyAGChannel*)value)->fThis);
     ((pyAGChannel*)value)->fPyOwned = false;
     return 0;
 }
@@ -58,7 +62,7 @@ static int pyAGApplicator_setEnabled(pyAGApplicator* self, PyObject* value, void
         PyErr_SetString(PyExc_TypeError, "enabled should be a bool");
         return -1;
     }
-    self->fThis->setEnabled(PyInt_AsLong(value) != 0);
+    IConvertApplicator(self)->setEnabled(PyInt_AsLong(value) != 0);
     return 0;
 }
 
@@ -67,7 +71,7 @@ static int pyAGApplicator_setChannelName(pyAGApplicator* self, PyObject* value, 
         PyErr_SetString(PyExc_TypeError, "channelName should be a string");
         return -1;
     }
-    self->fThis->setChannelName(PyStr_To_PlStr(value));
+    IConvertApplicator(self)->setChannelName(PyStr_To_PlStr(value));
     return 0;
 }
 

--- a/Python/PRP/Avatar/pyAGChannel.cpp
+++ b/Python/PRP/Avatar/pyAGChannel.cpp
@@ -27,7 +27,7 @@ static PyObject* pyAGChannel_new(PyTypeObject* type, PyObject* args, PyObject* k
 }
 
 static PyObject* pyAGChannel_getName(pyAGChannel* self, void*) {
-    return PlStr_To_PyStr(self->fThis->getName());
+    return PlStr_To_PyStr(plAGChannel::Convert(IConvert((pyCreatable*)self))->getName());
 }
 
 static int pyAGChannel_setName(pyAGChannel* self, PyObject* value, void*) {
@@ -35,7 +35,7 @@ static int pyAGChannel_setName(pyAGChannel* self, PyObject* value, void*) {
         PyErr_SetString(PyExc_TypeError, "name should be a string");
         return -1;
     }
-    self->fThis->setName(PyStr_To_PlStr(value));
+    plAGChannel::Convert(IConvert((pyCreatable*)self))->setName(PyStr_To_PlStr(value));
     return 0;
 }
 

--- a/Python/PRP/Avatar/pyAGMasterMod.cpp
+++ b/Python/PRP/Avatar/pyAGMasterMod.cpp
@@ -1,0 +1,287 @@
+/* This file is part of HSPlasma.
+ *
+ * HSPlasma is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * HSPlasma is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with HSPlasma.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <PyPlasma.h>
+#include <PRP/Avatar/plAGMasterMod.h>
+#include "pyAGMasterMod.h"
+#include "PRP/Modifier/pyModifier.h"
+#include "PRP/KeyedObject/pyKey.h"
+
+extern "C" {
+
+static PyObject* pyAGMasterMod_new(PyTypeObject* type, PyObject* args, PyObject* kwds) {
+    pyAGMasterMod* self = (pyAGMasterMod*)type->tp_alloc(type, 0);
+    if (self != NULL) {
+        self->fThis = new plAGMasterMod();
+        self->fPyOwned = true;
+    }
+    return (PyObject*)self;
+}
+
+static PyObject* pyAGMasterMod_addPrivateAnim(pyAGMasterMod* self, PyObject* args) {
+    PyObject* key;
+    if (!(PyArg_ParseTuple(args, "O", &key) && pyKey_Check(key))) {
+        PyErr_SetString(PyExc_TypeError, "addPrivateAnim expects a plKey");
+        return NULL;
+    }
+    self->fThis->addPrivateAnim(*((pyKey*)key)->fThis);
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+static PyObject* pyAGMasterMod_clearPrivateAnims(pyAGMasterMod* self) {
+    self->fThis->clearPrivateAnims();
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+static PyObject* pyAGMasterMod_delPrivateAnim(pyAGMasterMod* self, PyObject* args) {
+    Py_ssize_t idx;
+    if (!PyArg_ParseTuple(args, "n", &idx)) {
+        PyErr_SetString(PyExc_TypeError, "delPrivateAnim expects an int");
+        return NULL;
+    }
+    self->fThis->delPrivateAnim((size_t)idx);
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+static PyObject* pyAGMasterMod_addEoaKey(pyAGMasterMod* self, PyObject* args) {
+    PyObject* key;
+    if (!(PyArg_ParseTuple(args, "O", &key) && pyKey_Check(key))) {
+        PyErr_SetString(PyExc_TypeError, "addEoaKey expects a plKey");
+        return NULL;
+    }
+    self->fThis->addEoaKey(*((pyKey*)key)->fThis);
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+static PyObject* pyAGMasterMod_clearEoaKeys(pyAGMasterMod* self) {
+    self->fThis->clearEoaKeys();
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+static PyObject* pyAGMasterMod_delEoaKey(pyAGMasterMod* self, PyObject* args) {
+    Py_ssize_t idx;
+    if (!PyArg_ParseTuple(args, "n", &idx)) {
+        PyErr_SetString(PyExc_TypeError, "delEoaKey expects an int");
+        return NULL;
+    }
+    self->fThis->delEoaKey((size_t)idx);
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+static PyMethodDef pyAGMasterMod_Methods[] = {
+    { "addPrivateAnim", (PyCFunction)pyAGMasterMod_addPrivateAnim, METH_VARARGS,
+      "Params: key\n"
+      "Adds an animation key" },
+    { "clearPrivateAnims", (PyCFunction)pyAGMasterMod_clearPrivateAnims, METH_NOARGS,
+      "Removes all animation keys" },
+    { "delPrivateAnim", (PyCFunction)pyAGMasterMod_delPrivateAnim, METH_VARARGS,
+      "Params: idx\n"
+      "Removes an animation key" },
+    { "addEoaKey", (PyCFunction)pyAGMasterMod_addEoaKey, METH_VARARGS,
+      "Params: key\n"
+      "Adds an EoA key" },
+    { "clearEoaKeys", (PyCFunction)pyAGMasterMod_clearEoaKeys, METH_NOARGS,
+      "Removes all EoA keys" },
+    { "delEoaKey", (PyCFunction)pyAGMasterMod_delEoaKey, METH_VARARGS,
+      "Params: idx\n"
+      "Removes an EoA key" },
+    { NULL, NULL, 0, NULL }
+};
+
+static PyObject* pyAGMasterMod_getPrivateAnims(pyAGMasterMod* self, void*) {
+    const std::vector<plKey>& anims = self->fThis->getPrivateAnims();
+    PyObject* tup = PyTuple_New(anims.size());
+    for (size_t i = 0; i < anims.size(); ++i)
+        PyTuple_SET_ITEM(tup, i, pyKey_FromKey(anims[i]));
+    return tup;
+}
+
+static PyObject* pyAGMasterMod_getEoaKeys(pyAGMasterMod* self, void*) {
+    const std::vector<plKey>& keys = self->fThis->getEoaKeys();
+    PyObject* tup = PyTuple_New(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i)
+        PyTuple_SET_ITEM(tup, i, pyKey_FromKey(keys[i]));
+    return tup;
+}
+
+static PyObject* pyAGMasterMod_getGroupName(pyAGMasterMod* self, void*) {
+    return PlStr_To_PyStr(self->fThis->getGroupName());
+}
+
+static PyObject* pyAGMasterMod_getIsGrouped(pyAGMasterMod* self, void*) {
+    return PyBool_FromLong(self->fThis->getIsGrouped() ? 1 : 0);
+}
+
+static PyObject* pyAGMasterMod_getIsGroupMaster(pyAGMasterMod* self, void*) {
+    return PyBool_FromLong(self->fThis->getIsGroupMaster() ? 1 : 0);
+}
+
+static PyObject* pyAGMasterMod_getMsgForwarder(pyAGMasterMod* self, void*) {
+    return pyKey_FromKey(self->fThis->getMsgForwarder());
+}
+
+static int pyAGMasterMod_setPrivateAnims(pyAGMasterMod* self, PyObject* value, void*) {
+    PyErr_SetString(PyExc_RuntimeError, "To add privateAnims, use addPrivateAnim()");
+    return -1;
+}
+
+static int pyAGMasterMod_setEoaKeys(pyAGMasterMod* self, PyObject* value, void*) {
+    PyErr_SetString(PyExc_RuntimeError, "To add eoaKeys, use addEoaKey()");
+    return -1;
+}
+
+static int pyAGMasterMod_setGroupName(pyAGMasterMod* self, PyObject* value, void*) {
+    if (value == NULL || !PyAnyStr_Check(value)) {
+        PyErr_SetString(PyExc_TypeError, "groupName should be a string");
+        return -1;
+    }
+    self->fThis->setGroupName(PyStr_To_PlStr(value));
+    return 0;
+}
+
+static int pyAGMasterMod_setIsGrouped(pyAGMasterMod* self, PyObject* value, void*) {
+    if (value == NULL || !PyBool_Check(value)) {
+        PyErr_SetString(PyExc_TypeError, "isGrouped should be a boolean");
+        return -1;
+    }
+    self->fThis->setIsGrouped(PyInt_AsLong(value) != 0);
+    return 0;
+}
+
+static int pyAGMasterMod_setIsGroupMaster(pyAGMasterMod* self, PyObject* value, void*) {
+    if (value == NULL || !PyBool_Check(value)) {
+        PyErr_SetString(PyExc_TypeError, "isGroupMaster should be a boolean");
+        return -1;
+    }
+    self->fThis->setIsGroupMaster(PyInt_AsLong(value) != 0);
+    return 0;
+}
+
+static int pyAGMasterMod_setMsgForwarder(pyAGMasterMod* self, PyObject* value, void*) {
+    if (value == NULL || value == Py_None) {
+        self->fThis->setMsgForwarder(plKey());
+        return 0;
+    } else if (pyKey_Check(value)) {
+        self->fThis->setMsgForwarder(*((pyKey*)value)->fThis);
+        return 0;
+    } else {
+        PyErr_SetString(PyExc_TypeError, "msgForwarder should be a plKey");
+        return -1;
+    }
+}
+
+static PyGetSetDef pyAGMasterMod_GetSet[] = {
+    { _pycs("privateAnims"), (getter)pyAGMasterMod_getPrivateAnims, (setter)pyAGMasterMod_setPrivateAnims, NULL, NULL },
+    { _pycs("eoaKeys"), (getter)pyAGMasterMod_getEoaKeys, (setter)pyAGMasterMod_setEoaKeys, NULL, NULL },
+    { _pycs("groupName"), (getter)pyAGMasterMod_getGroupName, (setter)pyAGMasterMod_setGroupName, NULL, NULL },
+    { _pycs("isGrouped"), (getter)pyAGMasterMod_getIsGrouped, (setter)pyAGMasterMod_setIsGrouped, NULL, NULL },
+    { _pycs("isGroupMaster"), (getter)pyAGMasterMod_getIsGroupMaster, (setter)pyAGMasterMod_setIsGroupMaster, NULL, NULL },
+    { _pycs("msgForwarder"), (getter)pyAGMasterMod_getMsgForwarder, (setter)pyAGMasterMod_setMsgForwarder, NULL, NULL },
+    { NULL, NULL, NULL, NULL, NULL }
+};
+
+PyTypeObject pyAGMasterMod_Type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "PyHSPlasma.plAGMasterMod",         /* tp_name */
+    sizeof(pyAGMasterMod),              /* tp_basicsize */
+    0,                                  /* tp_itemsize */
+
+    NULL,                               /* tp_dealloc */
+    NULL,                               /* tp_print */
+    NULL,                               /* tp_getattr */
+    NULL,                               /* tp_setattr */
+    NULL,                               /* tp_compare */
+    NULL,                               /* tp_repr */
+    NULL,                               /* tp_as_number */
+    NULL,                               /* tp_as_sequence */
+    NULL,                               /* tp_as_mapping */
+    NULL,                               /* tp_hash */
+    NULL,                               /* tp_call */
+    NULL,                               /* tp_str */
+    NULL,                               /* tp_getattro */
+    NULL,                               /* tp_setattro */
+    NULL,                               /* tp_as_buffer */
+
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
+    "plAGMasterMod wrapper",                  /* tp_doc */
+
+    NULL,                               /* tp_traverse */
+    NULL,                               /* tp_clear */
+    NULL,                               /* tp_richcompare */
+    0,                                  /* tp_weaklistoffset */
+    NULL,                               /* tp_iter */
+    NULL,                               /* tp_iternext */
+
+    pyAGMasterMod_Methods,              /* tp_methods */
+    NULL,                               /* tp_members */
+    pyAGMasterMod_GetSet,               /* tp_getset */
+    NULL,                               /* tp_base */
+    NULL,                               /* tp_dict */
+    NULL,                               /* tp_descr_get */
+    NULL,                               /* tp_descr_set */
+    0,                                  /* tp_dictoffset */
+
+    NULL,                               /* tp_init */
+    NULL,                               /* tp_alloc */
+    pyAGMasterMod_new,                  /* tp_new */
+    NULL,                               /* tp_free */
+    NULL,                               /* tp_is_gc */
+
+    NULL,                               /* tp_bases */
+    NULL,                               /* tp_mro */
+    NULL,                               /* tp_cache */
+    NULL,                               /* tp_subclasses */
+    NULL,                               /* tp_weaklist */
+
+    NULL,                               /* tp_del */
+    TP_VERSION_TAG_INIT                 /* tp_version_tag */
+    TP_FINALIZE_INIT                    /* tp_finalize */
+};
+
+PyObject* Init_pyAGMasterMod_Type() {
+    pyAGMasterMod_Type.tp_base = &pySingleModifier_Type;
+    if (PyType_Ready(&pyAGMasterMod_Type) < 0)
+        return NULL;
+
+    Py_INCREF(&pyAGMasterMod_Type);
+    return (PyObject*)&pyAGMasterMod_Type;
+}
+
+int pyAGMasterMod_Check(PyObject* obj) {
+    if (obj->ob_type == &pyAGMasterMod_Type
+        || PyType_IsSubtype(obj->ob_type, &pyAGMasterMod_Type))
+        return 1;
+    return 0;
+}
+
+PyObject* pyAGMasterMod_FromAGMasterMod(class plAGMasterMod* obj) {
+    if (obj == NULL) {
+        Py_INCREF(Py_None);
+        return Py_None;
+    }
+    pyAGMasterMod* py = PyObject_New(pyAGMasterMod, &pyAGMasterMod_Type);
+    py->fThis = obj;
+    py->fPyOwned = false;
+    return (PyObject*)py;
+}
+
+};

--- a/Python/PRP/Avatar/pyAGMasterMod.h
+++ b/Python/PRP/Avatar/pyAGMasterMod.h
@@ -1,0 +1,35 @@
+/* This file is part of HSPlasma.
+ *
+ * HSPlasma is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * HSPlasma is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with HSPlasma.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _PY_AGMASTERMOD_H
+#define _PY_AGMASTERMOD_H
+
+extern "C" {
+
+typedef struct {
+    PyObject_HEAD
+    class plAGMasterMod* fThis;
+    bool fPyOwned;
+} pyAGMasterMod;
+
+extern PyTypeObject pyAGMasterMod_Type;
+PyObject* Init_pyAGMasterMod_Type();
+int pyAGMasterMod_Check(PyObject* obj);
+PyObject* pyAGMasterMod_FromAGMasterMod(class plAGMasterMod* obj);
+
+}
+
+#endif

--- a/Python/PRP/Avatar/pyAGModifier.cpp
+++ b/Python/PRP/Avatar/pyAGModifier.cpp
@@ -1,0 +1,164 @@
+/* This file is part of HSPlasma.
+ *
+ * HSPlasma is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * HSPlasma is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with HSPlasma.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <PyPlasma.h>
+#include <PRP/Avatar/plAGModifier.h>
+#include "pyAGModifier.h"
+#include "PRP/Modifier/pyModifier.h"
+
+extern "C" {
+
+static PyObject* pyAGModifier_new(PyTypeObject* type, PyObject* args, PyObject* kwds) {
+    pyAGModifier* self = (pyAGModifier*)type->tp_alloc(type, 0);
+    if (self != NULL) {
+        self->fThis = new plAGModifier();
+        self->fPyOwned = true;
+    }
+    return (PyObject*)self;
+}
+
+static PyObject* pyAGModifier_getChannelName(pyAGModifier* self, void*) {
+    return PlStr_To_PyStr(self->fThis->getChannelName());
+}
+
+static PyObject* pyAGModifier_getAutoApply(pyAGModifier* self, void*) {
+    return PyBool_FromLong(self->fThis->getAutoApply() ? 1 : 0);
+}
+
+static PyObject* pyAGModifier_getEnabled(pyAGModifier* self, void*) {
+    return PyBool_FromLong(self->fThis->getEnabled() ? 1 : 0);
+}
+
+static int pyAGModifier_setChannelName(pyAGModifier* self, PyObject* value, void*) {
+    if (value == NULL || !PyAnyStr_Check(value)) {
+        PyErr_SetString(PyExc_TypeError, "channelName should be a string");
+        return -1;
+    }
+    self->fThis->setChannelName(PyStr_To_PlStr(value));
+    return 0;
+}
+
+static int pyAGModifier_setAutoApply(pyAGModifier* self, PyObject* value, void*) {
+    if (value == NULL || !PyBool_Check(value)) {
+        PyErr_SetString(PyExc_TypeError, "autoApply should be a boolean");
+        return -1;
+    }
+    self->fThis->setAutoApply(PyInt_AsLong(value) != 0);
+    return 0;
+}
+
+static int pyAGModifier_setEnabled(pyAGModifier* self, PyObject* value, void*) {
+    if (value == NULL || !PyBool_Check(value)) {
+        PyErr_SetString(PyExc_TypeError, "enabled should be a boolean");
+        return -1;
+    }
+    self->fThis->setEnabled(PyInt_AsLong(value) != 0);
+    return 0;
+}
+
+static PyGetSetDef pyAGModifier_GetSet[] = {
+    { _pycs("channelName"), (getter)pyAGModifier_getChannelName, (setter)pyAGModifier_setChannelName, NULL, NULL },
+    { _pycs("autoApply"), (getter)pyAGModifier_getAutoApply, (setter)pyAGModifier_setAutoApply, NULL, NULL },
+    { _pycs("enabled"), (getter)pyAGModifier_getEnabled, (setter)pyAGModifier_setEnabled, NULL, NULL },
+    { NULL, NULL, NULL, NULL, NULL }
+};
+
+PyTypeObject pyAGModifier_Type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "PyHSPlasma.plAGModifier",          /* tp_name */
+    sizeof(pyAGModifier),               /* tp_basicsize */
+    0,                                  /* tp_itemsize */
+
+    NULL,                               /* tp_dealloc */
+    NULL,                               /* tp_print */
+    NULL,                               /* tp_getattr */
+    NULL,                               /* tp_setattr */
+    NULL,                               /* tp_compare */
+    NULL,                               /* tp_repr */
+    NULL,                               /* tp_as_number */
+    NULL,                               /* tp_as_sequence */
+    NULL,                               /* tp_as_mapping */
+    NULL,                               /* tp_hash */
+    NULL,                               /* tp_call */
+    NULL,                               /* tp_str */
+    NULL,                               /* tp_getattro */
+    NULL,                               /* tp_setattro */
+    NULL,                               /* tp_as_buffer */
+
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
+    "plAGModifier wrapper",                   /* tp_doc */
+
+    NULL,                               /* tp_traverse */
+    NULL,                               /* tp_clear */
+    NULL,                               /* tp_richcompare */
+    0,                                  /* tp_weaklistoffset */
+    NULL,                               /* tp_iter */
+    NULL,                               /* tp_iternext */
+
+    NULL,                               /* tp_methods */
+    NULL,                               /* tp_members */
+    pyAGModifier_GetSet,                /* tp_getset */
+    NULL,                               /* tp_base */
+    NULL,                               /* tp_dict */
+    NULL,                               /* tp_descr_get */
+    NULL,                               /* tp_descr_set */
+    0,                                  /* tp_dictoffset */
+
+    NULL,                               /* tp_init */
+    NULL,                               /* tp_alloc */
+    pyAGModifier_new,                   /* tp_new */
+    NULL,                               /* tp_free */
+    NULL,                               /* tp_is_gc */
+
+    NULL,                               /* tp_bases */
+    NULL,                               /* tp_mro */
+    NULL,                               /* tp_cache */
+    NULL,                               /* tp_subclasses */
+    NULL,                               /* tp_weaklist */
+
+    NULL,                               /* tp_del */
+    TP_VERSION_TAG_INIT                 /* tp_version_tag */
+    TP_FINALIZE_INIT                    /* tp_finalize */
+};
+
+PyObject* Init_pyAGModifier_Type() {
+    pyAGModifier_Type.tp_base = &pyModifier_Type;
+    if (PyType_Ready(&pyAGModifier_Type) < 0)
+        return NULL;
+
+    Py_INCREF(&pyAGModifier_Type);
+    return (PyObject*)&pyAGModifier_Type;
+}
+
+int pyAGModifier_Check(PyObject* obj) {
+    if (obj->ob_type == &pyAGModifier_Type
+        || PyType_IsSubtype(obj->ob_type, &pyAGModifier_Type))
+        return 1;
+    return 0;
+}
+
+PyObject* pyAGModifier_FromAGModifier(class plAGModifier* obj) {
+    if (obj == NULL) {
+        Py_INCREF(Py_None);
+        return Py_None;
+    }
+    pyAGModifier* py = PyObject_New(pyAGModifier, &pyAGModifier_Type);
+    py->fThis = obj;
+    py->fPyOwned = false;
+    return (PyObject*)py;
+}
+
+};

--- a/Python/PRP/Avatar/pyAGModifier.h
+++ b/Python/PRP/Avatar/pyAGModifier.h
@@ -1,0 +1,35 @@
+/* This file is part of HSPlasma.
+ *
+ * HSPlasma is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * HSPlasma is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with HSPlasma.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _PY_AGMODIFIER_H
+#define _PY_AGMODIFIER_H
+
+extern "C" {
+
+typedef struct {
+    PyObject_HEAD
+    class plAGModifier* fThis;
+    bool fPyOwned;
+} pyAGModifier;
+
+extern PyTypeObject pyAGModifier_Type;
+PyObject* Init_pyAGModifier_Type();
+int pyAGModifier_Check(PyObject* obj);
+PyObject* pyAGModifier_FromAGModifier(class plAGModifier* obj);
+
+}
+
+#endif

--- a/Python/PRP/Avatar/pyATCAnim.cpp
+++ b/Python/PRP/Avatar/pyATCAnim.cpp
@@ -20,6 +20,10 @@
 #include "pyAGAnim.h"
 #include "PRP/pyCreatable.h"
 
+static plATCAnim* IConvertAnim(pyATCAnim* self) {
+    return plATCAnim::Convert(IConvert((pyCreatable*)self));
+}
+
 extern "C" {
 
 static PyObject* pyATCAnim_new(PyTypeObject* type, PyObject* args, PyObject* kwds) {
@@ -32,13 +36,13 @@ static PyObject* pyATCAnim_new(PyTypeObject* type, PyObject* args, PyObject* kwd
 }
 
 static PyObject* pyATCAnim_clearMarkers(pyATCAnim* self) {
-    self->fThis->getMarkers().clear();
+    IConvertAnim(self)->getMarkers().clear();
     Py_INCREF(Py_None);
     return Py_None;
 }
 
 static PyObject* pyATCAnim_clearLoops(pyATCAnim* self) {
-    self->fThis->getLoops().clear();
+    IConvertAnim(self)->getLoops().clear();
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -50,7 +54,7 @@ static PyObject* pyATCAnim_setMarker(pyATCAnim* self, PyObject* args) {
         PyErr_SetString(PyExc_TypeError, "setMarker expects string, float");
         return NULL;
     }
-    self->fThis->setMarker(key, pos);
+    IConvertAnim(self)->setMarker(key, pos);
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -62,76 +66,78 @@ static PyObject* pyATCAnim_setLoop(pyATCAnim* self, PyObject* args) {
         PyErr_SetString(PyExc_TypeError, "setLoop expects string, float, float");
         return NULL;
     }
-    self->fThis->setLoop(key, begin, end);
+    IConvertAnim(self)->setLoop(key, begin, end);
     Py_INCREF(Py_None);
     return Py_None;
 }
 
 static PyObject* pyATCAnim_getInitial(pyATCAnim* self, void*) {
-    return PyFloat_FromDouble(self->fThis->getInitial());
+    return PyFloat_FromDouble(IConvertAnim(self)->getInitial());
 }
 
 static PyObject* pyATCAnim_getLoopStart(pyATCAnim* self, void*) {
-    return PyFloat_FromDouble(self->fThis->getLoopStart());
+    return PyFloat_FromDouble(IConvertAnim(self)->getLoopStart());
 }
 
 static PyObject* pyATCAnim_getLoopEnd(pyATCAnim* self, void*) {
-    return PyFloat_FromDouble(self->fThis->getLoopEnd());
+    return PyFloat_FromDouble(IConvertAnim(self)->getLoopEnd());
 }
 
 static PyObject* pyATCAnim_getAutoStart(pyATCAnim* self, void*) {
-    return PyBool_FromLong(self->fThis->getAutoStart() ? 1 : 0);
+    return PyBool_FromLong(IConvertAnim(self)->getAutoStart() ? 1 : 0);
 }
 
 static PyObject* pyATCAnim_getDoLoop(pyATCAnim* self, void*) {
-    return PyBool_FromLong(self->fThis->getDoLoop() ? 1 : 0);
+    return PyBool_FromLong(IConvertAnim(self)->getDoLoop() ? 1 : 0);
 }
 
 static PyObject* pyATCAnim_getEaseInType(pyATCAnim* self, void*) {
-    return PyInt_FromLong(self->fThis->getEaseInType());
+    return PyInt_FromLong(IConvertAnim(self)->getEaseInType());
 }
 
 static PyObject* pyATCAnim_getEaseOutType(pyATCAnim* self, void*) {
-    return PyInt_FromLong(self->fThis->getEaseOutType());
+    return PyInt_FromLong(IConvertAnim(self)->getEaseOutType());
 }
 
 static PyObject* pyATCAnim_getEaseInLength(pyATCAnim* self, void*) {
-    return PyFloat_FromDouble(self->fThis->getEaseInLength());
+    return PyFloat_FromDouble(IConvertAnim(self)->getEaseInLength());
 }
 
 static PyObject* pyATCAnim_getEaseInMin(pyATCAnim* self, void*) {
-    return PyFloat_FromDouble(self->fThis->getEaseInMin());
+    return PyFloat_FromDouble(IConvertAnim(self)->getEaseInMin());
 }
 
 static PyObject* pyATCAnim_getEaseInMax(pyATCAnim* self, void*) {
-    return PyFloat_FromDouble(self->fThis->getEaseInMax());
+    return PyFloat_FromDouble(IConvertAnim(self)->getEaseInMax());
 }
 
 static PyObject* pyATCAnim_getEaseOutLength(pyATCAnim* self, void*) {
-    return PyFloat_FromDouble(self->fThis->getEaseOutLength());
+    return PyFloat_FromDouble(IConvertAnim(self)->getEaseOutLength());
 }
 
 static PyObject* pyATCAnim_getEaseOutMin(pyATCAnim* self, void*) {
-    return PyFloat_FromDouble(self->fThis->getEaseOutMin());
+    return PyFloat_FromDouble(IConvertAnim(self)->getEaseOutMin());
 }
 
 static PyObject* pyATCAnim_getEaseOutMax(pyATCAnim* self, void*) {
-    return PyFloat_FromDouble(self->fThis->getEaseOutMax());
+    return PyFloat_FromDouble(IConvertAnim(self)->getEaseOutMax());
 }
 
 static PyObject* pyATCAnim_getMarkers(pyATCAnim* self, void*) {
+    plATCAnim* anim = IConvertAnim(self);
     PyObject* dict = PyDict_New();
-    for (plATCAnim::marker_t::iterator it = self->fThis->getMarkers().begin();
-         it != self->fThis->getMarkers().end(); it++) {
+    for (plATCAnim::marker_t::iterator it = anim->getMarkers().begin();
+         it != anim->getMarkers().end(); it++) {
         PyDict_SetItemString(dict, it->first, PyFloat_FromDouble(it->second));
     }
     return dict;
 }
 
 static PyObject* pyATCAnim_getLoops(pyATCAnim* self, void*) {
+    plATCAnim* anim = IConvertAnim(self);
     PyObject* dict = PyDict_New();
-    for (plATCAnim::loop_t::iterator it = self->fThis->getLoops().begin();
-         it != self->fThis->getLoops().end(); it++) {
+    for (plATCAnim::loop_t::iterator it = anim->getLoops().begin();
+         it != anim->getLoops().end(); it++) {
         PyDict_SetItemString(dict, it->first,
                   Py_BuildValue("ff", it->second.first, it->second.second));
     }
@@ -139,9 +145,10 @@ static PyObject* pyATCAnim_getLoops(pyATCAnim* self, void*) {
 }
 
 static PyObject* pyATCAnim_getStops(pyATCAnim* self, void*) {
-    PyObject* list = PyList_New(self->fThis->getStops().size());
-    for (size_t i=0; i<self->fThis->getStops().size(); i++)
-        PyList_SET_ITEM(list, i, PyFloat_FromDouble(self->fThis->getStops()[i]));
+    plATCAnim* anim = IConvertAnim(self);
+    PyObject* list = PyList_New(anim->getStops().size());
+    for (size_t i = 0; i < anim->getStops().size(); i++)
+        PyList_SET_ITEM(list, i, PyFloat_FromDouble(anim->getStops()[i]));
     return list;
 }
 
@@ -150,7 +157,7 @@ static int pyATCAnim_setInitial(pyATCAnim* self, PyObject* value, void*) {
         PyErr_SetString(PyExc_TypeError, "initial should be a float");
         return -1;
     }
-    self->fThis->setInitial(PyFloat_AsDouble(value));
+    IConvertAnim(self)->setInitial(PyFloat_AsDouble(value));
     return 0;
 }
 
@@ -159,7 +166,7 @@ static int pyATCAnim_setLoopStart(pyATCAnim* self, PyObject* value, void*) {
         PyErr_SetString(PyExc_TypeError, "loopStart should be a float");
         return -1;
     }
-    self->fThis->setLoopStart(PyFloat_AsDouble(value));
+    IConvertAnim(self)->setLoopStart(PyFloat_AsDouble(value));
     return 0;
 }
 
@@ -168,7 +175,7 @@ static int pyATCAnim_setLoopEnd(pyATCAnim* self, PyObject* value, void*) {
         PyErr_SetString(PyExc_TypeError, "loopEnd should be a float");
         return -1;
     }
-    self->fThis->setLoopEnd(PyFloat_AsDouble(value));
+    IConvertAnim(self)->setLoopEnd(PyFloat_AsDouble(value));
     return 0;
 }
 
@@ -177,7 +184,7 @@ static int pyATCAnim_setAutoStart(pyATCAnim* self, PyObject* value, void*) {
         PyErr_SetString(PyExc_TypeError, "autoStart should be a bool");
         return -1;
     }
-    self->fThis->setAutoStart(PyInt_AsLong(value) != 0);
+    IConvertAnim(self)->setAutoStart(PyInt_AsLong(value) != 0);
     return 0;
 }
 
@@ -186,7 +193,7 @@ static int pyATCAnim_setDoLoop(pyATCAnim* self, PyObject* value, void*) {
         PyErr_SetString(PyExc_TypeError, "loop should be a bool");
         return -1;
     }
-    self->fThis->setDoLoop(PyInt_AsLong(value) != 0);
+    IConvertAnim(self)->setDoLoop(PyInt_AsLong(value) != 0);
     return 0;
 }
 
@@ -195,7 +202,7 @@ static int pyATCAnim_setEaseInType(pyATCAnim* self, PyObject* value, void*) {
         PyErr_SetString(PyExc_TypeError, "easeInType should be an int");
         return -1;
     }
-    self->fThis->setEaseInType(PyInt_AsLong(value));
+    IConvertAnim(self)->setEaseInType(PyInt_AsLong(value));
     return 0;
 }
 
@@ -204,7 +211,7 @@ static int pyATCAnim_setEaseOutType(pyATCAnim* self, PyObject* value, void*) {
         PyErr_SetString(PyExc_TypeError, "easeOutType should be an int");
         return -1;
     }
-    self->fThis->setEaseOutType(PyInt_AsLong(value));
+    IConvertAnim(self)->setEaseOutType(PyInt_AsLong(value));
     return 0;
 }
 
@@ -213,9 +220,9 @@ static int pyATCAnim_setEaseInLength(pyATCAnim* self, PyObject* value, void*) {
         PyErr_SetString(PyExc_TypeError, "easeInLength should be a float");
         return -1;
     }
-    self->fThis->setEaseInParams(PyFloat_AsDouble(value),
-                                 self->fThis->getEaseInMin(),
-                                 self->fThis->getEaseInMax());
+    IConvertAnim(self)->setEaseInParams(PyFloat_AsDouble(value),
+                                        self->fThis->getEaseInMin(),
+                                        self->fThis->getEaseInMax());
     return 0;
 }
 
@@ -224,9 +231,9 @@ static int pyATCAnim_setEaseInMin(pyATCAnim* self, PyObject* value, void*) {
         PyErr_SetString(PyExc_TypeError, "easeInMin should be a float");
         return -1;
     }
-    self->fThis->setEaseInParams(self->fThis->getEaseInLength(),
-                                 PyFloat_AsDouble(value),
-                                 self->fThis->getEaseInMax());
+    IConvertAnim(self)->setEaseInParams(self->fThis->getEaseInLength(),
+                                        PyFloat_AsDouble(value),
+                                        self->fThis->getEaseInMax());
     return 0;
 }
 
@@ -235,9 +242,9 @@ static int pyATCAnim_setEaseInMax(pyATCAnim* self, PyObject* value, void*) {
         PyErr_SetString(PyExc_TypeError, "easeInMax should be a float");
         return -1;
     }
-    self->fThis->setEaseInParams(self->fThis->getEaseInLength(),
-                                 self->fThis->getEaseInMin(),
-                                 PyFloat_AsDouble(value));
+    IConvertAnim(self)->setEaseInParams(self->fThis->getEaseInLength(),
+                                        self->fThis->getEaseInMin(),
+                                        PyFloat_AsDouble(value));
     return 0;
 }
 
@@ -246,9 +253,9 @@ static int pyATCAnim_setEaseOutLength(pyATCAnim* self, PyObject* value, void*) {
         PyErr_SetString(PyExc_TypeError, "easeOutLength should be a float");
         return -1;
     }
-    self->fThis->setEaseOutParams(PyFloat_AsDouble(value),
-                                  self->fThis->getEaseOutMin(),
-                                  self->fThis->getEaseOutMax());
+    IConvertAnim(self)->setEaseOutParams(PyFloat_AsDouble(value),
+                                         self->fThis->getEaseOutMin(),
+                                         self->fThis->getEaseOutMax());
     return 0;
 }
 
@@ -257,9 +264,9 @@ static int pyATCAnim_setEaseOutMin(pyATCAnim* self, PyObject* value, void*) {
         PyErr_SetString(PyExc_TypeError, "easeOutMin should be a float");
         return -1;
     }
-    self->fThis->setEaseOutParams(self->fThis->getEaseOutLength(),
-                                  PyFloat_AsDouble(value),
-                                  self->fThis->getEaseOutMax());
+    IConvertAnim(self)->setEaseOutParams(self->fThis->getEaseOutLength(),
+                                         PyFloat_AsDouble(value),
+                                         self->fThis->getEaseOutMax());
     return 0;
 }
 
@@ -268,9 +275,9 @@ static int pyATCAnim_setEaseOutMax(pyATCAnim* self, PyObject* value, void*) {
         PyErr_SetString(PyExc_TypeError, "easeOutMax should be a float");
         return -1;
     }
-    self->fThis->setEaseOutParams(self->fThis->getEaseOutLength(),
-                                  self->fThis->getEaseOutMin(),
-                                  PyFloat_AsDouble(value));
+    IConvertAnim(self)->setEaseOutParams(self->fThis->getEaseOutLength(),
+                                         self->fThis->getEaseOutMin(),
+                                         PyFloat_AsDouble(value));
     return 0;
 }
 
@@ -286,7 +293,7 @@ static int pyATCAnim_setLoops(pyATCAnim* self, PyObject* value, void*) {
 
 static int pyATCAnim_setStops(pyATCAnim* self, PyObject* value, void*) {
     if (value == NULL) {
-        self->fThis->setStops(std::vector<float>());
+        IConvertAnim(self)->setStops(std::vector<float>());
         return 0;
     } else if (PyList_Check(value)) {
         std::vector<float> stops(PyList_Size(value));
@@ -297,7 +304,7 @@ static int pyATCAnim_setStops(pyATCAnim* self, PyObject* value, void*) {
             }
             stops[i] = PyFloat_AsDouble(PyList_GetItem(value, i));
         }
-        self->fThis->setStops(stops);
+        IConvertAnim(self)->setStops(stops);
         return 0;
     } else {
         PyErr_SetString(PyExc_TypeError, "stops should be a list of floats");

--- a/Python/PRP/Avatar/pyATCAnim.cpp
+++ b/Python/PRP/Avatar/pyATCAnim.cpp
@@ -295,19 +295,19 @@ static int pyATCAnim_setStops(pyATCAnim* self, PyObject* value, void*) {
     if (value == NULL) {
         IConvertAnim(self)->setStops(std::vector<float>());
         return 0;
-    } else if (PyList_Check(value)) {
-        std::vector<float> stops(PyList_Size(value));
+    } else if (PySequence_Check(value)) {
+        std::vector<float> stops(PySequence_Size(value));
         for (size_t i=0; i<stops.size(); i++) {
-            if (!PyFloat_Check(PyList_GetItem(value, i))) {
-                PyErr_SetString(PyExc_TypeError, "stops should be a list of floats");
+            if (!PyFloat_Check(PySequence_GetItem(value, i))) {
+                PyErr_SetString(PyExc_TypeError, "stops should be a sequence of floats");
                 return -1;
             }
-            stops[i] = PyFloat_AsDouble(PyList_GetItem(value, i));
+            stops[i] = PyFloat_AsDouble(PySequence_GetItem(value, i));
         }
         IConvertAnim(self)->setStops(stops);
         return 0;
     } else {
-        PyErr_SetString(PyExc_TypeError, "stops should be a list of floats");
+        PyErr_SetString(PyExc_TypeError, "stops should be a sequence of floats");
         return -1;
     }
 }

--- a/Python/PRP/Avatar/pyMatrixChannel.cpp
+++ b/Python/PRP/Avatar/pyMatrixChannel.cpp
@@ -32,7 +32,7 @@ static PyObject* pyMatrixChannel_new(PyTypeObject* type, PyObject* args, PyObjec
 }
 
 static PyObject* pyMatrixChannel_getAffine(pyMatrixChannel* self, void*) {
-    return pyAffineParts_FromAffineParts(self->fThis->getAffine());
+    return pyAffineParts_FromAffineParts(plMatrixChannel::Convert(IConvert((pyCreatable*)self))->getAffine());
 }
 
 static int pyMatrixChannel_setAffine(pyMatrixChannel* self, PyObject* value, void*) {
@@ -40,7 +40,7 @@ static int pyMatrixChannel_setAffine(pyMatrixChannel* self, PyObject* value, voi
         PyErr_SetString(PyExc_TypeError, "result should be an hsAffineParts");
         return -1;
     }
-    self->fThis->setAffine(*((pyAffineParts*)value)->fThis);
+    plMatrixChannel::Convert(IConvert((pyCreatable*)self))->setAffine(*((pyAffineParts*)value)->fThis);
     return 0;
 }
 

--- a/Python/PRP/Avatar/pyMatrixControllerChannel.cpp
+++ b/Python/PRP/Avatar/pyMatrixControllerChannel.cpp
@@ -32,7 +32,7 @@ static PyObject* pyMatrixControllerChannel_new(PyTypeObject* type, PyObject* arg
 }
 
 static PyObject* pyMatrixControllerChannel_getController(pyMatrixControllerChannel* self, void*) {
-    return pyController_FromController(self->fThis->getController());
+    return ICreate(self->fThis->getController());
 }
 
 static int pyMatrixControllerChannel_setController(pyMatrixControllerChannel* self, PyObject* value, void*) {

--- a/Python/PRP/pyCreatableConvert.cpp
+++ b/Python/PRP/pyCreatableConvert.cpp
@@ -176,6 +176,7 @@
 #include "PRP/Avatar/pyAGAnim.h"
 #include "PRP/Avatar/pyAGApplicator.h"
 #include "PRP/Avatar/pyAGChannel.h"
+#include "PRP/Avatar/pyAGMasterMod.h"
 #include "PRP/Avatar/pyAGModifier.h"
 #include "PRP/Avatar/pyATCAnim.h"
 #include "PRP/Avatar/pyMultistageBehMod.h"
@@ -350,7 +351,7 @@ plCreatable* IConvert(pyCreatable* pCre)
     else if (Py_TYPE(pCre) == &pyLimitedDirLightInfo_Type) return dynamic_cast<plCreatable*>(reinterpret_cast<plLimitedDirLightInfo*>(pCre->fThis));
     else if (Py_TYPE(pCre) == &pyAGAnim_Type) return dynamic_cast<plCreatable*>(reinterpret_cast<plAGAnim*>(pCre->fThis));
     else if (Py_TYPE(pCre) == &pyAGModifier_Type) return dynamic_cast<plCreatable*>(reinterpret_cast<plAGModifier*>(pCre->fThis));
-    //else if (Py_TYPE(pCre) == &pyAGMasterMod_Type) return dynamic_cast<plCreatable*>(reinterpret_cast<plAGMasterMod*>(pCre->fThis));
+    else if (Py_TYPE(pCre) == &pyAGMasterMod_Type) return dynamic_cast<plCreatable*>(reinterpret_cast<plAGMasterMod*>(pCre->fThis));
     //else if (Py_TYPE(pCre) == &pyCameraBrain_Avatar_Type) return dynamic_cast<plCreatable*>(reinterpret_cast<plCameraBrain_Avatar*>(pCre->fThis));
     //else if (Py_TYPE(pCre) == &pyCameraRegionDetector_Type) return dynamic_cast<plCreatable*>(reinterpret_cast<plCameraRegionDetector*>(pCre->fThis));
     //else if (Py_TYPE(pCre) == &pyCameraBrain_FP_Type) return dynamic_cast<plCreatable*>(reinterpret_cast<plCameraBrain_FP*>(pCre->fThis));
@@ -689,6 +690,7 @@ PyObject* ICreate(plCreatable* pCre)
         case kSittingModifier: return pySittingModifier_FromSittingModifier(plSittingModifier::Convert(pCre));
         case kAGAnim: return pyAGAnim_FromAGAnim(plAGAnim::Convert(pCre));
         case kAGModifier: return pyAGModifier_FromAGModifier(plAGModifier::Convert(pCre));
+        case kAGMasterMod: return pyAGMasterMod_FromAGMasterMod(plAGMasterMod::Convert(pCre));
         case kAgeGlobalAnim: return pyAgeGlobalAnim_FromAgeGlobalAnim(plAgeGlobalAnim::Convert(pCre));
         case kATCAnim: return pyATCAnim_FromATCAnim(plATCAnim::Convert(pCre));
         case kSubworldRegionDetector: return pySubworldRegionDetector_FromSubworldRegionDetector(plSubworldRegionDetector::Convert(pCre));

--- a/Python/PRP/pyCreatableConvert.cpp
+++ b/Python/PRP/pyCreatableConvert.cpp
@@ -176,6 +176,7 @@
 #include "PRP/Avatar/pyAGAnim.h"
 #include "PRP/Avatar/pyAGApplicator.h"
 #include "PRP/Avatar/pyAGChannel.h"
+#include "PRP/Avatar/pyAGModifier.h"
 #include "PRP/Avatar/pyATCAnim.h"
 #include "PRP/Avatar/pyMultistageBehMod.h"
 #include "PRP/Avatar/pySittingModifier.h"
@@ -348,7 +349,7 @@ plCreatable* IConvert(pyCreatable* pCre)
     //else if (Py_TYPE(pCre) == &pyLayerShadowBase_Type) return dynamic_cast<plCreatable*>(reinterpret_cast<plLayerShadowBase*>(pCre->fThis));
     else if (Py_TYPE(pCre) == &pyLimitedDirLightInfo_Type) return dynamic_cast<plCreatable*>(reinterpret_cast<plLimitedDirLightInfo*>(pCre->fThis));
     else if (Py_TYPE(pCre) == &pyAGAnim_Type) return dynamic_cast<plCreatable*>(reinterpret_cast<plAGAnim*>(pCre->fThis));
-    //else if (Py_TYPE(pCre) == &pyAGModifier_Type) return dynamic_cast<plCreatable*>(reinterpret_cast<plAGModifier*>(pCre->fThis));
+    else if (Py_TYPE(pCre) == &pyAGModifier_Type) return dynamic_cast<plCreatable*>(reinterpret_cast<plAGModifier*>(pCre->fThis));
     //else if (Py_TYPE(pCre) == &pyAGMasterMod_Type) return dynamic_cast<plCreatable*>(reinterpret_cast<plAGMasterMod*>(pCre->fThis));
     //else if (Py_TYPE(pCre) == &pyCameraBrain_Avatar_Type) return dynamic_cast<plCreatable*>(reinterpret_cast<plCameraBrain_Avatar*>(pCre->fThis));
     //else if (Py_TYPE(pCre) == &pyCameraRegionDetector_Type) return dynamic_cast<plCreatable*>(reinterpret_cast<plCameraRegionDetector*>(pCre->fThis));
@@ -687,6 +688,7 @@ PyObject* ICreate(plCreatable* pCre)
         case kDynamicTextMap: return pyDynamicTextMap_FromDynamicTextMap(plDynamicTextMap::Convert(pCre));
         case kSittingModifier: return pySittingModifier_FromSittingModifier(plSittingModifier::Convert(pCre));
         case kAGAnim: return pyAGAnim_FromAGAnim(plAGAnim::Convert(pCre));
+        case kAGModifier: return pyAGModifier_FromAGModifier(plAGModifier::Convert(pCre));
         case kAgeGlobalAnim: return pyAgeGlobalAnim_FromAgeGlobalAnim(plAgeGlobalAnim::Convert(pCre));
         case kATCAnim: return pyATCAnim_FromATCAnim(plATCAnim::Convert(pCre));
         case kSubworldRegionDetector: return pySubworldRegionDetector_FromSubworldRegionDetector(plSubworldRegionDetector::Convert(pCre));

--- a/core/PRP/Animation/plLeafController.cpp
+++ b/core/PRP/Animation/plLeafController.cpp
@@ -448,5 +448,5 @@ void plLeafController::setEaseControllers(const std::vector<class plEaseControll
     DeallocControllers();
     AllocControllers(controllers.size());
     for (size_t i=0; i<controllers.size(); i++)
-        fEaseControllers[i] = controllers[i];
+        *fEaseControllers[i] = *controllers[i];
 }

--- a/core/PRP/Animation/plLeafController.cpp
+++ b/core/PRP/Animation/plLeafController.cpp
@@ -441,7 +441,7 @@ void plLeafController::setKeys(const std::vector<hsKeyFrame*>& keys, unsigned in
     DeallocKeys();
     AllocKeys(keys.size(), type);
     for (size_t i=0; i<keys.size(); i++)
-        fKeys[i] = keys[i];
+        *fKeys[i] = *keys[i];
 }
 
 void plLeafController::setEaseControllers(const std::vector<class plEaseController*>& controllers) {

--- a/core/PRP/Avatar/plAGMasterMod.h
+++ b/core/PRP/Avatar/plAGMasterMod.h
@@ -37,6 +37,29 @@ public:
 protected:
     virtual void IPrcWrite(pfPrcHelper* prc);
     virtual void IPrcParse(const pfPrcTag* tag, plResManager* mgr);
+
+public:
+    const std::vector<plKey>& getPrivateAnims() const { return fPrivateAnims; }
+    std::vector<plKey>& getPrivateAnims() { return fPrivateAnims; }
+    void addPrivateAnim(plKey key) { fPrivateAnims.push_back(key); }
+    void delPrivateAnim(size_t idx) { fPrivateAnims.erase(fPrivateAnims.begin() + idx); }
+    void clearPrivateAnims() { fPrivateAnims.clear(); }
+
+    const std::vector<plKey>& getEoaKeys() const { return fEoaKeys2; }
+    std::vector<plKey>& getEoaKeys() { return fEoaKeys2; }
+    void addEoaKey(plKey key) { fEoaKeys2.push_back(key); }
+    void delEoaKey(size_t idx) { fEoaKeys2.erase(fEoaKeys2.begin() + idx); }
+    void clearEoaKeys() { fEoaKeys2.clear(); }
+
+    plString getGroupName() const { return fGroupName; }
+    bool getIsGrouped() const { return fIsGrouped; }
+    bool getIsGroupMaster() const { return fIsGroupMaster; }
+    plKey getMsgForwarder() const { return fMsgForwarder; }
+
+    void setGroupName(const plString& value) { fGroupName = value; }
+    void setIsGrouped(bool value) { fIsGrouped = value; }
+    void setIsGroupMaster(bool value) { fIsGroupMaster = value; }
+    void setMsgForwarder(plKey value) { fMsgForwarder = value; }
 };
 
 #endif

--- a/core/PRP/Avatar/plAGModifier.h
+++ b/core/PRP/Avatar/plAGModifier.h
@@ -35,6 +35,15 @@ public:
 protected:
     virtual void IPrcWrite(pfPrcHelper* prc);
     virtual void IPrcParse(const pfPrcTag* tag, plResManager* mgr);
+
+public:
+    plString getChannelName() const { return fChannelName; }
+    bool getAutoApply() const { return fAutoApply; }
+    bool getEnabled() const { return fEnabled; }
+
+    void setChannelName(const plString& value) { fChannelName = value; }
+    void setAutoApply(bool value) { fAutoApply = value; }
+    void setEnabled(bool value) { fEnabled = value; }
 };
 
 #endif


### PR DESCRIPTION
Improves the animation bits of PyHSPlasma by adding correct duck-typing for many return values and fixes many of those pesky plCreatable casts. This doesn't fix every single problem in the land, but it hits all of the ones needed for exporting simple animations in Korman and then some :smile:.