### PR TITLE
Deal with python library version '2.7.10+'

### DIFF
--- a/Python/CMakeLists.txt
+++ b/Python/CMakeLists.txt
@@ -1,8 +1,10 @@
 find_package(PythonLibs REQUIRED)
-find_package(PythonInterp "${PYTHONLIBS_VERSION_STRING}" REQUIRED)
+# this sometimes ends in '+', filter that
+STRING(REGEX REPLACE "([0-9.])[+]*" "\\1" PYTHONLIBS_VERSION_STRING_FILTERED "${PYTHONLIBS_VERSION_STRING}")
+find_package(PythonInterp "${PYTHONLIBS_VERSION_STRING_FILTERED}" REQUIRED)
 # make sure the versions match
-if (NOT "${PYTHONLIBS_VERSION_STRING}" STREQUAL "${PYTHON_VERSION_STRING}")
-    message(FATAL_ERROR "Versions of Python libraries (${PYTHONLIBS_VERSION_STRING}) and Python interpreter (${PYTHON_VERSION_STRING}) do not match. Please configure the paths manually.")
+if (NOT "${PYTHONLIBS_VERSION_STRING_FILTERED}" STREQUAL "${PYTHON_VERSION_STRING}")
+    message(FATAL_ERROR "Versions of Python libraries (${PYTHONLIBS_VERSION_STRING_FILTERED}) and Python interpreter (${PYTHON_VERSION_STRING}) do not match. Please configure the paths manually.")
 endif()
 
 


### PR DESCRIPTION
Without this patch, I am getting an error, the interpreter search complaining that there is no version '2.7.10+'. I have no idea who thought it was a good idea to make *that* the version number returned by the library search.