### PR TITLE
Add a stub for pyRAMStream.close()

### DIFF
--- a/Python/Stream/pyEncryptedStream.cpp
+++ b/Python/Stream/pyEncryptedStream.cpp
@@ -56,12 +56,6 @@ static PyObject* pyEncryptedStream_open(pyEncryptedStream* self, PyObject* args)
     }
 }
 
-static PyObject* pyEncryptedStream_close(pyEncryptedStream* self) {
-    self->fThis->close();
-    Py_INCREF(Py_None);
-    return Py_None;
-}
-
 static PyObject* pyEncryptedStream_setKey(pyEncryptedStream* self, PyObject* args) {
     PyObject* keyList;
     if (!PyArg_ParseTuple(args, "O", &keyList)) {
@@ -124,8 +118,6 @@ static PyMethodDef pyEncryptedStream_Methods[] = {
       "Opens the specified file.\n"
       "Mode is: fmRead, fmWrite, fmReadWrite, fmCreate\n"
       "Encryption is: kEncNone, kEncXtea, kEncAES, kEncDroid, kEncAuto" },
-    { "close", (PyCFunction)pyEncryptedStream_close, METH_NOARGS,
-      "Closes the active file, if it is open" },
     { "setKey", (PyCFunction)pyEncryptedStream_setKey, METH_VARARGS,
       "Params: key\n"
       "Sets the encryption key. `key` should be an array of 4 ints" },

--- a/Python/Stream/pyFileStream.cpp
+++ b/Python/Stream/pyFileStream.cpp
@@ -53,12 +53,6 @@ static PyObject* pyFileStream_open(pyFileStream* self, PyObject* args) {
     }
 }
 
-static PyObject* pyFileStream_close(pyFileStream* self) {
-    self->fThis->close();
-    Py_INCREF(Py_None);
-    return Py_None;
-}
-
 static PyObject* pyFileStream__enter__(PyObject* self) {
     Py_INCREF(self);
     return self;
@@ -75,8 +69,6 @@ static PyMethodDef pyFileStream_Methods[] = {
       "Params: filename, mode\n"
       "Opens the specified file.\n"
       "Mode is: fmRead, fmWrite, fmReadWrite, fmCreate" },
-    { "close", (PyCFunction)pyFileStream_close, METH_NOARGS,
-      "Closes the active file, if it is open" },
     { "__enter__", (PyCFunction)pyFileStream__enter__, METH_NOARGS, NULL },
     { "__exit__", (PyCFunction)pyFileStream__exit__, METH_VARARGS, NULL },
     { NULL, NULL, 0, NULL }

--- a/Python/Stream/pyRAMStream.cpp
+++ b/Python/Stream/pyRAMStream.cpp
@@ -44,6 +44,11 @@ static PyObject* pyRAMStream_resize(pyRAMStream* self, PyObject* args) {
     return Py_None;
 }
 
+static PyObject* pyRAMStream_close(pyRAMStream* self, PyObject*) {
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
 static PyObject* pyRAMStream_getBuffer(pyRAMStream* self, void* closure) {
     char* buf = new char[self->fThis->size()];
     self->fThis->copyTo(buf, self->fThis->size());
@@ -70,6 +75,9 @@ static PyMethodDef pyRAMStream_Methods[] = {
       "Allocates newsize bytes in the internal buffer.  This will truncate "
       "data if it's shorter than the current buffer, or zero-fill the extra "
       "space if it's larger than the current buffer." },
+    { "close", (PyCFunction)pyRAMStream_close, METH_NOARGS,
+      "Closes the stream. Note that this is a no-op on RAM streams and "
+      "exists to match the interface of other hsStream subclasses." },
     { NULL, NULL, 0, NULL }
 };
 

--- a/Python/Stream/pyRAMStream.cpp
+++ b/Python/Stream/pyRAMStream.cpp
@@ -44,11 +44,6 @@ static PyObject* pyRAMStream_resize(pyRAMStream* self, PyObject* args) {
     return Py_None;
 }
 
-static PyObject* pyRAMStream_close(pyRAMStream* self, PyObject*) {
-    Py_INCREF(Py_None);
-    return Py_None;
-}
-
 static PyObject* pyRAMStream_getBuffer(pyRAMStream* self, void* closure) {
     char* buf = new char[self->fThis->size()];
     self->fThis->copyTo(buf, self->fThis->size());
@@ -75,9 +70,6 @@ static PyMethodDef pyRAMStream_Methods[] = {
       "Allocates newsize bytes in the internal buffer.  This will truncate "
       "data if it's shorter than the current buffer, or zero-fill the extra "
       "space if it's larger than the current buffer." },
-    { "close", (PyCFunction)pyRAMStream_close, METH_NOARGS,
-      "Closes the stream. Note that this is a no-op on RAM streams and "
-      "exists to match the interface of other hsStream subclasses." },
     { NULL, NULL, 0, NULL }
 };
 

--- a/Python/Stream/pyStream.cpp
+++ b/Python/Stream/pyStream.cpp
@@ -41,6 +41,12 @@ static PyObject* pyStream_new(PyTypeObject* type, PyObject* args, PyObject* kwds
     return NULL;
 }
 
+static PyObject* pyStream_close(pyStream* self) {
+    self->fThis->close();
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
 static PyObject* pyStream_eof(pyStream* self) {
     bool eof = self->fThis->eof();
     if (eof) {
@@ -414,6 +420,8 @@ static int pyStream_setPos(pyStream* self, PyObject* value, void* closure) {
 }
 
 static PyMethodDef pyStream_Methods[] = {
+    { "close", (PyCFunction)pyStream_close, METH_NOARGS,
+      "Closes the stream, if it is open" },
     { "eof", (PyCFunction)pyStream_eof, METH_NOARGS,
       "Returns True if the position is at the end of the stream" },
     { "seek", (PyCFunction)pyStream_seek, METH_VARARGS,

--- a/core/Stream/hsStream.h
+++ b/core/Stream/hsStream.h
@@ -36,6 +36,8 @@ public:
     explicit hsStream(int pv = PlasmaVer::pvUnknown) { setVer(PlasmaVer(pv)); }
     virtual ~hsStream() { }
 
+    virtual void close() { }
+
     PlasmaVer getVer() const { return ver; }
     virtual void setVer(PlasmaVer pv) { ver = pv; }
 


### PR DESCRIPTION
I know this doesn't match the C++ API, but it seems more pythonic to be able to write:
```python
stream.close()
```
as a catch-all instead of
```python
if isinstance(stream, hsFileStream):
    stream.close()
```
when you're juggling both hsFileStream and hsRAMStream.