### PR TITLE
Static build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ endif()
 option(ENABLE_PYTHON "Build HSPlasma Python integration" OFF)
 option(ENABLE_TOOLS "Build the HSPlasma tools" ON)
 option(ENABLE_NET "Build HSPlasmaNet" ON)
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
 try_compile(HAVE_OVERRIDE ${PROJECT_BINARY_DIR}
             ${PROJECT_SOURCE_DIR}/cmake/check_override.cpp)

--- a/Python/CMakeLists.txt
+++ b/Python/CMakeLists.txt
@@ -538,7 +538,7 @@ set(PYTHON_HDRS
     PyPlasma.h
 )
 
-add_library(PyHSPlasma SHARED
+add_library(PyHSPlasma
           ${DEBUG_SRCS}    ${DEBUG_HDRS}
           ${MATH_SRCS}     ${MATH_HDRS}
           ${PRP_ANIM_SRCS} ${PRP_ANIM_HDRS}

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -759,7 +759,7 @@ set(SQUISH
     3rdPartyLibs/squish/squish.h
 )
 
-add_library(HSPlasma SHARED
+add_library(HSPlasma
             ${DEBUG_SRCS}    ${DEBUG_HDRS}
             ${MATH_SRCS}     ${MATH_HDRS}
             ${PRP_ANIM_SRCS} ${PRP_ANIM_HDRS}

--- a/net/CMakeLists.txt
+++ b/net/CMakeLists.txt
@@ -86,7 +86,7 @@ set(PN_HDRS
     pnSocketInterface.h
 )
 
-add_library(HSPlasmaNet SHARED
+add_library(HSPlasmaNet
             ${PN_AUTH_SRCS}  ${PN_AUTH_HDRS}
             ${PN_CRYPT_SRCS} ${PN_CRYPT_HDRS}
             ${PN_FILE_SRCS}  ${PN_FILE_HDRS}


### PR DESCRIPTION
Added an option to build static libraries. (or rather, added an option to build shared libs, and set it to default on)

Also, I built this with MinGW 4.9.2, and it requires a newer std flag, or else it complains about some of the Win32 includes. Using gnu++11 shouldn't cause issues with other gcc environments, but it may be worth checking, especially given that mismatching this flag _will_ cause linking issues.