### PR TITLE
Python refactor 3

### DIFF
--- a/Python/Module.cpp
+++ b/Python/Module.cpp
@@ -148,7 +148,7 @@ PY_METHOD_GLOBAL_VA(PyHSPlasma, CleanFileName,
         PyErr_SetString(PyExc_TypeError, "CleanFileName expects a string");
         return NULL;
     }
-    return PlStr_To_PyStr(CleanFileName(fname, allowPathChars != 0));
+    return pyPlasma_convert(CleanFileName(fname, allowPathChars != 0));
 }
 
 }

--- a/Python/PRP/Animation/pyLeafController.cpp
+++ b/Python/PRP/Animation/pyLeafController.cpp
@@ -80,7 +80,7 @@ PY_GETSET_SETTER_DECL(LeafController, keys) {
     Py_ssize_t keyCount = keySeq.size();
     std::vector<hsKeyFrame*> keyframes;
     keyframes.reserve(keyCount);
-    unsigned int keyType = pyPlasma_check<unsigned int>(keyTypeObj);
+    unsigned int keyType = pyPlasma_get<unsigned int>(keyTypeObj);
     for (Py_ssize_t i = 0; i < keyCount; ++i) {
         PyObject* key = keySeq.get(i);
         if (!pyKeyFrame_Check(key)) {

--- a/Python/PRP/Animation/pyScaleKey.cpp
+++ b/Python/PRP/Animation/pyScaleKey.cpp
@@ -34,10 +34,8 @@ PY_GETSET_GETTER_DECL(ScaleKey, value) {
 }
 
 PY_GETSET_SETTER_DECL(ScaleKey, value) {
-    if (value == NULL) {
-        PyErr_SetString(PyExc_RuntimeError, "value cannot be deleted");
-        return -1;
-    } else if (!PyTuple_Check(value) || PyTuple_Size(value) != 2) {
+    PY_PROPERTY_CHECK_NULL(value)
+    if (!PyTuple_Check(value) || PyTuple_Size(value) != 2) {
         PyErr_SetString(PyExc_TypeError, "value should be a tuple (hsVector3, hsQuat)");
         return -1;
     }

--- a/Python/PRP/Animation/pySplineEaseCurve.cpp
+++ b/Python/PRP/Animation/pySplineEaseCurve.cpp
@@ -38,11 +38,11 @@ PY_GETSET_SETTER_DECL(SplineEaseCurve, splineCoef) {
     }
     for (size_t i=0; i<4; i++) {
         PyObject* itm = PyTuple_GetItem(value, i);
-        if (!PyFloat_Check(itm)) {
+        if (!pyPlasma_check<float>(itm)) {
             PyErr_SetString(PyExc_TypeError, "splineCoef should be a tuple of 4 floats");
             return -1;
         }
-        self->fThis->setSplineCoef(i, PyFloat_AsDouble(itm));
+        self->fThis->setSplineCoef(i, pyPlasma_get<float>(itm));
     }
     return 0;
 }

--- a/Python/PRP/Animation/pySplineEaseCurve.cpp
+++ b/Python/PRP/Animation/pySplineEaseCurve.cpp
@@ -31,10 +31,8 @@ PY_GETSET_GETTER_DECL(SplineEaseCurve, splineCoef) {
 }
 
 PY_GETSET_SETTER_DECL(SplineEaseCurve, splineCoef) {
-    if (value == NULL) {
-        PyErr_SetString(PyExc_RuntimeError, "splineCoef cannot be deleted");
-        return -1;
-    } else if (!PyTuple_Check(value) || PyTuple_Size(value) != 4) {
+    PY_PROPERTY_CHECK_NULL(splineCoef)
+    if (!PyTuple_Check(value) || PyTuple_Size(value) != 4) {
         PyErr_SetString(PyExc_TypeError, "splineCoef should be a tuple of 4 floats");
         return -1;
     }

--- a/Python/PRP/Audio/pySoundBuffer.cpp
+++ b/Python/PRP/Audio/pySoundBuffer.cpp
@@ -39,10 +39,8 @@ PY_GETSET_GETTER_DECL(SoundBuffer, data) {
 }
 
 PY_GETSET_SETTER_DECL(SoundBuffer, data) {
-    if (value == NULL) {
-        PyErr_SetString(PyExc_RuntimeError, "data cannot be deleted");
-        return -1;
-    } else if (value == Py_None) {
+    PY_PROPERTY_CHECK_NULL(data)
+    if (value == Py_None) {
         self->fThis->setData(0, NULL);
         return 0;
     } else if (!PyBytes_Check(value)) {

--- a/Python/PRP/Audio/pyWinAudible.cpp
+++ b/Python/PRP/Audio/pyWinAudible.cpp
@@ -59,18 +59,6 @@ PY_METHOD_VA(WinAudible, clearSounds, "Remove all sound objects from the Audible
     Py_RETURN_NONE;
 }
 
-static PyObject* pyWinAudible_getSounds(pyWinAudible* self, void*) {
-    PyObject* list = PyList_New(self->fThis->getSounds().size());
-    for (size_t i=0; i<self->fThis->getSounds().size(); i++)
-        PyList_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getSounds()[i]));
-    return list;
-}
-
-static int pyWinAudible_setSounds(pyWinAudible* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "to add sounds, use addSound()");
-    return -1;
-}
-
 static PyMethodDef pyWinAudible_Methods[] = {
     pyWinAudible_addSound_method,
     pyWinAudible_delSound_method,
@@ -78,10 +66,21 @@ static PyMethodDef pyWinAudible_Methods[] = {
     PY_METHOD_TERMINATOR
 };
 
+PY_GETSET_GETTER_DECL(WinAudible, sounds) {
+    const std::vector<plKey>& sounds = self->fThis->getSounds();
+    PyObject* list = PyTuple_New(sounds.size());
+    for (size_t i=0; i<sounds.size(); i++)
+        PyTuple_SET_ITEM(list, i, pyPlasma_convert(sounds[i]));
+    return list;
+}
+
+PY_PROPERTY_SETTER_MSG(WinAudible, sounds, "To add sounds, use addSound()")
+PY_PROPERTY_GETSET_DECL(WinAudible, sounds)
+
 PY_PROPERTY(plKey, WinAudible, sceneNode, getSceneNode, setSceneNode)
 
 static PyGetSetDef pyWinAudible_GetSet[] = {
-    { _pycs("sounds"), (getter)pyWinAudible_getSounds, (setter)pyWinAudible_setSounds, NULL, NULL },
+    pyWinAudible_sounds_getset,
     pyWinAudible_sceneNode_getset,
     PY_GETSET_TERMINATOR
 };

--- a/Python/PRP/Avatar/pyAGAnim.cpp
+++ b/Python/PRP/Avatar/pyAGAnim.cpp
@@ -61,25 +61,23 @@ PY_METHOD_VA(AGAnim, delApplicator,
     Py_RETURN_NONE;
 }
 
-static PyObject* pyAGAnim_getApps(pyAGAnim* self, void*) {
-    plAGAnim* anim = self->fThis;
-    PyObject* list = PyList_New(anim->getApplicators().size());
-    for (size_t i=0; i < anim->getApplicators().size(); i++)
-        PyList_SET_ITEM(list, i, ICreate(anim->getApplicators()[i]));
-    return list;
-}
-
-static int pyAGAnim_setApps(pyAGAnim* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "To add applicators, use addApplicator()");
-    return -1;
-}
-
 static PyMethodDef pyAGAnim_Methods[] = {
     pyAGAnim_clearApplicators_method,
     pyAGAnim_addApplicator_method,
     pyAGAnim_delApplicator_method,
     PY_METHOD_TERMINATOR
 };
+
+PY_GETSET_GETTER_DECL(AGAnim, applicators) {
+    plAGAnim* anim = self->fThis;
+    PyObject* list = PyTuple_New(anim->getApplicators().size());
+    for (size_t i=0; i < anim->getApplicators().size(); i++)
+        PyTuple_SET_ITEM(list, i, ICreate(anim->getApplicators()[i]));
+    return list;
+}
+
+PY_PROPERTY_SETTER_MSG(AGAnim, applicators, "To add applicators, use addApplicator()")
+PY_PROPERTY_GETSET_DECL(AGAnim, applicators)
 
 PY_PROPERTY(float, AGAnim, blend, getBlend, setBlend)
 PY_PROPERTY(float, AGAnim, start, getStart, setStart)
@@ -91,7 +89,7 @@ static PyGetSetDef pyAGAnim_GetSet[] = {
     pyAGAnim_start_getset,
     pyAGAnim_end_getset,
     pyAGAnim_name_getset,
-    { _pycs("applicators"), (getter)pyAGAnim_getApps, (setter)pyAGAnim_setApps, NULL, NULL },
+    pyAGAnim_applicators_getset,
     PY_GETSET_TERMINATOR
 };
 

--- a/Python/PRP/Avatar/pyAGMasterMod.cpp
+++ b/Python/PRP/Avatar/pyAGMasterMod.cpp
@@ -96,7 +96,7 @@ static PyMethodDef pyAGMasterMod_Methods[] = {
     PY_METHOD_TERMINATOR
 };
 
-static PyObject* pyAGMasterMod_getPrivateAnims(pyAGMasterMod* self, void*) {
+PY_GETSET_GETTER_DECL(AGMasterMod, privateAnims) {
     const std::vector<plKey>& anims = self->fThis->getPrivateAnims();
     PyObject* tup = PyTuple_New(anims.size());
     for (size_t i = 0; i < anims.size(); ++i)
@@ -104,7 +104,11 @@ static PyObject* pyAGMasterMod_getPrivateAnims(pyAGMasterMod* self, void*) {
     return tup;
 }
 
-static PyObject* pyAGMasterMod_getEoaKeys(pyAGMasterMod* self, void*) {
+PY_PROPERTY_SETTER_MSG(AGMasterMod, privateAnims,
+                       "To add privateAnims, use addPrivateAnim()")
+PY_PROPERTY_GETSET_DECL(AGMasterMod, privateAnims)
+
+PY_GETSET_GETTER_DECL(AGMasterMod, eoaKeys) {
     const std::vector<plKey>& keys = self->fThis->getEoaKeys();
     PyObject* tup = PyTuple_New(keys.size());
     for (size_t i = 0; i < keys.size(); ++i)
@@ -112,15 +116,8 @@ static PyObject* pyAGMasterMod_getEoaKeys(pyAGMasterMod* self, void*) {
     return tup;
 }
 
-static int pyAGMasterMod_setPrivateAnims(pyAGMasterMod* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "To add privateAnims, use addPrivateAnim()");
-    return -1;
-}
-
-static int pyAGMasterMod_setEoaKeys(pyAGMasterMod* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "To add eoaKeys, use addEoaKey()");
-    return -1;
-}
+PY_PROPERTY_SETTER_MSG(AGMasterMod, eoaKeys, "To add eoaKeys, use addEoaKey()")
+PY_PROPERTY_GETSET_DECL(AGMasterMod, eoaKeys)
 
 PY_PROPERTY(plString, AGMasterMod, groupName, getGroupName, setGroupName)
 PY_PROPERTY(bool, AGMasterMod, isGrouped, getIsGrouped, setIsGrouped)
@@ -128,8 +125,8 @@ PY_PROPERTY(bool, AGMasterMod, isGroupMaster, getIsGroupMaster, setIsGroupMaster
 PY_PROPERTY(plKey, AGMasterMod, msgForwarder, getMsgForwarder, setMsgForwarder)
 
 static PyGetSetDef pyAGMasterMod_GetSet[] = {
-    { _pycs("privateAnims"), (getter)pyAGMasterMod_getPrivateAnims, (setter)pyAGMasterMod_setPrivateAnims, NULL, NULL },
-    { _pycs("eoaKeys"), (getter)pyAGMasterMod_getEoaKeys, (setter)pyAGMasterMod_setEoaKeys, NULL, NULL },
+    pyAGMasterMod_privateAnims_getset,
+    pyAGMasterMod_eoaKeys_getset,
     pyAGMasterMod_groupName_getset,
     pyAGMasterMod_isGrouped_getset,
     pyAGMasterMod_isGroupMaster_getset,

--- a/Python/PRP/Avatar/pyAnimStage.cpp
+++ b/Python/PRP/Avatar/pyAnimStage.cpp
@@ -40,10 +40,8 @@ PY_GETSET_GETTER_DECL(AnimStage, advanceTo) {
 }
 
 PY_GETSET_SETTER_DECL(AnimStage, advanceTo) {
-    if (value == NULL) {
-        PyErr_SetString(PyExc_RuntimeError, "advanceTo cannot be deleted");
-        return -1;
-    } else if (value == Py_None) {
+    PY_PROPERTY_CHECK_NULL(advanceTo)
+    if (value == Py_None) {
         self->fThis->setAdvanceTo(false);
         return 0;
     } else if (pyPlasma_check<unsigned int>(value)) {
@@ -65,10 +63,8 @@ PY_GETSET_GETTER_DECL(AnimStage, regressTo) {
 }
 
 PY_GETSET_SETTER_DECL(AnimStage, regressTo) {
-    if (value == NULL) {
-        PyErr_SetString(PyExc_RuntimeError, "regressTo cannot be deleted");
-        return -1;
-    } else if (value == Py_None) {
+    PY_PROPERTY_CHECK_NULL(regressTo)
+    if (value == Py_None) {
         self->fThis->setRegressTo(false);
         return 0;
     } else if (pyPlasma_check<unsigned int>(value)) {

--- a/Python/PRP/Avatar/pyMultistageBehMod.cpp
+++ b/Python/PRP/Avatar/pyMultistageBehMod.cpp
@@ -100,30 +100,6 @@ PY_METHOD_NOARGS(MultistageBehMod, clearReceivers,
     Py_RETURN_NONE;
 }
 
-static PyObject* pyMultistageBehMod_getStages(pyMultistageBehMod* self, void*) {
-    PyObject* list = PyList_New(self->fThis->getStages().size());
-    for (size_t i=0; i<self->fThis->getStages().size(); i++)
-        PyList_SET_ITEM(list, i, ICreate(self->fThis->getStages()[i]));
-    return list;
-}
-
-static PyObject* pyMultistageBehMod_getReceivers(pyMultistageBehMod* self, void*) {
-    PyObject* list = PyList_New(self->fThis->getReceivers().size());
-    for (size_t i=0; i<self->fThis->getReceivers().size(); i++)
-        PyList_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getReceivers()[i]));
-    return list;
-}
-
-static int pyMultistageBehMod_setStages(pyMultistageBehMod* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "To add stages, use addStage()");
-    return -1;
-}
-
-static int pyMultistageBehMod_setReceivers(pyMultistageBehMod* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "To add receivers, use addReceiver()");
-    return -1;
-}
-
 static PyMethodDef pyMultistageBehMod_Methods[] = {
     pyMultistageBehMod_addStage_method,
     pyMultistageBehMod_delStage_method,
@@ -134,16 +110,34 @@ static PyMethodDef pyMultistageBehMod_Methods[] = {
     PY_METHOD_TERMINATOR
 };
 
+PY_GETSET_GETTER_DECL(MultistageBehMod, stages) {
+    PyObject* list = PyTuple_New(self->fThis->getStages().size());
+    for (size_t i=0; i<self->fThis->getStages().size(); i++)
+        PyTuple_SET_ITEM(list, i, ICreate(self->fThis->getStages()[i]));
+    return list;
+}
+
+PY_PROPERTY_SETTER_MSG(MultistageBehMod, stages, "To add stages, use addStage()")
+PY_PROPERTY_GETSET_DECL(MultistageBehMod, stages)
+
+PY_GETSET_GETTER_DECL(MultistageBehMod, receivers) {
+    PyObject* list = PyTuple_New(self->fThis->getReceivers().size());
+    for (size_t i=0; i<self->fThis->getReceivers().size(); i++)
+        PyTuple_SET_ITEM(list, i, pyPlasma_convert(self->fThis->getReceivers()[i]));
+    return list;
+}
+
+PY_PROPERTY_SETTER_MSG(MultistageBehMod, receivers, "To add receivers, use addReceiver()")
+PY_PROPERTY_GETSET_DECL(MultistageBehMod, receivers)
+
 PY_PROPERTY(bool, MultistageBehMod, freezePhys, getFreezePhys, setFreezePhys)
 PY_PROPERTY(bool, MultistageBehMod, smartSeek, getSmartSeek, setSmartSeek)
 PY_PROPERTY(bool, MultistageBehMod, reverseFBControlsOnRelease,
             getReverseFBControlsOnRelease, setReverseFBControlsOnRelease)
 
 static PyGetSetDef pyMultistageBehMod_GetSet[] = {
-    { _pycs("stages"), (getter)pyMultistageBehMod_getStages,
-        (setter)pyMultistageBehMod_setStages, NULL, NULL },
-    { _pycs("receivers"), (getter)pyMultistageBehMod_getReceivers,
-        (setter)pyMultistageBehMod_setReceivers, NULL, NULL },
+    pyMultistageBehMod_stages_getset,
+    pyMultistageBehMod_receivers_getset,
     pyMultistageBehMod_freezePhys_getset,
     pyMultistageBehMod_smartSeek_getset,
     pyMultistageBehMod_reverseFBControlsOnRelease_getset,

--- a/Python/PRP/Avatar/pySittingModifier.cpp
+++ b/Python/PRP/Avatar/pySittingModifier.cpp
@@ -62,23 +62,22 @@ static PyMethodDef pySittingModifier_Methods[] = {
     PY_METHOD_TERMINATOR
 };
 
-static PyObject* pySittingModifier_getNotifyKeys(pySittingModifier* self, void*) {
+PY_GETSET_GETTER_DECL(SittingModifier, notifyKeys) {
     PyObject* keys = PyTuple_New(self->fThis->getNotifyKeys().size());
     for (size_t i = 0; i < self->fThis->getNotifyKeys().size(); ++i)
         PyTuple_SET_ITEM(keys, i, pyKey_FromKey(self->fThis->getNotifyKeys()[i]));
     return keys;
 }
 
-static int pySittingModifier_setNotifyKeys(pySittingModifier* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "To add notifyKeys, use addNotifyKey()");
-    return -1;
-}
+PY_PROPERTY_SETTER_MSG(SittingModifier, notifyKeys,
+                       "To add notifyKeys, use addNotifyKey()")
+PY_PROPERTY_GETSET_DECL(SittingModifier, notifyKeys)
 
 PY_PROPERTY(uint8_t, SittingModifier, miscFlags, getMiscFlags, setMiscFlags)
 
 static PyGetSetDef pySittingModifier_GetSet[] = {
     pySittingModifier_miscFlags_getset,
-    { _pycs("notifyKeys"), (getter)pySittingModifier_getNotifyKeys, (setter)pySittingModifier_setNotifyKeys, NULL, NULL },
+    pySittingModifier_notifyKeys_getset,
     PY_GETSET_TERMINATOR
 };
 

--- a/Python/PRP/ConditionalObject/pyANDConditionalObject.cpp
+++ b/Python/PRP/ConditionalObject/pyANDConditionalObject.cpp
@@ -33,7 +33,7 @@ PY_METHOD_VA(ANDConditionalObject, addChild,
         PyErr_SetString(PyExc_TypeError, "addChild expects a plKey");
         return NULL;
     }
-    self->fThis->addChild(*((pyKey*)key)->fThis);
+    self->fThis->addChild(pyPlasma_get<plKey>(key));
     Py_RETURN_NONE;
 }
 
@@ -64,21 +64,18 @@ static PyMethodDef pyANDConditionalObject_Methods[] = {
     PY_METHOD_TERMINATOR
 };
 
-static PyObject* pyANDConditionalObject_getANDs(pyANDConditionalObject* self, void*) {
+PY_GETSET_GETTER_DECL(ANDConditionalObject, children) {
     PyObject* children = PyTuple_New(self->fThis->getChildren().size());
     for (size_t i = 0; i < self->fThis->getChildren().size(); ++i)
-        PyTuple_SET_ITEM(children, i, pyKey_FromKey(self->fThis->getChildren()[i]));
+        PyTuple_SET_ITEM(children, i, pyPlasma_convert(self->fThis->getChildren()[i]));
     return children;
 }
 
-static int pyANDConditionalObject_setANDs(pyANDConditionalObject* self, PyObject*, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "To add children, use addChild()");
-    return -1;
-}
+PY_PROPERTY_SETTER_MSG(ANDConditionalObject, children, "To add children, use addChild()")
+PY_PROPERTY_GETSET_DECL(ANDConditionalObject, children)
 
 static PyGetSetDef pyANDConditionalObject_GetSet[] = {
-    { _pycs("children"), (getter)pyANDConditionalObject_getANDs,
-       (setter)pyANDConditionalObject_setANDs, NULL, NULL },
+    pyANDConditionalObject_children_getset,
     PY_GETSET_TERMINATOR
 };
 

--- a/Python/PRP/ConditionalObject/pyActivatorConditionalObject.cpp
+++ b/Python/PRP/ConditionalObject/pyActivatorConditionalObject.cpp
@@ -65,7 +65,7 @@ static PyMethodDef pyActivatorConditionalObject_Methods[] = {
     PY_METHOD_TERMINATOR
 };
 
-static PyObject* pyActivatorConditionalObject_getActivators(pyActivatorConditionalObject* self, void*) {
+PY_GETSET_GETTER_DECL(ActivatorConditionalObject, activators) {
     plActivatorConditionalObject* act = self->fThis;
     PyObject* activators = PyTuple_New(act->getActivators().size());
     for (size_t i = 0; i < act->getActivators().size(); ++i)
@@ -73,14 +73,12 @@ static PyObject* pyActivatorConditionalObject_getActivators(pyActivatorCondition
     return activators;
 }
 
-static int pyActivatorConditionalObject_setActivators(pyActivatorConditionalObject* self, PyObject*, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "To add activators, use addActivator()");
-    return -1;
-}
+PY_PROPERTY_SETTER_MSG(ActivatorConditionalObject, activators,
+                       "To add activators, use addActivator()")
+PY_PROPERTY_GETSET_DECL(ActivatorConditionalObject, activators)
 
 static PyGetSetDef pyActivatorConditionalObject_GetSet[] = {
-    { _pycs("activators"), (getter)pyActivatorConditionalObject_getActivators,
-       (setter)pyActivatorConditionalObject_setActivators, NULL, NULL },
+    pyActivatorConditionalObject_activators_getset,
     PY_GETSET_TERMINATOR
 };
 

--- a/Python/PRP/ConditionalObject/pyORConditionalObject.cpp
+++ b/Python/PRP/ConditionalObject/pyORConditionalObject.cpp
@@ -33,7 +33,7 @@ PY_METHOD_VA(ORConditionalObject, addChild,
         PyErr_SetString(PyExc_TypeError, "addChild expects a plKey");
         return NULL;
     }
-    self->fThis->addChild(*((pyKey*)key)->fThis);
+    self->fThis->addChild(pyPlasma_get<plKey>(key));
     Py_RETURN_NONE;
 }
 
@@ -64,21 +64,18 @@ static PyMethodDef pyORConditionalObject_Methods[] = {
     PY_METHOD_TERMINATOR
 };
 
-static PyObject* pyORConditionalObject_getORs(pyORConditionalObject* self, void*) {
+PY_GETSET_GETTER_DECL(ORConditionalObject, children) {
     PyObject* children = PyTuple_New(self->fThis->getChildren().size());
     for (size_t i = 0; i < self->fThis->getChildren().size(); ++i)
-        PyTuple_SET_ITEM(children, i, pyKey_FromKey(self->fThis->getChildren()[i]));
+        PyTuple_SET_ITEM(children, i, pyPlasma_convert(self->fThis->getChildren()[i]));
     return children;
 }
 
-static int pyORConditionalObject_setORs(pyORConditionalObject* self, PyObject*, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "To add children, use addChild()");
-    return -1;
-}
+PY_PROPERTY_SETTER_MSG(ORConditionalObject, children, "To add children, use addChild()")
+PY_PROPERTY_GETSET_DECL(ORConditionalObject, children)
 
 static PyGetSetDef pyORConditionalObject_GetSet[] = {
-    { _pycs("children"), (getter)pyORConditionalObject_getORs,
-       (setter)pyORConditionalObject_setORs, NULL, NULL },
+    pyORConditionalObject_children_getset,
     PY_GETSET_TERMINATOR
 };
 

--- a/Python/PRP/Geometry/pyCluster.cpp
+++ b/Python/PRP/Geometry/pyCluster.cpp
@@ -102,18 +102,6 @@ PY_METHOD_VA(Cluster, delInstance,
     Py_RETURN_NONE;
 }
 
-static PyObject* pyCluster_getInstances(pyCluster* self, void*) {
-    PyObject* list = PyList_New(self->fThis->getInstances().size());
-    for (size_t i=0; i<self->fThis->getInstances().size(); i++)
-        PyList_SET_ITEM(list, i, pySpanInstance_FromSpanInstance(self->fThis->getInstances()[i]));
-    return list;
-}
-
-static int pyCluster_setInstances(pyCluster* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "To add instances, use addInstance");
-    return -1;
-}
-
 static PyMethodDef pyCluster_Methods[] = {
     pyCluster_read_method,
     pyCluster_write_method,
@@ -123,14 +111,23 @@ static PyMethodDef pyCluster_Methods[] = {
     PY_METHOD_TERMINATOR
 };
 
+PY_GETSET_GETTER_DECL(Cluster, instances) {
+    PyObject* list = PyTuple_New(self->fThis->getInstances().size());
+    for (size_t i=0; i<self->fThis->getInstances().size(); i++)
+        PyTuple_SET_ITEM(list, i, pySpanInstance_FromSpanInstance(self->fThis->getInstances()[i]));
+    return list;
+}
+
+PY_PROPERTY_SETTER_MSG(Cluster, instances, "To add instances, use addInstance")
+PY_PROPERTY_GETSET_DECL(Cluster, instances)
+
 PY_PROPERTY_PROXY_RO(plSpanEncoding, Cluster, encoding, getEncoding)
 PY_PROPERTY_CREATABLE(plClusterGroup, ClusterGroup, Cluster, group, getGroup, setGroup)
 
 static PyGetSetDef pyCluster_GetSet[] = {
     pyCluster_encoding_getset,
     pyCluster_group_getset,
-    { _pycs("instances"), (getter)pyCluster_getInstances,
-        (setter)pyCluster_setInstances, NULL, NULL },
+    pyCluster_instances_getset,
     PY_GETSET_TERMINATOR
 };
 

--- a/Python/PRP/Geometry/pyClusterGroup.cpp
+++ b/Python/PRP/Geometry/pyClusterGroup.cpp
@@ -133,42 +133,6 @@ PY_METHOD_NOARGS(ClusterGroup, clearLights, "Remove all lights from the group") 
     Py_RETURN_NONE;
 }
 
-static PyObject* pyClusterGroup_getClusters(pyClusterGroup* self, void*) {
-    PyObject* list = PyList_New(self->fThis->getClusters().size());
-    for (size_t i=0; i<self->fThis->getClusters().size(); i++)
-        PyList_SET_ITEM(list, i, pyCluster_FromCluster(self->fThis->getClusters()[i]));
-    return list;
-}
-
-static PyObject* pyClusterGroup_getRegions(pyClusterGroup* self, void*) {
-    PyObject* list = PyList_New(self->fThis->getRegions().size());
-    for (size_t i=0; i<self->fThis->getRegions().size(); i++)
-        PyList_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getRegions()[i]));
-    return list;
-}
-
-static PyObject* pyClusterGroup_getLights(pyClusterGroup* self, void*) {
-    PyObject* list = PyList_New(self->fThis->getLights().size());
-    for (size_t i=0; i<self->fThis->getLights().size(); i++)
-        PyList_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getLights()[i]));
-    return list;
-}
-
-static int pyClusterGroup_setClusters(pyClusterGroup* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "To add clusters, use addCluster");
-    return -1;
-}
-
-static int pyClusterGroup_setRegions(pyClusterGroup* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "To add regions, use addRegion");
-    return -1;
-}
-
-static int pyClusterGroup_setLights(pyClusterGroup* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "To add lights, use addLight");
-    return -1;
-}
-
 static PyMethodDef pyClusterGroup_Methods[] = {
     pyClusterGroup_addCluster_method,
     pyClusterGroup_delCluster_method,
@@ -181,6 +145,36 @@ static PyMethodDef pyClusterGroup_Methods[] = {
     pyClusterGroup_clearLights_method,
     PY_METHOD_TERMINATOR
 };
+
+PY_GETSET_GETTER_DECL(ClusterGroup, clusters) {
+    PyObject* list = PyTuple_New(self->fThis->getClusters().size());
+    for (size_t i=0; i<self->fThis->getClusters().size(); i++)
+        PyTuple_SET_ITEM(list, i, pyCluster_FromCluster(self->fThis->getClusters()[i]));
+    return list;
+}
+
+PY_PROPERTY_SETTER_MSG(ClusterGroup, clusters, "To add clusters, use addCluster")
+PY_PROPERTY_GETSET_DECL(ClusterGroup, clusters)
+
+PY_GETSET_GETTER_DECL(ClusterGroup, regions) {
+    PyObject* list = PyTuple_New(self->fThis->getRegions().size());
+    for (size_t i=0; i<self->fThis->getRegions().size(); i++)
+        PyTuple_SET_ITEM(list, i, pyPlasma_convert(self->fThis->getRegions()[i]));
+    return list;
+}
+
+PY_PROPERTY_SETTER_MSG(ClusterGroup, regions, "To add regions, use addRegion")
+PY_PROPERTY_GETSET_DECL(ClusterGroup, regions)
+
+PY_GETSET_GETTER_DECL(ClusterGroup, lights) {
+    PyObject* list = PyTuple_New(self->fThis->getLights().size());
+    for (size_t i=0; i<self->fThis->getLights().size(); i++)
+        PyTuple_SET_ITEM(list, i, pyPlasma_convert(self->fThis->getLights()[i]));
+    return list;
+}
+
+PY_PROPERTY_SETTER_MSG(ClusterGroup, lights, "To add lights, use addLight")
+PY_PROPERTY_GETSET_DECL(ClusterGroup, lights)
 
 PY_PROPERTY_PROXY_RO(plLODDist, ClusterGroup, LOD, getLOD)
 PY_PROPERTY_PROXY_RO(plSpanTemplate, ClusterGroup, template, getTemplate)
@@ -196,12 +190,9 @@ static PyGetSetDef pyClusterGroup_GetSet[] = {
     pyClusterGroup_sceneNode_getset,
     pyClusterGroup_drawable_getset,
     pyClusterGroup_renderLevel_getset,
-    { _pycs("clusters"), (getter)pyClusterGroup_getClusters,
-        (setter)pyClusterGroup_setClusters, NULL, NULL },
-    { _pycs("regions"), (getter)pyClusterGroup_getRegions,
-        (setter)pyClusterGroup_setRegions, NULL, NULL },
-    { _pycs("lights"), (getter)pyClusterGroup_getLights,
-        (setter)pyClusterGroup_setLights, NULL, NULL },
+    pyClusterGroup_clusters_getset,
+    pyClusterGroup_regions_getset,
+    pyClusterGroup_lights_getset,
     PY_GETSET_TERMINATOR
 };
 

--- a/Python/PRP/Geometry/pyGBufferGroup.cpp
+++ b/Python/PRP/Geometry/pyGBufferGroup.cpp
@@ -82,9 +82,9 @@ PY_METHOD_VA(GBufferGroup, getVertices,
         verts = self->fThis->getVertices(idx);
     else
         verts = self->fThis->getVertices(start, len);
-    PyObject* list = PyList_New(verts.size());
+    PyObject* list = PyTuple_New(verts.size());
     for (size_t i=0; i<verts.size(); i++)
-        PyList_SET_ITEM(list, i, pyGBufferVertex_FromGBufferVertex(verts[i]));
+        PyTuple_SET_ITEM(list, i, pyGBufferVertex_FromGBufferVertex(verts[i]));
     return list;
 }
 
@@ -103,9 +103,9 @@ PY_METHOD_VA(GBufferGroup, getIndices,
         indices = self->fThis->getIndices(idx);
     else
         indices = self->fThis->getIndices(idx, start, len);
-    PyObject* list = PyList_New(indices.size());
+    PyObject* list = PyTuple_New(indices.size());
     for (size_t i=0; i<indices.size(); i++)
-        PyList_SET_ITEM(list, i, pyPlasma_convert(indices[i]));
+        PyTuple_SET_ITEM(list, i, pyPlasma_convert(indices[i]));
     return list;
 }
 
@@ -120,9 +120,9 @@ PY_METHOD_VA(GBufferGroup, getCells,
     }
 
     std::vector<plGBufferCell> cells = self->fThis->getCells(idx);
-    PyObject* list = PyList_New(cells.size());
+    PyObject* list = PyTuple_New(cells.size());
     for (size_t i=0; i<cells.size(); i++)
-        PyList_SET_ITEM(list, i, pyGBufferCell_FromGBufferCell(cells[i]));
+        PyTuple_SET_ITEM(list, i, pyGBufferCell_FromGBufferCell(cells[i]));
     return list;
 }
 
@@ -130,23 +130,25 @@ PY_METHOD_VA(GBufferGroup, addVertices,
     "Params: list\n"
     "Add a Vertex Buffer with the contents of the supplied vertex list")
 {
-    PyObject* list;
-    if (!PyArg_ParseTuple(args, "O", &list)) {
-        PyErr_SetString(PyExc_TypeError, "addVertices expects a list of plGBufferVertex objects");
+    PyObject* seqObj;
+    if (!PyArg_ParseTuple(args, "O", &seqObj)) {
+        PyErr_SetString(PyExc_TypeError, "addVertices expects a sequence of plGBufferVertex objects");
         return NULL;
     }
-    if (!PyList_Check(list)) {
-        PyErr_SetString(PyExc_TypeError, "addVertices expects a list of plGBufferVertex objects");
+    pySequenceFastRef list(seqObj);
+    if (!list.isSequence()) {
+        PyErr_SetString(PyExc_TypeError, "addVertices expects a sequence of plGBufferVertex objects");
         return NULL;
     }
 
-    std::vector<plGBufferVertex> verts(PyList_Size(list));
+    std::vector<plGBufferVertex> verts(list.size());
     for (size_t i=0; i<verts.size(); i++) {
-        if (!pyGBufferVertex_Check(PyList_GetItem(list, i))) {
-            PyErr_SetString(PyExc_TypeError, "addVertices expects a list of plGBufferVertex objects");
+        PyObject* item = list.get(i);
+        if (!pyGBufferVertex_Check(item)) {
+            PyErr_SetString(PyExc_TypeError, "addVertices expects a sequence of plGBufferVertex objects");
             return NULL;
         }
-        verts[i] = *((pyGBufferVertex*)PyList_GetItem(list, i))->fThis;
+        verts[i] = *((pyGBufferVertex*)item)->fThis;
     }
     self->fThis->addVertices(verts);
     Py_RETURN_NONE;
@@ -156,23 +158,25 @@ PY_METHOD_VA(GBufferGroup, addIndices,
     "Params: list\n"
     "Add a Face Index Buffer with the contents of the supplied index list")
 {
-    PyObject* list;
-    if (!PyArg_ParseTuple(args, "O", &list)) {
-        PyErr_SetString(PyExc_TypeError, "addIndices expects a list of ints");
+    PyObject* seqObj;
+    if (!PyArg_ParseTuple(args, "O", &seqObj)) {
+        PyErr_SetString(PyExc_TypeError, "addIndices expects a sequence of ints");
         return NULL;
     }
-    if (!PyList_Check(list)) {
-        PyErr_SetString(PyExc_TypeError, "addIndices expects a list of ints");
+    pySequenceFastRef list(seqObj);
+    if (!list.isSequence()) {
+        PyErr_SetString(PyExc_TypeError, "addIndices expects a sequence of ints");
         return NULL;
     }
 
-    std::vector<unsigned short> indices(PyList_Size(list));
+    std::vector<unsigned short> indices(list.size());
     for (size_t i=0; i<indices.size(); i++) {
-        if (!PyInt_Check(PyList_GetItem(list, i))) {
-            PyErr_SetString(PyExc_TypeError, "addVertices expects a list of ints");
+        PyObject* item = list.get(i);
+        if (!pyPlasma_check<unsigned short>(item)) {
+            PyErr_SetString(PyExc_TypeError, "addVertices expects a sequence of ints");
             return NULL;
         }
-        indices[i] = PyInt_AsLong(PyList_GetItem(list, i));
+        indices[i] = pyPlasma_get<unsigned short>(item);
     }
     self->fThis->addIndices(indices);
     Py_RETURN_NONE;
@@ -182,23 +186,25 @@ PY_METHOD_VA(GBufferGroup, addCells,
     "Params: list\n"
     "Add a Cell Buffer with the contents of the specified cell list" )
 {
-    PyObject* list;
-    if (!PyArg_ParseTuple(args, "O", &list)) {
-        PyErr_SetString(PyExc_TypeError, "addCells expects a list of plGBufferCell objects");
+    PyObject* seqObj;
+    if (!PyArg_ParseTuple(args, "O", &seqObj)) {
+        PyErr_SetString(PyExc_TypeError, "addCells expects a sequence of plGBufferCell objects");
         return NULL;
     }
-    if (!PyList_Check(list)) {
-        PyErr_SetString(PyExc_TypeError, "addCells expects a list of plGBufferCell objects");
+    pySequenceFastRef list(seqObj);
+    if (!list.isSequence()) {
+        PyErr_SetString(PyExc_TypeError, "addCells expects a sequence of plGBufferCell objects");
         return NULL;
     }
 
-    std::vector<plGBufferCell> cells(PyList_Size(list));
+    std::vector<plGBufferCell> cells(list.size());
     for (size_t i=0; i<cells.size(); i++) {
-        if (!pyGBufferCell_Check(PyList_GetItem(list, i))) {
-            PyErr_SetString(PyExc_TypeError, "addCells expects a list of plGBufferCell objects");
+        PyObject* item = list.get(i);
+        if (!pyGBufferCell_Check(item)) {
+            PyErr_SetString(PyExc_TypeError, "addCells expects a sequence of plGBufferCell objects");
             return NULL;
         }
-        cells[i] = *((pyGBufferCell*)PyList_GetItem(list, i))->fThis;
+        cells[i] = *((pyGBufferCell*)item)->fThis;
     }
     self->fThis->addCells(cells);
     Py_RETURN_NONE;
@@ -294,9 +300,9 @@ PY_METHOD_VA(GBufferGroup, getIdxBufferStorage,
     }
     size_t count = self->fThis->getIdxBufferCount(idx);
     const unsigned short* indices = self->fThis->getIdxBufferStorage(idx);
-    PyObject* idxList = PyList_New(count);
+    PyObject* idxList = PyTuple_New(count);
     for (size_t i=0; i<count; i++)
-        PyList_SET_ITEM(idxList, i, pyPlasma_convert(indices[i]));
+        PyTuple_SET_ITEM(idxList, i, pyPlasma_convert(indices[i]));
     return idxList;
 }
 

--- a/Python/PRP/Geometry/pyGBufferVertex.cpp
+++ b/Python/PRP/Geometry/pyGBufferVertex.cpp
@@ -25,64 +25,74 @@ PY_PLASMA_VALUE_DEALLOC(GBufferVertex)
 PY_PLASMA_EMPTY_INIT(GBufferVertex)
 PY_PLASMA_VALUE_NEW(GBufferVertex, plGBufferVertex)
 
-static PyObject* pyGBufferVertex_getWeights(pyGBufferVertex* self, void*) {
-    PyObject* list = PyList_New(3);
-    PyList_SET_ITEM(list, 0, pyPlasma_convert(self->fThis->fSkinWeights[0]));
-    PyList_SET_ITEM(list, 1, pyPlasma_convert(self->fThis->fSkinWeights[1]));
-    PyList_SET_ITEM(list, 2, pyPlasma_convert(self->fThis->fSkinWeights[2]));
+PY_GETSET_GETTER_DECL(GBufferVertex, skinWeights) {
+    PyObject* list = PyTuple_New(3);
+    PyTuple_SET_ITEM(list, 0, pyPlasma_convert(self->fThis->fSkinWeights[0]));
+    PyTuple_SET_ITEM(list, 1, pyPlasma_convert(self->fThis->fSkinWeights[1]));
+    PyTuple_SET_ITEM(list, 2, pyPlasma_convert(self->fThis->fSkinWeights[2]));
     return list;
 }
 
-static PyObject* pyGBufferVertex_getUVWs(pyGBufferVertex* self, void*) {
-    PyObject* list = PyList_New(10);
-    for (size_t i=0; i<10; i++)
-        PyList_SET_ITEM(list, i, pyVector3_FromVector3(self->fThis->fUVWs[i]));
-    return list;
-}
-
-static int pyGBufferVertex_setWeights(pyGBufferVertex* self, PyObject* value, void*) {
-    if (value != NULL && !PyList_Check(value)) {
-        PyErr_SetString(PyExc_TypeError, "weights should be a list of up to 3 floats");
+PY_GETSET_SETTER_DECL(GBufferVertex, skinWeights) {
+    PY_PROPERTY_CHECK_NULL(weights)
+    pySequenceFastRef seq(value);
+    if (!seq.isSequence()) {
+        PyErr_SetString(PyExc_TypeError, "skinWeights should be a sequence of up to 3 floats");
         return -1;
     }
-    int size = (value == NULL) ? 0 : PyList_Size(value);
+    Py_ssize_t size = seq.size();
     if (size > 3) {
-        PyErr_SetString(PyExc_RuntimeError, "weights should be a list of up to 3 floats");
+        PyErr_SetString(PyExc_RuntimeError, "skinWeights should be a sequence of up to 3 floats");
         return -1;
     }
-    for (int i=0; i<size; i++) {
-        if (!PyFloat_Check(PyList_GetItem(value, i))) {
-            PyErr_SetString(PyExc_TypeError, "weights should be a list of up to 3 floats");
+    for (Py_ssize_t i=0; i<size; i++) {
+        PyObject* item = seq.get(i);
+        if (!pyPlasma_check<float>(item)) {
+            PyErr_SetString(PyExc_TypeError, "skinWeights should be a sequence of up to 3 floats");
             return -1;
         }
-        self->fThis->fSkinWeights[i] = PyFloat_AsDouble(PyList_GetItem(value, i));
+        self->fThis->fSkinWeights[i] = pyPlasma_get<float>(item);
     }
-    for (int i=size; i<3; i++)
+    for (Py_ssize_t i=size; i<3; i++)
         self->fThis->fSkinWeights[i] = 0.0f;
     return 0;
 }
 
-static int pyGBufferVertex_setUVWs(pyGBufferVertex* self, PyObject* value, void*) {
-    if (value != NULL && !PyList_Check(value)) {
-        PyErr_SetString(PyExc_TypeError, "UVWs should be a list of up to 10 hsVector3s");
+PY_PROPERTY_GETSET_DECL(GBufferVertex, skinWeights)
+
+PY_GETSET_GETTER_DECL(GBufferVertex, UVWs) {
+    PyObject* list = PyTuple_New(10);
+    for (size_t i=0; i<10; i++)
+        PyTuple_SET_ITEM(list, i, pyVector3_FromVector3(self->fThis->fUVWs[i]));
+    return list;
+}
+
+PY_GETSET_SETTER_DECL(GBufferVertex, UVWs) {
+    PY_PROPERTY_CHECK_NULL(UVWs)
+    pySequenceFastRef seq(value);
+    if (!seq.isSequence()) {
+        PyErr_SetString(PyExc_TypeError, "UVWs should be a sequence of up to 10 hsVector3s");
         return -1;
     }
-    int size = (value == NULL) ? 0 : PyList_Size(value);
+    Py_ssize_t size = seq.size();
     if (size > 10) {
-        PyErr_SetString(PyExc_RuntimeError, "UVWs should be a list of up to 10 hsVector3s");
+        PyErr_SetString(PyExc_RuntimeError, "UVWs should be a sequence of up to 10 hsVector3s");
         return -1;
     }
-    for (int i=0; i<size; i++) {
-        if (!pyVector3_Check(PyList_GetItem(value, i))) {
-            PyErr_SetString(PyExc_TypeError, "UVWs should be a list of up to 10 hsVector3s");
+    for (Py_ssize_t i=0; i<size; i++) {
+        PyObject* item = seq.get(i);
+        if (!pyPlasma_check<hsVector3>(item)) {
+            PyErr_SetString(PyExc_TypeError, "UVWs should be a sequence of up to 10 hsVector3s");
             return -1;
         }
-        self->fThis->fUVWs[i] = *((pyVector3*)PyList_GetItem(value, i))->fThis;
+        self->fThis->fUVWs[i] = pyPlasma_get<hsVector3>(item);
     }
-    for (int i=size; i<10; i++)
+    for (Py_ssize_t i=size; i<10; i++)
         self->fThis->fUVWs[i] = hsVector3(0.0f, 0.0f, 0.0f);
     return 0;
 }
+
+PY_PROPERTY_GETSET_DECL(GBufferVertex, UVWs)
 
 PY_PROPERTY_MEMBER(hsVector3, GBufferVertex, pos, fPos)
 PY_PROPERTY_MEMBER(hsVector3, GBufferVertex, normal, fNormal)
@@ -94,10 +104,8 @@ static PyGetSetDef pyGBufferVertex_GetSet[] = {
     pyGBufferVertex_normal_getset,
     pyGBufferVertex_skinIdx_getset,
     pyGBufferVertex_color_getset,
-    { _pycs("skinWeights"), (getter)pyGBufferVertex_getWeights,
-        (setter)pyGBufferVertex_setWeights, NULL, NULL },
-    { _pycs("UVWs"), (getter)pyGBufferVertex_getUVWs,
-        (setter)pyGBufferVertex_setUVWs, NULL, NULL },
+    pyGBufferVertex_skinWeights_getset,
+    pyGBufferVertex_UVWs_getset,
     PY_GETSET_TERMINATOR
 };
 

--- a/Python/PRP/Geometry/pyOccluder.cpp
+++ b/Python/PRP/Geometry/pyOccluder.cpp
@@ -98,29 +98,25 @@ PY_METHOD_VA(Occluder, delVisRegion,
     Py_RETURN_NONE;
 }
 
-static PyObject* pyOccluder_getPolys(pyOccluder* self, void*) {
-    PyObject* list = PyList_New(self->fThis->getPolys().size());
+PY_GETSET_GETTER_DECL(Occluder, polys) {
+    PyObject* list = PyTuple_New(self->fThis->getPolys().size());
     for (size_t i=0; i<self->fThis->getPolys().size(); i++)
-        PyList_SET_ITEM(list, i, pyCullPoly_FromCullPoly(self->fThis->getPolys()[i]));
+        PyTuple_SET_ITEM(list, i, pyCullPoly_FromCullPoly(self->fThis->getPolys()[i]));
     return list;
 }
 
-static PyObject* pyOccluder_getVisRegions(pyOccluder* self, void*) {
-    PyObject* list = PyList_New(self->fThis->getVisRegions().size());
+PY_PROPERTY_SETTER_MSG(Occluder, polys, "To add polys, use addPoly()")
+PY_PROPERTY_GETSET_DECL(Occluder, polys)
+
+PY_GETSET_GETTER_DECL(Occluder, visRegions) {
+    PyObject* list = PyTuple_New(self->fThis->getVisRegions().size());
     for (size_t i=0; i<self->fThis->getVisRegions().size(); i++)
-        PyList_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getVisRegions()[i]));
+        PyTuple_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getVisRegions()[i]));
     return list;
 }
 
-static int pyOccluder_setPolys(pyOccluder* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "to add polys, use addPoly()");
-    return -1;
-}
-
-static int pyOccluder_setVisRegions(pyOccluder* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "to add visRegions, use addVisRegion()");
-    return -1;
-}
+PY_PROPERTY_SETTER_MSG(Occluder, visRegions, "To add visRegions, use addVisRegion()")
+PY_PROPERTY_GETSET_DECL(Occluder, visRegions)
 
 static PyMethodDef pyOccluder_Methods[] = {
     pyOccluder_clearPolys_method,
@@ -140,10 +136,8 @@ static PyGetSetDef pyOccluder_GetSet[] = {
     pyOccluder_priority_getset,
     pyOccluder_worldBounds_getset,
     pyOccluder_sceneNode_getset,
-    { _pycs("polys"), (getter)pyOccluder_getPolys,
-        (setter)pyOccluder_setPolys, NULL, NULL },
-    { _pycs("visRegions"), (getter)pyOccluder_getVisRegions,
-        (setter)pyOccluder_setVisRegions, NULL, NULL },
+    pyOccluder_polys_getset,
+    pyOccluder_visRegions_getset,
     PY_GETSET_TERMINATOR
 };
 

--- a/Python/PRP/Geometry/pySpan.cpp
+++ b/Python/PRP/Geometry/pySpan.cpp
@@ -110,25 +110,6 @@ PY_METHOD_VA(Span, addPermaProj,
     Py_RETURN_NONE;
 }
 
-static PyObject* pySpan_getLights(pySpan* self, void*) {
-    PyObject* list = PyList_New(self->fThis->getPermaLights().size());
-    for (size_t i=0; i<self->fThis->getPermaLights().size(); i++)
-        PyList_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getPermaLights()[i]));
-    return list;
-}
-
-static PyObject* pySpan_getProjs(pySpan* self, void*) {
-    PyObject* list = PyList_New(self->fThis->getPermaProjs().size());
-    for (size_t i=0; i<self->fThis->getPermaProjs().size(); i++)
-        PyList_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getPermaProjs()[i]));
-    return list;
-}
-
-static int pySpan_setLights(pySpan* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "To add Lights, use addPermaLight and addPermaProj");
-    return -1;
-}
-
 static PyMethodDef pySpan_Methods[] = {
     pySpan_ClassName_method,
     pySpan_read_method,
@@ -139,6 +120,26 @@ static PyMethodDef pySpan_Methods[] = {
     pySpan_addPermaProj_method,
     PY_METHOD_TERMINATOR
 };
+
+PY_GETSET_GETTER_DECL(Span, permaLights) {
+    PyObject* list = PyTuple_New(self->fThis->getPermaLights().size());
+    for (size_t i=0; i<self->fThis->getPermaLights().size(); i++)
+        PyTuple_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getPermaLights()[i]));
+    return list;
+}
+
+PY_PROPERTY_SETTER_MSG(Span, permaLights, "To add permaLights, use addPermaLight()")
+PY_PROPERTY_GETSET_DECL(Span, permaLights)
+
+PY_GETSET_GETTER_DECL(Span, permaProjs) {
+    PyObject* list = PyTuple_New(self->fThis->getPermaProjs().size());
+    for (size_t i=0; i<self->fThis->getPermaProjs().size(); i++)
+        PyTuple_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getPermaProjs()[i]));
+    return list;
+}
+
+PY_PROPERTY_SETTER_MSG(Span, permaProjs, "To add permaProjs, use addPermaProj()")
+PY_PROPERTY_GETSET_DECL(Span, permaProjs)
 
 PY_PROPERTY(plKey, Span, fog, getFogEnvironment, setFogEnvironment) // Backwards compatibility
 PY_PROPERTY(plKey, Span, fogEnvironment, getFogEnvironment, setFogEnvironment)
@@ -161,10 +162,8 @@ PY_PROPERTY_BOUNDS(Bounds3Ext, Span, worldBounds, getWorldBounds, setWorldBounds
 static PyGetSetDef pySpan_GetSet[] = {
     pySpan_fogEnvironment_getset,
     pySpan_fog_getset,
-    { _pycs("permaLights"), (getter)pySpan_getLights,
-        (setter)pySpan_setLights, NULL, NULL },
-    { _pycs("permaProjs"), (getter)pySpan_getProjs,
-        (setter)pySpan_setLights, NULL, NULL },
+    pySpan_permaLights_getset,
+    pySpan_permaProjs_getset,
     pySpan_localToWorld_getset,
     pySpan_worldToLocal_getset,
     pySpan_subType_getset,

--- a/Python/PRP/Geometry/pySpanTemplate.cpp
+++ b/Python/PRP/Geometry/pySpanTemplate.cpp
@@ -57,38 +57,32 @@ PY_METHOD_VA(SpanTemplate, write,
     Py_RETURN_NONE;
 }
 
-static PyObject* pySpanTemplate_getVerts(pySpanTemplate* self, void*) {
+static PyMethodDef pySpanTemplate_Methods[] = {
+    pySpanTemplate_read_method,
+    pySpanTemplate_write_method,
+    PY_METHOD_TERMINATOR
+};
+
+PY_GETSET_GETTER_DECL(SpanTemplate, vertices) {
     std::vector<plSpanTemplate::Vertex> verts = self->fThis->getVertices();
-    PyObject* list = PyList_New(verts.size());
+    PyObject* list = PyTuple_New(verts.size());
     for (size_t i=0; i<verts.size(); i++)
-        PyList_SET_ITEM(list, i, pySpanTemplateVertex_FromSpanTemplateVertex(&verts[i]));
+        PyTuple_SET_ITEM(list, i, pySpanTemplateVertex_FromSpanTemplateVertex(&verts[i]));
     return list;
 }
 
-static PyObject* pySpanTemplate_getIndices(pySpanTemplate* self, void*) {
-    const unsigned short* indices = self->fThis->getIndices();
-    size_t numIndices = self->fThis->getNumTris() * 3;
-    PyObject* list = PyList_New(numIndices);
-    for (size_t i=0; i<numIndices; i++)
-        PyList_SET_ITEM(list, i, pyPlasma_convert(indices[i]));
-    return list;
-}
-
-static int pySpanTemplate_setVerts(pySpanTemplate* self, PyObject* value, void*) {
-    std::vector<plSpanTemplate::Vertex> verts;
-    if (value == NULL) {
-        self->fThis->setVertices(verts);
-        return 0;
-    }
-    if (!PyList_Check(value)) {
-        PyErr_SetString(PyExc_TypeError, "vertices should be a list of plSpanTemplateVertex objects");
+PY_GETSET_SETTER_DECL(SpanTemplate, vertices) {
+    PY_PROPERTY_CHECK_NULL(vertices)
+    pySequenceFastRef seq(value);
+    if (!seq.isSequence()) {
+        PyErr_SetString(PyExc_TypeError, "vertices should be a sequence of plSpanTemplateVertex objects");
         return -1;
     }
-    verts.resize(PyList_Size(value));
+    std::vector<plSpanTemplate::Vertex> verts(seq.size());
     for (size_t i=0; i<verts.size(); i++) {
-        PyObject* itm = PyList_GetItem(value, i);
+        PyObject* itm = seq.get(i);
         if (!pySpanTemplateVertex_Check(itm)) {
-            PyErr_SetString(PyExc_TypeError, "vertices should be a list of plSpanTemplateVertex objects");
+            PyErr_SetString(PyExc_TypeError, "vertices should be a sequence of plSpanTemplateVertex objects");
             return -1;
         }
         verts[i] = *((pySpanTemplateVertex*)itm)->fThis;
@@ -97,43 +91,45 @@ static int pySpanTemplate_setVerts(pySpanTemplate* self, PyObject* value, void*)
     return 0;
 }
 
-static int pySpanTemplate_setIndices(pySpanTemplate* self, PyObject* value, void*) {
-    std::vector<unsigned short> indices;
-    if (value == NULL) {
-        self->fThis->setIndices(0, NULL);
-        return 0;
-    }
-    if (!PyList_Check(value)) {
-        PyErr_SetString(PyExc_TypeError, "indices should be a list of ints");
+PY_PROPERTY_GETSET_DECL(SpanTemplate, vertices)
+
+PY_GETSET_GETTER_DECL(SpanTemplate, indices) {
+    const unsigned short* indices = self->fThis->getIndices();
+    size_t numIndices = self->fThis->getNumTris() * 3;
+    PyObject* list = PyTuple_New(numIndices);
+    for (size_t i=0; i<numIndices; i++)
+        PyTuple_SET_ITEM(list, i, pyPlasma_convert(indices[i]));
+    return list;
+}
+
+PY_GETSET_SETTER_DECL(SpanTemplate, indices) {
+    PY_PROPERTY_CHECK_NULL(indices)
+    pySequenceFastRef seq(value);
+    if (!seq.isSequence()) {
+        PyErr_SetString(PyExc_TypeError, "indices should be a sequence of ints");
         return -1;
     }
-    size_t numIndices = PyList_Size(value);
-    indices.resize(numIndices);
-    for (size_t i=0; i<numIndices; i++) {
-        PyObject* itm = PyList_GetItem(value, i);
-        if (!PyInt_Check(itm)) {
-            PyErr_SetString(PyExc_TypeError, "indices should be a list of ints");
+    Py_ssize_t numIndices = seq.size();
+    std::vector<unsigned short> indices(numIndices);
+    for (Py_ssize_t i=0; i<numIndices; i++) {
+        PyObject* itm = seq.get(i);
+        if (!pyPlasma_check<unsigned short>(itm)) {
+            PyErr_SetString(PyExc_TypeError, "indices should be a sequence of ints");
             return -1;
         }
-        indices[i] = PyInt_AsLong(itm);
+        indices[i] = pyPlasma_get<unsigned short>(itm);
     }
     self->fThis->setIndices(numIndices, indices.data());
     return 0;
 }
 
-static PyMethodDef pySpanTemplate_Methods[] = {
-    pySpanTemplate_read_method,
-    pySpanTemplate_write_method,
-    PY_METHOD_TERMINATOR
-};
+PY_PROPERTY_GETSET_DECL(SpanTemplate, indices)
 
 PY_PROPERTY(unsigned short, SpanTemplate, format, getFormat, setFormat)
 
 static PyGetSetDef pySpanTemplate_GetSet[] = {
-    { _pycs("vertices"), (getter)pySpanTemplate_getVerts,
-        (setter)pySpanTemplate_setVerts, NULL, NULL },
-    { _pycs("indices"), (getter)pySpanTemplate_getIndices,
-        (setter)pySpanTemplate_setIndices, NULL, NULL },
+    pySpanTemplate_vertices_getset,
+    pySpanTemplate_indices_getset,
     pySpanTemplate_format_getset,
     PY_GETSET_TERMINATOR
 };

--- a/Python/PRP/Geometry/pySpanTemplateVertex.cpp
+++ b/Python/PRP/Geometry/pySpanTemplateVertex.cpp
@@ -25,71 +25,73 @@ PY_PLASMA_DEALLOC(SpanTemplateVertex)
 PY_PLASMA_EMPTY_INIT(SpanTemplateVertex)
 PY_PLASMA_NEW(SpanTemplateVertex, plSpanTemplate::Vertex)
 
-static PyObject* pySpanTemplateVertex_getUVWs(pySpanTemplateVertex* self, void*) {
-    PyObject* list = PyList_New(10);
+PY_GETSET_GETTER_DECL(SpanTemplateVertex, UVWs) {
+    PyObject* list = PyTuple_New(10);
     for (size_t i=0; i<10; i++)
-        PyList_SET_ITEM(list, i, pyPlasma_convert(self->fThis->fUVWs[i]));
+        PyTuple_SET_ITEM(list, i, pyPlasma_convert(self->fThis->fUVWs[i]));
     return list;
 }
 
-static PyObject* pySpanTemplateVertex_getWeights(pySpanTemplateVertex* self, void*) {
-    PyObject* list = PyList_New(3);
-    for (size_t i=0; i<3; i++)
-        PyList_SET_ITEM(list, i, pyPlasma_convert(self->fThis->fWeights[i]));
-    return list;
-}
-
-static int pySpanTemplateVertex_setUVWs(pySpanTemplateVertex* self, PyObject* value, void*) {
-    std::vector<hsVector3> uvws;
-    if (value == NULL || !PyList_Check(value)) {
-        PyErr_SetString(PyExc_TypeError, "UVWs should be a list of up to 10 hsVector3 objects");
+PY_GETSET_SETTER_DECL(SpanTemplateVertex, UVWs) {
+    PY_PROPERTY_CHECK_NULL(UVWs)
+    pySequenceFastRef seq(value);
+    if (!seq.isSequence()) {
+        PyErr_SetString(PyExc_TypeError, "UVWs should be a sequence of up to 10 hsVector3 objects");
         return -1;
     }
-    uvws.resize(PyList_Size(value));
-    if (uvws.size() > 10) {
-        PyErr_SetString(PyExc_RuntimeError, "UVWs should be a list of up to 10 hsVector3 objects");
+    Py_ssize_t size = seq.size();
+    if (size > 10) {
+        PyErr_SetString(PyExc_RuntimeError, "UVWs should be a sequence of up to 10 hsVector3 objects");
         return -1;
     }
-    for (size_t i=0; i<uvws.size(); i++) {
-        PyObject* itm = PyList_GetItem(value, i);
-        if (!pyVector3_Check(itm)) {
-            PyErr_SetString(PyExc_TypeError, "UVWs should be a list of up to 10 hsVector3 objects");
+    for (Py_ssize_t i=0; i<size; i++) {
+        PyObject* itm = seq.get(i);
+        if (!pyPlasma_check<hsVector3>(itm)) {
+            PyErr_SetString(PyExc_TypeError, "UVWs should be a sequence of up to 10 hsVector3 objects");
             return -1;
         }
-        uvws[i] = *((pyVector3*)itm)->fThis;
+        self->fThis->fUVWs[i] = pyPlasma_get<hsVector3>(itm);
     }
-    for (size_t i=0; i<uvws.size(); i++)
-        self->fThis->fUVWs[i] = uvws[i];
-    for (size_t i=uvws.size(); i<10; i++)
+    for (Py_ssize_t i=size; i<10; i++)
         self->fThis->fUVWs[i] = hsVector3(0.0f, 0.0f, 0.0f);
     return 0;
 }
 
-static int pySpanTemplateVertex_setWeights(pySpanTemplateVertex* self, PyObject* value, void*) {
-    std::vector<float> weights;
-    if (value == NULL || !PyList_Check(value)) {
-        PyErr_SetString(PyExc_TypeError, "weights should be a list of up to 3 floats");
+PY_PROPERTY_GETSET_DECL(SpanTemplateVertex, UVWs)
+
+PY_GETSET_GETTER_DECL(SpanTemplateVertex, weights) {
+    PyObject* list = PyTuple_New(3);
+    for (size_t i=0; i<3; i++)
+        PyTuple_SET_ITEM(list, i, pyPlasma_convert(self->fThis->fWeights[i]));
+    return list;
+}
+
+PY_GETSET_SETTER_DECL(SpanTemplateVertex, weights) {
+    PY_PROPERTY_CHECK_NULL(weights)
+    pySequenceFastRef seq(value);
+    if (!seq.isSequence()) {
+        PyErr_SetString(PyExc_TypeError, "weights should be a sequence of up to 3 floats");
         return -1;
     }
-    weights.resize(PyList_Size(value));
-    if (weights.size() > 3) {
-        PyErr_SetString(PyExc_RuntimeError, "weights should be a list of up to 3 floats");
+    Py_ssize_t size = seq.size();
+    if (size > 3) {
+        PyErr_SetString(PyExc_RuntimeError, "weights should be a sequence of up to 3 floats");
         return -1;
     }
-    for (size_t i=0; i<weights.size(); i++) {
-        PyObject* itm = PyList_GetItem(value, i);
-        if (!PyFloat_Check(itm)) {
-            PyErr_SetString(PyExc_TypeError, "weights should be a list of up to 3 floats");
+    for (Py_ssize_t i=0; i<size; i++) {
+        PyObject* itm = seq.get(i);
+        if (!pyPlasma_check<float>(itm)) {
+            PyErr_SetString(PyExc_TypeError, "weights should be a sequence of up to 3 floats");
             return -1;
         }
-        weights[i] = PyFloat_AsDouble(itm);
+        self->fThis->fWeights[i] = pyPlasma_get<float>(itm);
     }
-    for (size_t i=0; i<weights.size(); i++)
-        self->fThis->fWeights[i] = weights[i];
-    for (size_t i=weights.size(); i<3; i++)
+    for (Py_ssize_t i=size; i<3; i++)
         self->fThis->fWeights[i] = 0.0f;
     return 0;
 }
+
+PY_PROPERTY_GETSET_DECL(SpanTemplateVertex, weights)
 
 PY_PROPERTY_MEMBER(hsVector3, SpanTemplateVertex, position, fPosition)
 PY_PROPERTY_MEMBER(hsVector3, SpanTemplateVertex, normal, fNormal)
@@ -103,10 +105,8 @@ static PyGetSetDef pySpanTemplateVertex_GetSet[] = {
     pySpanTemplateVertex_color1_getset,
     pySpanTemplateVertex_color2_getset,
     pySpanTemplateVertex_weightIdx_getset,
-    { _pycs("UVWs"), (getter)pySpanTemplateVertex_getUVWs,
-        (setter)pySpanTemplateVertex_setUVWs, NULL, NULL },
-    { _pycs("weights"), (getter)pySpanTemplateVertex_getWeights,
-        (setter)pySpanTemplateVertex_setWeights, NULL, NULL },
+    pySpanTemplateVertex_UVWs_getset,
+    pySpanTemplateVertex_weights_getset,
     PY_GETSET_TERMINATOR
 };
 

--- a/Python/PRP/Geometry/pyTempVertex.cpp
+++ b/Python/PRP/Geometry/pyTempVertex.cpp
@@ -79,14 +79,12 @@ PY_GETSET_GETTER_DECL(TempVertex, color) {
 }
 
 PY_GETSET_SETTER_DECL(TempVertex, color) {
-    if (value == NULL) {
-        PyErr_SetString(PyExc_RuntimeError, "color cannot be deleted");
-        return -1;
-    } else if (pyColor32_Check(value)) {
+    PY_PROPERTY_CHECK_NULL(color)
+    if (pyColor32_Check(value)) {
         self->fThis->fColor = ((pyColor32*)value)->fThis->color;
         return 0;
-    } else if (PyInt_Check(value)) {
-        self->fThis->fColor = PyInt_AsLong(value);
+    } else if (pyPlasma_check<unsigned int>(value)) {
+        self->fThis->fColor = pyPlasma_get<unsigned int>(value);
         return 0;
     } else {
         PyErr_SetString(PyExc_TypeError, "color must be an int or an hsColor32");

--- a/Python/PRP/Geometry/pyTempVertex.cpp
+++ b/Python/PRP/Geometry/pyTempVertex.cpp
@@ -24,55 +24,61 @@ extern "C" {
 PY_PLASMA_VALUE_DEALLOC(TempVertex)
 PY_PLASMA_VALUE_NEW(TempVertex, plGeometrySpan::TempVertex)
 
-static PyObject* pyTempVertex_getUVs(pyTempVertex* self, void*) {
-    PyObject* list = PyList_New(8);
+PY_GETSET_GETTER_DECL(TempVertex, uvs) {
+    PyObject* list = PyTuple_New(8);
     for (size_t i = 0; i < 8; ++i)
-        PyList_SET_ITEM(list, i, pyPlasma_convert(self->fThis->fUVs[i]));
+        PyTuple_SET_ITEM(list, i, pyPlasma_convert(self->fThis->fUVs[i]));
     return list;
 }
 
-static PyObject* pyTempVertex_getWeights(pyTempVertex* self, void*) {
-    PyObject* list = PyList_New(3);
-    for (size_t i = 0; i < 3; ++i)
-        PyList_SET_ITEM(list, i, pyPlasma_convert(self->fThis->fWeights[i]));
-    return list;
-}
-
-static int pyTempVertex_setUVs(pyTempVertex* self, PyObject* value, void*) {
-    if (value == NULL || !PySequence_Check(value)) {
+PY_GETSET_SETTER_DECL(TempVertex, uvs) {
+    PY_PROPERTY_CHECK_NULL(uvs)
+    pySequenceFastRef seq(value);
+    if (!seq.isSequence()) {
         PyErr_SetString(PyExc_TypeError, "uvs must be a sequence of hsVector3");
         return -1;
     }
-    size_t size = (PySequence_Size(value) > 8) ? 8 : PySequence_Size(value);
-    for (size_t i = 0; i < size; ++i) {
-        if (!pyVector3_Check(PySequence_Fast_GET_ITEM(value, i))) {
+    Py_ssize_t size = (seq.size() > 8) ? 8 : seq.size();
+    for (Py_ssize_t i = 0; i < size; ++i) {
+        PyObject* uv = seq.get(i);
+        if (!pyPlasma_check<hsVector3>(uv)) {
             PyErr_SetString(PyExc_TypeError, "uvs must be a sequence of hsVector3");
             return -1;
         }
+        self->fThis->fUVs[i] = pyPlasma_get<hsVector3>(uv);
     }
-
-    for (size_t i = 0; i < size; ++i)
-        self->fThis->fUVs[i] = *((pyVector3*)PySequence_Fast_GET_ITEM(value, i))->fThis;
     return 0;
 }
 
-static int pyTempVertex_setWeights(pyTempVertex* self, PyObject* value, void*) {
-    if (value == NULL || !PySequence_Check(value)) {
+PY_PROPERTY_GETSET_DECL(TempVertex, uvs)
+
+PY_GETSET_GETTER_DECL(TempVertex, weights) {
+    PyObject* list = PyTuple_New(3);
+    for (size_t i = 0; i < 3; ++i)
+        PyTuple_SET_ITEM(list, i, pyPlasma_convert(self->fThis->fWeights[i]));
+    return list;
+}
+
+PY_GETSET_SETTER_DECL(TempVertex, weights) {
+    PY_PROPERTY_CHECK_NULL(weights)
+    pySequenceFastRef seq(value);
+    if (!seq.isSequence()) {
         PyErr_SetString(PyExc_TypeError, "weights must be a sequence of floats");
         return -1;
     }
-    size_t size = (PySequence_Size(value) > 3) ? 3 : PySequence_Size(value);
-    for (size_t i = 0; i < size; ++i) {
-        if (!PyFloat_Check(PySequence_Fast_GET_ITEM(value, i))) {
+    Py_ssize_t size = (seq.size() > 3) ? 3 : seq.size();
+    for (Py_ssize_t i = 0; i < size; ++i) {
+        PyObject* weight = seq.get(i);
+        if (!pyPlasma_check<float>(weight)) {
             PyErr_SetString(PyExc_TypeError, "weights must be a sequence of floats");
             return -1;
         }
+        self->fThis->fWeights[i] = pyPlasma_get<float>(weight);
     }
-
-    for (size_t i = 0; i < size; ++i)
-        self->fThis->fWeights[i] = PyFloat_AsDouble(PySequence_Fast_GET_ITEM(value, i));
     return 0;
 }
+
+PY_PROPERTY_GETSET_DECL(TempVertex, weights)
 
 PY_GETSET_GETTER_DECL(TempVertex, color) {
     return pyColor32_FromColor32(hsColor32(self->fThis->fColor));
@@ -103,8 +109,8 @@ PyGetSetDef pyTempVertex_GetSet[] = {
     pyTempVertex_indices_getset,
     pyTempVertex_normal_getset,
     pyTempVertex_position_getset,
-    { _pycs("uvs"), (getter)pyTempVertex_getUVs, (setter)pyTempVertex_setUVs, NULL, NULL },
-    { _pycs("weights"), (getter)pyTempVertex_getWeights, (setter)pyTempVertex_setWeights, NULL, NULL },
+    pyTempVertex_uvs_getset,
+    pyTempVertex_weights_getset,
     PY_GETSET_TERMINATOR
 };
 

--- a/Python/PRP/KeyedObject/pyKey.cpp
+++ b/Python/PRP/KeyedObject/pyKey.cpp
@@ -179,10 +179,8 @@ PY_GETSET_GETTER_DECL(Key, name) {
 }
 
 PY_GETSET_SETTER_DECL(Key, name) {
-    if (value == NULL) {
-        PyErr_SetString(PyExc_RuntimeError, "name cannot be deleted");
-        return -1;
-    } else if (!pyPlasma_check<plString>(value)) {
+    PY_PROPERTY_CHECK_NULL(name)
+    if (!pyPlasma_check<plString>(value)) {
         PyErr_SetString(PyExc_TypeError, "name expected type plString");
         return -1;
     }
@@ -197,10 +195,8 @@ PY_GETSET_GETTER_DECL(Key, location) {
 }
 
 PY_GETSET_SETTER_DECL(Key, location) {
-    if (value == NULL) {
-        PyErr_SetString(PyExc_RuntimeError, "location cannot be deleted");
-        return -1;
-    } else if (value == Py_None) {
+    PY_PROPERTY_CHECK_NULL(location)
+    if (value == Py_None) {
         (*self->fThis)->setLocation(plLocation());
         return 0;
     } else if (!pyLocation_Check(value)) {
@@ -218,10 +214,8 @@ PY_GETSET_GETTER_DECL(Key, mask) {
 }
 
 PY_GETSET_SETTER_DECL(Key, mask) {
-    if (value == NULL) {
-        PyErr_SetString(PyExc_RuntimeError, "mask cannot be deleted");
-        return -1;
-    } else if (!pyPlasma_check<unsigned short>(value)) {
+    PY_PROPERTY_CHECK_NULL(mask)
+    if (!pyPlasma_check<unsigned short>(value)) {
         PyErr_SetString(PyExc_TypeError, "mask expected type unsigned short");
         return -1;
     }
@@ -238,10 +232,8 @@ PY_GETSET_GETTER_DECL(Key, id) {
 }
 
 PY_GETSET_SETTER_DECL(Key, id) {
-    if (value == NULL) {
-        PyErr_SetString(PyExc_RuntimeError, "id cannot be deleted");
-        return -1;
-    } else if (!pyPlasma_check<uint32_t>(value)) {
+    PY_PROPERTY_CHECK_NULL(id)
+    if (!pyPlasma_check<uint32_t>(value)) {
         PyErr_SetString(PyExc_TypeError, "id expected type uint32_t");
         return -1;
     }

--- a/Python/PRP/Light/pyLightInfo.cpp
+++ b/Python/PRP/Light/pyLightInfo.cpp
@@ -45,23 +45,21 @@ PY_METHOD_VA(LightInfo, addVisRegion,
     Py_RETURN_NONE;
 }
 
-static PyObject* pyLightInfo_getVisRegions(pyLightInfo* self, void*) {
-    PyObject* list = PyList_New(self->fThis->getVisRegions().size());
-    for (size_t i=0; i<self->fThis->getVisRegions().size(); i++)
-        PyList_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getVisRegions()[i]));
-    return list;
-}
-
-static int pyLightInfo_setVisRegions(pyLightInfo* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "To add Vis Regions, use addVisRegion()");
-    return -1;
-}
-
 static PyMethodDef pyLightInfo_Methods[] = {
     pyLightInfo_clearVisRegions_method,
     pyLightInfo_addVisRegion_method,
     PY_METHOD_TERMINATOR
 };
+
+PY_GETSET_GETTER_DECL(LightInfo, visRegions) {
+    PyObject* list = PyTuple_New(self->fThis->getVisRegions().size());
+    for (size_t i=0; i<self->fThis->getVisRegions().size(); i++)
+        PyTuple_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getVisRegions()[i]));
+    return list;
+}
+
+PY_PROPERTY_SETTER_MSG(LightInfo, visRegions, "To add Vis Regions, use addVisRegion()")
+PY_PROPERTY_GETSET_DECL(LightInfo, visRegions)
 
 PY_PROPERTY(hsColorRGBA, LightInfo, ambient, getAmbient, setAmbient)
 PY_PROPERTY(hsColorRGBA, LightInfo, diffuse, getDiffuse, setDiffuse)
@@ -85,8 +83,7 @@ static PyGetSetDef pyLightInfo_GetSet[] = {
     pyLightInfo_projection_getset,
     pyLightInfo_softVolume_getset,
     pyLightInfo_sceneNode_getset,
-    { _pycs("visRegions"), (getter)pyLightInfo_getVisRegions,
-        (setter)pyLightInfo_setVisRegions, NULL, NULL },
+    pyLightInfo_visRegions_getset,
     PY_GETSET_TERMINATOR
 };
 

--- a/Python/PRP/Message/pyLinkToAgeMsg.cpp
+++ b/Python/PRP/Message/pyLinkToAgeMsg.cpp
@@ -32,11 +32,10 @@ PY_GETSET_GETTER_DECL(LinkToAgeMsg, ageLink) {
 }
 
 PY_GETSET_SETTER_DECL(LinkToAgeMsg, ageLink) {
+    PY_PROPERTY_CHECK_NULL(ageLink)
+
     plAgeLinkStruct& als = self->fThis->getAgeLink();
-    if (value == NULL) {
-        PyErr_SetString(PyExc_RuntimeError, "ageLink cannot be deleted");
-        return -1;
-    } else if (pyAgeLinkStruct_Check(value)) {
+    if (pyAgeLinkStruct_Check(value)) {
         als = *((pyAgeLinkStruct*)value)->fThis;
         return 0;
     } else {

--- a/Python/PRP/Message/pyMessage.cpp
+++ b/Python/PRP/Message/pyMessage.cpp
@@ -59,24 +59,22 @@ PY_METHOD_NOARGS(Message, clearReceivers, "Remove all receivers from the object"
     Py_RETURN_NONE;
 }
 
-static PyObject* pyMessage_getReceivers(pyMessage* self, void*) {
-    PyObject* list = PyList_New(self->fThis->getReceivers().size());
-    for (size_t i=0; i<self->fThis->getReceivers().size(); i++)
-        PyList_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getReceivers()[i]));
-    return list;
-}
-
-static int pyMessage_setReceivers(pyMessage* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "To add receivers, use addReceiver()");
-    return -1;
-}
-
 static PyMethodDef pyMessage_Methods[] = {
     pyMessage_addReceiver_method,
     pyMessage_delReceiver_method,
     pyMessage_clearReceivers_method,
     PY_METHOD_TERMINATOR
 };
+
+PY_GETSET_GETTER_DECL(Message, receivers) {
+    PyObject* list = PyTuple_New(self->fThis->getReceivers().size());
+    for (size_t i=0; i<self->fThis->getReceivers().size(); i++)
+        PyTuple_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getReceivers()[i]));
+    return list;
+}
+
+PY_PROPERTY_SETTER_MSG(Message, receivers, "To add receivers, use addReceiver()")
+PY_PROPERTY_GETSET_DECL(Message, receivers)
 
 PY_PROPERTY(plKey, Message, sender, getSender, setSender)
 PY_PROPERTY(double, Message, timeStamp, getTimeStamp, setTimeStamp)
@@ -86,8 +84,7 @@ static PyGetSetDef pyMessage_GetSet[] = {
     pyMessage_sender_getset,
     pyMessage_timeStamp_getset,
     pyMessage_BCastFlags_getset,
-    { _pycs("receivers"), (getter)pyMessage_getReceivers,
-        (setter)pyMessage_setReceivers, NULL, NULL },
+    pyMessage_receivers_getset,
     PY_GETSET_TERMINATOR
 };
 

--- a/Python/PRP/Message/pyMessageWithCallbacks.cpp
+++ b/Python/PRP/Message/pyMessageWithCallbacks.cpp
@@ -69,7 +69,7 @@ static PyMethodDef pyMessageWithCallbacks_Methods[] = {
     PY_METHOD_TERMINATOR
 };
 
-static PyObject* pyMessageWithCallbacks_getCallbacks(pyMessageWithCallbacks* self, void*) {
+PY_GETSET_GETTER_DECL(MessageWithCallbacks, callbacks) {
     const std::vector<plMessage*>& callbacks = self->fThis->getCallbacks();
     PyObject* tup = PyTuple_New(callbacks.size());
     for (size_t i = 0; i < callbacks.size(); ++i)
@@ -77,14 +77,11 @@ static PyObject* pyMessageWithCallbacks_getCallbacks(pyMessageWithCallbacks* sel
     return tup;
 }
 
-static int pyMessageWithCallbacks_setCallbacks(pyMessageWithCallbacks* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "To add callbacks, use addCallback");
-    return -1;
-}
+PY_PROPERTY_SETTER_MSG(MessageWithCallbacks, callbacks, "To add callbacks, use addCallback")
+PY_PROPERTY_GETSET_DECL(MessageWithCallbacks, callbacks)
 
 static PyGetSetDef pyMessageWithCallbacks_GetSet[] = {
-    { _pycs("callbacks"), (getter)pyMessageWithCallbacks_getCallbacks,
-       (setter)pyMessageWithCallbacks_setCallbacks, NULL, NULL },
+    pyMessageWithCallbacks_callbacks_getset,
     PY_GETSET_TERMINATOR
 };
 

--- a/Python/PRP/Message/pyMsgForwarder.cpp
+++ b/Python/PRP/Message/pyMsgForwarder.cpp
@@ -62,18 +62,6 @@ PY_METHOD_VA(MsgForwarder, delForwardKey,
     Py_RETURN_NONE;
 }
 
-static PyObject* pyMsgForwarder_getForwardKeys(pyMsgForwarder* self, void*) {
-    PyObject* list = PyList_New(self->fThis->getForwardKeys().size());
-    for (size_t i=0; i<self->fThis->getForwardKeys().size(); i++)
-        PyList_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getForwardKeys()[i]));
-    return list;
-}
-
-static int pyMsgForwarder_setForwardKeys(pyMsgForwarder* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "to add forward keys, use addForwardKey");
-    return -1;
-}
-
 static PyMethodDef pyMsgForwarder_Methods[] = {
     pyMsgForwarder_clearForwardKeys_method,
     pyMsgForwarder_addForwardKey_method,
@@ -81,9 +69,18 @@ static PyMethodDef pyMsgForwarder_Methods[] = {
     PY_METHOD_TERMINATOR
 };
 
+PY_GETSET_GETTER_DECL(MsgForwarder, forwardKeys) {
+    PyObject* list = PyTuple_New(self->fThis->getForwardKeys().size());
+    for (size_t i=0; i<self->fThis->getForwardKeys().size(); i++)
+        PyTuple_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getForwardKeys()[i]));
+    return list;
+}
+
+PY_PROPERTY_SETTER_MSG(MsgForwarder, forwardKeys, "To add forward keys, use addForwardKey")
+PY_PROPERTY_GETSET_DECL(MsgForwarder, forwardKeys)
+
 static PyGetSetDef pyMsgForwarder_GetSet[] = {
-    { _pycs("forwardKeys"), (getter)pyMsgForwarder_getForwardKeys,
-        (setter)pyMsgForwarder_setForwardKeys, NULL, NULL },
+    pyMsgForwarder_forwardKeys_getset,
     PY_GETSET_TERMINATOR
 };
 

--- a/Python/PRP/Message/pyNotifyMsg.cpp
+++ b/Python/PRP/Message/pyNotifyMsg.cpp
@@ -61,18 +61,6 @@ PY_METHOD_VA(NotifyMsg, delEvent,
     Py_RETURN_NONE;
 }
 
-static PyObject* pyNotifyMsg_getEvents(pyNotifyMsg* self, void*) {
-    PyObject* list = PyList_New(self->fThis->getEvents().size());
-    for (size_t i=0; i<self->fThis->getEvents().size(); i++)
-        PyList_SET_ITEM(list, i, ICreateEventData(self->fThis->getEvents()[i]));
-    return list;
-}
-
-static int pyNotifyMsg_setEvents(pyNotifyMsg* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "to add events, use addEvent");
-    return -1;
-}
-
 static PyMethodDef pyNotifyMsg_Methods[] = {
     pyNotifyMsg_clearEvents_method,
     pyNotifyMsg_addEvent_method,
@@ -80,13 +68,22 @@ static PyMethodDef pyNotifyMsg_Methods[] = {
     PY_METHOD_TERMINATOR
 };
 
+PY_GETSET_GETTER_DECL(NotifyMsg, events) {
+    PyObject* list = PyTuple_New(self->fThis->getEvents().size());
+    for (size_t i=0; i<self->fThis->getEvents().size(); i++)
+        PyTuple_SET_ITEM(list, i, ICreateEventData(self->fThis->getEvents()[i]));
+    return list;
+}
+
+PY_PROPERTY_SETTER_MSG(NotifyMsg, events, "To add events, use addEvent")
+PY_PROPERTY_GETSET_DECL(NotifyMsg, events)
+
 PY_PROPERTY(int, NotifyMsg, type, getType, setType)
 PY_PROPERTY(float, NotifyMsg, state, getState, setState)
 PY_PROPERTY(int, NotifyMsg, id, getID, setID)
 
 static PyGetSetDef pyNotifyMsg_GetSet[] = {
-    { _pycs("events"), (getter)pyNotifyMsg_getEvents,
-        (setter)pyNotifyMsg_setEvents, NULL, NULL },
+    pyNotifyMsg_events_getset,
     pyNotifyMsg_type_getset,
     pyNotifyMsg_state_getset,
     pyNotifyMsg_id_getset,

--- a/Python/PRP/Message/pyOneShotMsg.cpp
+++ b/Python/PRP/Message/pyOneShotMsg.cpp
@@ -68,19 +68,22 @@ static PyMethodDef pyOneShotMsg_Methods[] = {
     PY_METHOD_TERMINATOR
 };
 
-static PyObject* pyOneShotMsg_getCallbacks(pyOneShotMsg* self, void*) {
+PY_GETSET_GETTER_DECL(OneShotMsg, callbacks) {
     const plOneShotCallbacks& cbs = self->fThis->getCallbacks();
     PyObject* tup = PyTuple_New(cbs.getNumCallbacks());
     for (size_t i = 0; i < cbs.getNumCallbacks(); ++i) {
         const auto& cb = cbs.getCallbacks()[i];
-        PyObject* value = Py_BuildValue("OOh", PlStr_To_PyStr(cb.fMarker), pyKey_FromKey(cb.fReceiver), cb.fUser);
+        PyObject* value = Py_BuildValue("OOh", pyPlasma_convert(cb.fMarker),
+                                        pyPlasma_convert(cb.fReceiver), cb.fUser);
         PyTuple_SET_ITEM(tup, i, value);
     }
     return tup;
 }
 
+PY_PROPERTY_GETSET_RO_DECL(OneShotMsg, callbacks)
+
 static PyGetSetDef pyOneShotMsg_GetSet[] = {
-    { _pycs("callbacks"), (getter)pyOneShotMsg_getCallbacks, NULL, NULL, NULL },
+    pyOneShotMsg_callbacks_getset,
     PY_GETSET_TERMINATOR
 };
 

--- a/Python/PRP/Misc/pyAgeInfoStruct.cpp
+++ b/Python/PRP/Misc/pyAgeInfoStruct.cpp
@@ -32,10 +32,8 @@ PY_GETSET_GETTER_DECL(AgeInfoStruct, ageInstanceGuid) {
 }
 
 PY_GETSET_SETTER_DECL(AgeInfoStruct, ageInstanceGuid) {
-    if (value == NULL) {
-        PyErr_SetString(PyExc_RuntimeError, "ageInstanceGuid cannot be deleted");
-        return -1;
-    } else if (!pyPlasma_check<plString>(value)) {
+    PY_PROPERTY_CHECK_NULL(ageInstanceGuid)
+    if (!pyPlasma_check<plString>(value)) {
         PyErr_SetString(PyExc_TypeError, "ageInstanceGuid should be a string");
         return -1;
     }

--- a/Python/PRP/Misc/pyAgeLinkStruct.cpp
+++ b/Python/PRP/Misc/pyAgeLinkStruct.cpp
@@ -78,10 +78,8 @@ PY_PROPERTY(signed char, AgeLinkStruct, linkingRules, getLinkingRules, setLinkin
 PY_PROPERTY_READ(AgeLinkStruct, parentAgeFilename, getParentAgeFilename)
 
 PY_GETSET_SETTER_DECL(AgeLinkStruct, parentAgeFilename) {
-    if (value == NULL) {
-        PyErr_SetString(PyExc_RuntimeError, "Cannot delete parentAgeFilename");
-        return -1;
-    } else if (value == Py_None) {
+    PY_PROPERTY_CHECK_NULL(parentAgeFilename)
+    if (value == Py_None) {
         self->fThis->clearParentAgeFilename();
         return 0;
     } else if (pyPlasma_check<plString>(value)) {

--- a/Python/PRP/Misc/pyAgeLinkStruct.cpp
+++ b/Python/PRP/Misc/pyAgeLinkStruct.cpp
@@ -30,11 +30,10 @@ PY_GETSET_GETTER_DECL(AgeLinkStruct, ageInfo) {
 }
 
 PY_GETSET_SETTER_DECL(AgeLinkStruct, ageInfo) {
+    PY_PROPERTY_CHECK_NULL(ageInfo)
+
     plAgeInfoStruct& ais = self->fThis->getAgeInfo();
-    if (value == NULL) {
-        PyErr_SetString(PyExc_RuntimeError, "ageInfo cannot be deleted");
-        return -1;
-    } else if (value == Py_None) {
+    if (value == Py_None) {
         self->fThis->setHasAgeInfo(false);
         ais = plAgeInfoStruct();
         return 0;
@@ -55,11 +54,10 @@ PY_GETSET_GETTER_DECL(AgeLinkStruct, spawnPoint) {
 }
 
 PY_GETSET_SETTER_DECL(AgeLinkStruct, spawnPoint) {
+    PY_PROPERTY_CHECK_NULL(spawnPoint)
+
     plSpawnPointInfo& spi = self->fThis->getSpawnPoint();
-    if (value == NULL) {
-        PyErr_SetString(PyExc_RuntimeError, "spawnPoint cannot be deleted");
-        return -1;
-    } else if (value == Py_None) {
+    if (value == Py_None) {
         self->fThis->setHasSpawnPoint(false);
         spi = plSpawnPointInfo();
         return 0;

--- a/Python/PRP/Modifier/pyExcludeRegionModifier.cpp
+++ b/Python/PRP/Modifier/pyExcludeRegionModifier.cpp
@@ -33,7 +33,7 @@ PY_METHOD_VA(ExcludeRegionModifier, addSafePoint,
         PyErr_SetString(PyExc_TypeError, "addSafePoint expects a plKey");
         return NULL;
     }
-    self->fThis->addSafePoint(*((pyKey*)key)->fThis);
+    self->fThis->addSafePoint(pyPlasma_get<plKey>(key));
     Py_RETURN_NONE;
 }
 
@@ -68,7 +68,7 @@ static PyMethodDef pyExcludeRegionModifier_Methods[] = {
     PY_METHOD_TERMINATOR
 };
 
-static PyObject* pyExcludeRegionModifier_getSafePoints(pyExcludeRegionModifier* self, void*) {
+PY_GETSET_GETTER_DECL(ExcludeRegionModifier, safePoints) {
     const std::vector<plKey>& points = self->fThis->getSafePoints();
     PyObject* tup = PyTuple_New(points.size());
     for (size_t i = 0; i < points.size(); ++i)
@@ -76,16 +76,14 @@ static PyObject* pyExcludeRegionModifier_getSafePoints(pyExcludeRegionModifier* 
     return tup;
 }
 
-static int pyExcludeRegionModifier_setSafePoints(pyExcludeRegionModifier* self, PyObject*, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "To add safePoints, use addSafePoint()");
-    return -1;
-}
+PY_PROPERTY_SETTER_MSG(ExcludeRegionModifier, safePoints, "To add safePoints, use addSafePoint()")
+PY_PROPERTY_GETSET_DECL(ExcludeRegionModifier, safePoints)
 
 PY_PROPERTY(bool, ExcludeRegionModifier, seek, getSeek, setSeek)
 PY_PROPERTY(float, ExcludeRegionModifier, seekTime, getSeekTime, setSeekTime)
 
 static PyGetSetDef pyExcludeRegionModifier_GetSet[] = {
-    { _pycs("safePoints"), (getter)pyExcludeRegionModifier_getSafePoints, (setter)pyExcludeRegionModifier_setSafePoints, NULL, NULL },
+    pyExcludeRegionModifier_safePoints_getset,
     pyExcludeRegionModifier_seek_getset,
     pyExcludeRegionModifier_seekTime_getset,
     PY_GETSET_TERMINATOR

--- a/Python/PRP/Modifier/pyInterfaceInfoModifier.cpp
+++ b/Python/PRP/Modifier/pyInterfaceInfoModifier.cpp
@@ -60,18 +60,6 @@ PY_METHOD_VA(InterfaceInfoModifier, delIntfKey,
     Py_RETURN_NONE;
 }
 
-static PyObject* pyInterfaceInfoModifier_getIntfKeys(pyInterfaceInfoModifier* self, void*) {
-    PyObject* list = PyList_New(self->fThis->getIntfKeys().size());
-    for (size_t i=0; i<self->fThis->getIntfKeys().size(); i++)
-        PyList_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getIntfKeys()[i]));
-    return list;
-}
-
-static int pyInterfaceInfoModifier_setIntfKeys(pyInterfaceInfoModifier* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "to add interface keys, use addIntfKey");
-    return -1;
-}
-
 static PyMethodDef pyInterfaceInfoModifier_Methods[] = {
     pyInterfaceInfoModifier_clearIntfKeys_method,
     pyInterfaceInfoModifier_addIntfKey_method,
@@ -79,9 +67,18 @@ static PyMethodDef pyInterfaceInfoModifier_Methods[] = {
     PY_METHOD_TERMINATOR
 };
 
+PY_GETSET_GETTER_DECL(InterfaceInfoModifier, intfKeys) {
+    PyObject* list = PyTuple_New(self->fThis->getIntfKeys().size());
+    for (size_t i=0; i<self->fThis->getIntfKeys().size(); i++)
+        PyTuple_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getIntfKeys()[i]));
+    return list;
+}
+
+PY_PROPERTY_SETTER_MSG(InterfaceInfoModifier, intfKeys, "To add interface keys, use addIntfKey")
+PY_PROPERTY_GETSET_DECL(InterfaceInfoModifier, intfKeys)
+
 static PyGetSetDef pyInterfaceInfoModifier_GetSet[] = {
-    { _pycs("intfKeys"), (getter)pyInterfaceInfoModifier_getIntfKeys,
-        (setter)pyInterfaceInfoModifier_setIntfKeys, NULL, NULL },
+    pyInterfaceInfoModifier_intfKeys_getset,
     PY_GETSET_TERMINATOR
 };
 

--- a/Python/PRP/Modifier/pyLogicModBase.cpp
+++ b/Python/PRP/Modifier/pyLogicModBase.cpp
@@ -88,18 +88,6 @@ PY_METHOD_VA(LogicModBase, setLogicFlag,
     Py_RETURN_NONE;
 }
 
-static PyObject* pyLogicModBase_getCommands(pyLogicModBase* self, void*) {
-    PyObject* list = PyList_New(self->fThis->getCommands().size());
-    for (size_t i=0; i<self->fThis->getCommands().size(); i++)
-        PyList_SET_ITEM(list, i, ICreate(self->fThis->getCommands()[i]));
-    return list;
-}
-
-static int pyLogicModBase_setCommands(pyLogicModBase* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "to add commands, use addCommand");
-    return -1;
-}
-
 static PyMethodDef pyLogicModBase_Methods[] = {
     pyLogicModBase_clearCommands_method,
     pyLogicModBase_addCommand_method,
@@ -109,13 +97,22 @@ static PyMethodDef pyLogicModBase_Methods[] = {
     PY_METHOD_TERMINATOR
 };
 
+PY_GETSET_GETTER_DECL(LogicModBase, commands) {
+    PyObject* list = PyTuple_New(self->fThis->getCommands().size());
+    for (size_t i=0; i<self->fThis->getCommands().size(); i++)
+        PyTuple_SET_ITEM(list, i, ICreate(self->fThis->getCommands()[i]));
+    return list;
+}
+
+PY_PROPERTY_SETTER_MSG(LogicModBase, commands, "To add commands, use addCommand")
+PY_PROPERTY_GETSET_DECL(LogicModBase, commands)
+
 PY_PROPERTY_CREATABLE(plNotifyMsg, NotifyMsg, LogicModBase, notify,
                       getNotify, setNotify)
 PY_PROPERTY(bool, LogicModBase, disabled, isDisabled, setDisabled)
 
 static PyGetSetDef pyLogicModBase_GetSet[] = {
-    { _pycs("commands"), (getter)pyLogicModBase_getCommands,
-        (setter)pyLogicModBase_setCommands, NULL, NULL },
+    pyLogicModBase_commands_getset,
     pyLogicModBase_notify_getset,
     pyLogicModBase_disabled_getset,
     PY_GETSET_TERMINATOR

--- a/Python/PRP/Modifier/pyLogicModifier.cpp
+++ b/Python/PRP/Modifier/pyLogicModifier.cpp
@@ -59,18 +59,6 @@ PY_METHOD_VA(LogicModifier, delCondition,
     Py_RETURN_NONE;
 }
 
-static PyObject* pyLogicModifier_getConditions(pyLogicModifier* self, void*) {
-    PyObject* list = PyList_New(self->fThis->getConditions().size());
-    for (size_t i=0; i<self->fThis->getConditions().size(); i++)
-        PyList_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getConditions()[i]));
-    return list;
-}
-
-static int pyLogicModifier_setConditions(pyLogicModifier* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "to add conditions, use addCondition");
-    return -1;
-}
-
 static PyMethodDef pyLogicModifier_Methods[] = {
     pyLogicModifier_clearConditions_method,
     pyLogicModifier_addCondition_method,
@@ -78,12 +66,21 @@ static PyMethodDef pyLogicModifier_Methods[] = {
     PY_METHOD_TERMINATOR
 };
 
+PY_GETSET_GETTER_DECL(LogicModifier, conditions) {
+    PyObject* list = PyTuple_New(self->fThis->getConditions().size());
+    for (size_t i=0; i<self->fThis->getConditions().size(); i++)
+        PyTuple_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getConditions()[i]));
+    return list;
+}
+
+PY_PROPERTY_SETTER_MSG(LogicModifier, conditions, "To add conditions, use addCondition")
+PY_PROPERTY_GETSET_DECL(LogicModifier, conditions)
+
 PY_PROPERTY(unsigned int, LogicModifier, cursor, getCursor, setCursor)
 PY_PROPERTY(plKey, LogicModifier, parent, getParent, setParent)
 
 static PyGetSetDef pyLogicModifier_GetSet[] = {
-    { _pycs("conditions"), (getter)pyLogicModifier_getConditions,
-        (setter)pyLogicModifier_setConditions, NULL, NULL },
+    pyLogicModifier_conditions_getset,
     pyLogicModifier_cursor_getset,
     pyLogicModifier_parent_getset,
     PY_GETSET_TERMINATOR

--- a/Python/PRP/Modifier/pyPythonFileMod.cpp
+++ b/Python/PRP/Modifier/pyPythonFileMod.cpp
@@ -73,30 +73,6 @@ PY_METHOD_VA(PythonFileMod, addParameter,
     Py_RETURN_NONE;
 }
 
-static PyObject* pyPythonFileMod_getReceivers(pyPythonFileMod* self, void*) {
-    PyObject* list = PyList_New(self->fThis->getReceivers().size());
-    for (size_t i=0; i<self->fThis->getReceivers().size(); i++)
-        PyList_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getReceivers()[i]));
-    return list;
-}
-
-static PyObject* pyPythonFileMod_getParameters(pyPythonFileMod* self, void*) {
-    PyObject* list = PyList_New(self->fThis->getParameters().size());
-    for (size_t i=0; i<self->fThis->getParameters().size(); i++)
-        PyList_SET_ITEM(list, i, pyPythonParameter_FromPythonParameter(self->fThis->getParameters()[i]));
-    return list;
-}
-
-static int pyPythonFileMod_setReceivers(pyPythonFileMod* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "to add receivers, use addReceiver");
-    return -1;
-}
-
-static int pyPythonFileMod_setParameters(pyPythonFileMod* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "to add parameters, use addParameter");
-    return -1;
-}
-
 static PyMethodDef pyPythonFileMod_Methods[] = {
     pyPythonFileMod_clearReceivers_method,
     pyPythonFileMod_clearParameters_method,
@@ -105,14 +81,32 @@ static PyMethodDef pyPythonFileMod_Methods[] = {
     PY_METHOD_TERMINATOR
 };
 
+PY_GETSET_GETTER_DECL(PythonFileMod, receivers) {
+    PyObject* list = PyTuple_New(self->fThis->getReceivers().size());
+    for (size_t i=0; i<self->fThis->getReceivers().size(); i++)
+        PyTuple_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getReceivers()[i]));
+    return list;
+}
+
+PY_PROPERTY_SETTER_MSG(PythonFileMod, receivers, "To add receivers, use addReceiver")
+PY_PROPERTY_GETSET_DECL(PythonFileMod, receivers)
+
+PY_GETSET_GETTER_DECL(PythonFileMod, parameters) {
+    PyObject* list = PyTuple_New(self->fThis->getParameters().size());
+    for (size_t i=0; i<self->fThis->getParameters().size(); i++)
+        PyTuple_SET_ITEM(list, i, pyPythonParameter_FromPythonParameter(self->fThis->getParameters()[i]));
+    return list;
+}
+
+PY_PROPERTY_SETTER_MSG(PythonFileMod, parameters, "To add parameters, use addParameter")
+PY_PROPERTY_GETSET_DECL(PythonFileMod, parameters)
+
 PY_PROPERTY(plString, PythonFileMod, filename, getFilename, setFilename)
 
 static PyGetSetDef pyPythonFileMod_GetSet[] = {
     pyPythonFileMod_filename_getset,
-    { _pycs("receivers"), (getter)pyPythonFileMod_getReceivers,
-        (setter)pyPythonFileMod_setReceivers, NULL, NULL },
-    { _pycs("parameters"), (getter)pyPythonFileMod_getParameters,
-        (setter)pyPythonFileMod_setParameters, NULL, NULL },
+    pyPythonFileMod_receivers_getset,
+    pyPythonFileMod_parameters_getset,
     PY_GETSET_TERMINATOR
 };
 

--- a/Python/PRP/Modifier/pyPythonParameter.cpp
+++ b/Python/PRP/Modifier/pyPythonParameter.cpp
@@ -113,10 +113,7 @@ PY_GETSET_GETTER_DECL(PythonParameter, value) {
 }
 
 PY_GETSET_SETTER_DECL(PythonParameter, value) {
-    if (value == NULL) {
-        PyErr_SetString(PyExc_RuntimeError, "value cannot be deleted");
-        return -1;
-    }
+    PY_PROPERTY_CHECK_NULL(value)
 
     switch (self->fThis->fValueType) {
     case plPythonParameter::kInt:

--- a/Python/PRP/Modifier/pyResponderModifier.cpp
+++ b/Python/PRP/Modifier/pyResponderModifier.cpp
@@ -60,18 +60,6 @@ PY_METHOD_NOARGS(ResponderModifier, clearStates, "Delete all states from the Res
     Py_RETURN_NONE;
 }
 
-static PyObject* pyResponderModifier_getStates(pyResponderModifier* self, void*) {
-    PyObject* list = PyList_New(self->fThis->getStates().size());
-    for (size_t i=0; i<self->fThis->getStates().size(); i++)
-        PyList_SET_ITEM(list, i, pyResponderModifier_State_FromResponderModifier_State(self->fThis->getStates()[i]));
-    return list;
-}
-
-static int pyResponderModifier_setStates(pyResponderModifier* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "to add states, use addState");
-    return -1;
-}
-
 static PyMethodDef pyResponderModifier_Methods[] = {
     pyResponderModifier_addState_method,
     pyResponderModifier_delState_method,
@@ -79,13 +67,22 @@ static PyMethodDef pyResponderModifier_Methods[] = {
     PY_METHOD_TERMINATOR
 };
 
+PY_GETSET_GETTER_DECL(ResponderModifier, states) {
+    PyObject* list = PyTuple_New(self->fThis->getStates().size());
+    for (size_t i=0; i<self->fThis->getStates().size(); i++)
+        PyTuple_SET_ITEM(list, i, pyResponderModifier_State_FromResponderModifier_State(self->fThis->getStates()[i]));
+    return list;
+}
+
+PY_PROPERTY_SETTER_MSG(ResponderModifier, states, "To add states, use addState")
+PY_PROPERTY_GETSET_DECL(ResponderModifier, states)
+
 PY_PROPERTY(signed char, ResponderModifier, curState, getCurState, setCurState)
 PY_PROPERTY(bool, ResponderModifier, enabled, isEnabled, setEnabled)
 PY_PROPERTY(unsigned char, ResponderModifier, flags, getFlags, setFlags)
 
 static PyGetSetDef pyResponderModifier_GetSet[] = {
-    { _pycs("states"), (getter)pyResponderModifier_getStates,
-        (setter)pyResponderModifier_setStates, NULL, NULL },
+    pyResponderModifier_states_getset,
     pyResponderModifier_curState_getset,
     pyResponderModifier_enabled_getset,
     pyResponderModifier_flags_getset,

--- a/Python/PRP/Modifier/pyResponderModifier_State.cpp
+++ b/Python/PRP/Modifier/pyResponderModifier_State.cpp
@@ -91,10 +91,7 @@ PY_GETSET_GETTER_DECL(ResponderModifier_State, waitToCmd) {
 }
 
 PY_GETSET_SETTER_DECL(ResponderModifier_State, waitToCmd) {
-    if (value == NULL) {
-        PyErr_SetString(PyExc_RuntimeError, "waitToCmd cannot be deleted");
-        return 0;
-    }
+    PY_PROPERTY_CHECK_NULL(waitToCmd)
     if (!PyDict_Check(value)) {
         PyErr_SetString(PyExc_TypeError, "waitToCmd should be a dict { int => int }");
         return -1;

--- a/Python/PRP/Modifier/pyResponderModifier_State.cpp
+++ b/Python/PRP/Modifier/pyResponderModifier_State.cpp
@@ -64,24 +64,22 @@ PY_METHOD_NOARGS(ResponderModifier_State, clearCommands,
     Py_RETURN_NONE;
 }
 
-static PyObject* pyResponderModifier_State_getCommands(pyResponderModifier_State* self, void*) {
-    PyObject* list = PyList_New(self->fThis->fCmds.size());
-    for (size_t i=0; i<self->fThis->fCmds.size(); i++)
-        PyList_SET_ITEM(list, i, pyResponderModifier_Cmd_FromResponderModifier_Cmd(self->fThis->fCmds[i]));
-    return list;
-}
-
-static int pyResponderModifier_State_setCommands(pyResponderModifier_State* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_TypeError, "To add commands, use addCommand");
-    return -1;
-}
-
 static PyMethodDef pyResponderModifier_State_Methods[] = {
     pyResponderModifier_State_addCommand_method,
     pyResponderModifier_State_delCommand_method,
     pyResponderModifier_State_clearCommands_method,
     PY_METHOD_TERMINATOR
 };
+
+PY_GETSET_GETTER_DECL(ResponderModifier_State, commands) {
+    PyObject* list = PyTuple_New(self->fThis->fCmds.size());
+    for (size_t i=0; i<self->fThis->fCmds.size(); i++)
+        PyTuple_SET_ITEM(list, i, pyResponderModifier_Cmd_FromResponderModifier_Cmd(self->fThis->fCmds[i]));
+    return list;
+}
+
+PY_PROPERTY_SETTER_MSG(ResponderModifier_State, commands, "To add commands, use addCommand")
+PY_PROPERTY_GETSET_DECL(ResponderModifier_State, commands)
 
 PY_GETSET_GETTER_DECL(ResponderModifier_State, waitToCmd) {
     PyObject* dict = PyDict_New();
@@ -117,8 +115,7 @@ PY_PROPERTY_MEMBER(int8_t, ResponderModifier_State, numCallbacks, fNumCallbacks)
 PY_PROPERTY_MEMBER(int8_t, ResponderModifier_State, switchToState, fSwitchToState)
 
 static PyGetSetDef pyResponderModifier_State_GetSet[] = {
-    { _pycs("commands"), (getter)pyResponderModifier_State_getCommands,
-        (setter)pyResponderModifier_State_setCommands, NULL, NULL },
+    pyResponderModifier_State_commands_getset,
     pyResponderModifier_State_numCallbacks_getset,
     pyResponderModifier_State_switchToState_getset,
     pyResponderModifier_State_waitToCmd_getset,

--- a/Python/PRP/Object/pyCoordinateInterface.cpp
+++ b/Python/PRP/Object/pyCoordinateInterface.cpp
@@ -62,24 +62,22 @@ PY_METHOD_VA(CoordinateInterface, delChild,
     Py_RETURN_NONE;
 }
 
-static PyObject* pyCoordinateInterface_getChildren(pyCoordinateInterface* self, void*) {
-    PyObject* list = PyList_New(self->fThis->getChildren().size());
-    for (size_t i=0; i<self->fThis->getChildren().size(); i++)
-        PyList_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getChildren()[i]));
-    return list;
-}
-
-static int pyCoordinateInterface_setChildren(pyCoordinateInterface* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "To add Children, use addChild");
-    return -1;
-}
-
 PyMethodDef pyCoordinateInterface_Methods[] = {
     pyCoordinateInterface_clearChildren_method,
     pyCoordinateInterface_addChild_method,
     pyCoordinateInterface_delChild_method,
     PY_METHOD_TERMINATOR
 };
+
+PY_GETSET_GETTER_DECL(CoordinateInterface, children) {
+    PyObject* list = PyTuple_New(self->fThis->getChildren().size());
+    for (size_t i=0; i<self->fThis->getChildren().size(); i++)
+        PyTuple_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getChildren()[i]));
+    return list;
+}
+
+PY_PROPERTY_SETTER_MSG(CoordinateInterface, children, "To add Children, use addChild")
+PY_PROPERTY_GETSET_DECL(CoordinateInterface, children)
 
 PY_PROPERTY(hsMatrix44, CoordinateInterface, localToWorld, getLocalToWorld, setLocalToWorld)
 PY_PROPERTY(hsMatrix44, CoordinateInterface, worldToLocal, getWorldToLocal, setWorldToLocal)
@@ -91,9 +89,7 @@ PyGetSetDef pyCoordinateInterface_GetSet[] = {
     pyCoordinateInterface_worldToLocal_getset,
     pyCoordinateInterface_localToParent_getset,
     pyCoordinateInterface_parentToLocal_getset,
-    { _pycs("children"), (getter)pyCoordinateInterface_getChildren,
-        (setter)pyCoordinateInterface_setChildren,
-        _pycs("Child Objects"), NULL },
+    pyCoordinateInterface_children_getset,
     PY_GETSET_TERMINATOR
 };
 

--- a/Python/PRP/Object/pyDrawInterface.cpp
+++ b/Python/PRP/Object/pyDrawInterface.cpp
@@ -99,36 +99,6 @@ PY_METHOD_VA(DrawInterface, delRegion,
     Py_RETURN_NONE;
 }
 
-static PyObject* pyDrawInterface_getDrawables(pyDrawInterface* self, void*) {
-    PyObject* list = PyList_New(self->fThis->getNumDrawables());
-    for (size_t i=0; i<self->fThis->getNumDrawables(); i++) {
-        PyObject* tup = Py_BuildValue("(Oi)",
-            pyKey_FromKey(self->fThis->getDrawable(i)),
-            self->fThis->getDrawableKey(i));
-        if (tup == NULL)
-            return NULL;
-        PyList_SET_ITEM(list, i, tup);
-    }
-    return list;
-}
-
-static PyObject* pyDrawInterface_getRegions(pyDrawInterface* self, void*) {
-    PyObject* list = PyList_New(self->fThis->getRegions().size());
-    for (size_t i=0; i<self->fThis->getRegions().size(); i++)
-        PyList_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getRegions()[i]));
-    return list;
-}
-
-static int pyDrawInterface_setDrawables(pyDrawInterface* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "To add Drawables, use addDrawable");
-    return -1;
-}
-
-static int pyDrawInterface_setRegions(pyDrawInterface* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "To add Regions, use addRegion");
-    return -1;
-}
-
 PyMethodDef pyDrawInterface_Methods[] = {
     pyDrawInterface_clearDrawables_method,
     pyDrawInterface_addDrawable_method,
@@ -139,12 +109,35 @@ PyMethodDef pyDrawInterface_Methods[] = {
     PY_METHOD_TERMINATOR
 };
 
+PY_GETSET_GETTER_DECL(DrawInterface, drawables) {
+    PyObject* list = PyTuple_New(self->fThis->getNumDrawables());
+    for (size_t i=0; i<self->fThis->getNumDrawables(); i++) {
+        PyObject* tup = Py_BuildValue("(Oi)",
+            pyKey_FromKey(self->fThis->getDrawable(i)),
+            self->fThis->getDrawableKey(i));
+        if (tup == NULL)
+            return NULL;
+        PyTuple_SET_ITEM(list, i, tup);
+    }
+    return list;
+}
+
+PY_PROPERTY_SETTER_MSG(DrawInterface, drawables, "To add Drawables, use addDrawable")
+PY_PROPERTY_GETSET_DECL(DrawInterface, drawables)
+
+PY_GETSET_GETTER_DECL(DrawInterface, regions) {
+    PyObject* list = PyTuple_New(self->fThis->getRegions().size());
+    for (size_t i=0; i<self->fThis->getRegions().size(); i++)
+        PyTuple_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getRegions()[i]));
+    return list;
+}
+
+PY_PROPERTY_SETTER_MSG(DrawInterface, regions, "To add Regions, use addRegion")
+PY_PROPERTY_GETSET_DECL(DrawInterface, regions)
+
 PyGetSetDef pyDrawInterface_GetSet[] = {
-    { _pycs("drawables"), (getter)pyDrawInterface_getDrawables,
-        (setter)pyDrawInterface_setDrawables,
-        _pycs("Drawable references and keys"), NULL },
-    { _pycs("regions"), (getter)pyDrawInterface_getRegions,
-        (setter)pyDrawInterface_setRegions, _pycs("Drawable regions"), NULL },
+    pyDrawInterface_drawables_getset,
+    pyDrawInterface_regions_getset,
     PY_GETSET_TERMINATOR
 };
 

--- a/Python/PRP/Object/pySceneObject.cpp
+++ b/Python/PRP/Object/pySceneObject.cpp
@@ -99,30 +99,6 @@ PY_METHOD_VA(SceneObject, delModifier,
     Py_RETURN_NONE;
 }
 
-static PyObject* pySceneObject_getIntfs(pySceneObject* self, void*) {
-    PyObject* list = PyList_New(self->fThis->getInterfaces().size());
-    for (size_t i=0; i<self->fThis->getInterfaces().size(); i++)
-        PyList_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getInterfaces()[i]));
-    return list;
-}
-
-static PyObject* pySceneObject_getMods(pySceneObject* self, void*) {
-    PyObject* list = PyList_New(self->fThis->getModifiers().size());
-    for (size_t i=0; i<self->fThis->getModifiers().size(); i++)
-        PyList_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getModifiers()[i]));
-    return list;
-}
-
-static int pySceneObject_setIntfs(pySceneObject* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "To add Interfaces, use addInterface");
-    return -1;
-}
-
-static int pySceneObject_setMods(pySceneObject* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "To add Modifiers, use addModifier");
-    return -1;
-}
-
 PyMethodDef pySceneObject_Methods[] = {
     pySceneObject_clearInterfaces_method,
     pySceneObject_clearModifiers_method,
@@ -132,6 +108,26 @@ PyMethodDef pySceneObject_Methods[] = {
     pySceneObject_delModifier_method,
     PY_METHOD_TERMINATOR
 };
+
+PY_GETSET_GETTER_DECL(SceneObject, interfaces) {
+    PyObject* list = PyTuple_New(self->fThis->getInterfaces().size());
+    for (size_t i=0; i<self->fThis->getInterfaces().size(); i++)
+        PyTuple_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getInterfaces()[i]));
+    return list;
+}
+
+PY_PROPERTY_SETTER_MSG(SceneObject, interfaces, "To add Interfaces, use addInterface")
+PY_PROPERTY_GETSET_DECL(SceneObject, interfaces)
+
+PY_GETSET_GETTER_DECL(SceneObject, modifiers) {
+    PyObject* list = PyTuple_New(self->fThis->getModifiers().size());
+    for (size_t i=0; i<self->fThis->getModifiers().size(); i++)
+        PyTuple_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getModifiers()[i]));
+    return list;
+}
+
+PY_PROPERTY_SETTER_MSG(SceneObject, modifiers, "To add Modifiers, use addModifier")
+PY_PROPERTY_GETSET_DECL(SceneObject, modifiers)
 
 PY_PROPERTY(plKey, SceneObject, draw, getDrawInterface, setDrawInterface)
 PY_PROPERTY(plKey, SceneObject, sim, getSimInterface, setSimInterface)
@@ -145,10 +141,8 @@ PyGetSetDef pySceneObject_GetSet[] = {
     pySceneObject_coord_getset,
     pySceneObject_audio_getset,
     pySceneObject_sceneNode_getset,
-    { _pycs("interfaces"), (getter)pySceneObject_getIntfs, (setter)pySceneObject_setIntfs,
-        _pycs("Extra SceneObject Interfaces"), NULL },
-    { _pycs("modifiers"), (getter)pySceneObject_getMods, (setter)pySceneObject_setMods,
-        _pycs("SceneObject Modifiers"), NULL },
+    pySceneObject_interfaces_getset,
+    pySceneObject_modifiers_getset,
     PY_GETSET_TERMINATOR
 };
 

--- a/Python/PRP/Object/pySynchedObject.cpp
+++ b/Python/PRP/Object/pySynchedObject.cpp
@@ -50,76 +50,76 @@ PY_METHOD_VA(SynchedObject, setVolatile,
     Py_RETURN_NONE;
 }
 
-static PyObject* pySynchedObject_getExcludes(pySynchedObject* self, void*) {
-    plSynchedObject* so = self->fThis;
-    PyObject* list = PyList_New(so->getExcludes().size());
-    for (size_t i=0; i<so->getExcludes().size(); i++)
-        PyList_SET_ITEM(list, i, pyPlasma_convert(so->getExcludes()[i]));
-    return list;
-}
-
-static PyObject* pySynchedObject_getVolatiles(pySynchedObject* self, void*) {
-    plSynchedObject* so = self->fThis;
-    PyObject* list = PyList_New(so->getVolatiles().size());
-    for (size_t i=0; i<so->getVolatiles().size(); i++)
-        PyList_SET_ITEM(list, i, pyPlasma_convert(so->getVolatiles()[i]));
-    return list;
-}
-
-static int pySynchedObject_setExcludes(pySynchedObject* self, PyObject* value, void*) {
-    if (value == NULL) {
-        self->fThis->clearExcludes();
-        return 0;
-    } else if (PyList_Check(value)) {
-        size_t count = PyList_Size(value);
-        for (size_t i=0; i<count; i++) {
-            if (!PyAnyStr_Check(PyList_GetItem(value, i))) {
-                PyErr_SetString(PyExc_TypeError, "excludes should be a list of strings");
-                return -1;
-            }
-            self->fThis->setExclude(PyStr_To_PlStr(PyList_GetItem(value, i)));
-        }
-        return 0;
-    } else {
-        PyErr_SetString(PyExc_TypeError, "excludes should be a list of strings");
-        return -1;
-    }
-}
-
-static int pySynchedObject_setVolatiles(pySynchedObject* self, PyObject* value, void*) {
-    if (value == NULL) {
-        self->fThis->clearVolatiles();
-        return 0;
-    } else if (PyList_Check(value)) {
-        size_t count = PyList_Size(value);
-        for (size_t i=0; i<count; i++) {
-            if (!PyAnyStr_Check(PyList_GetItem(value, i))) {
-                PyErr_SetString(PyExc_TypeError, "volatiles should be a list of strings");
-                return -1;
-            }
-            self->fThis->setVolatile(PyStr_To_PlStr(PyList_GetItem(value, i)));
-        }
-        return 0;
-    } else {
-        PyErr_SetString(PyExc_TypeError, "volatiles should be a list of strings");
-        return -1;
-    }
-}
-
 static PyMethodDef pySynchedObject_Methods[] = {
     pySynchedObject_setExclude_method,
     pySynchedObject_setVolatile_method,
     PY_METHOD_TERMINATOR
 };
 
+PY_GETSET_GETTER_DECL(SynchedObject, excludes) {
+    plSynchedObject* so = self->fThis;
+    PyObject* list = PyTuple_New(so->getExcludes().size());
+    for (size_t i=0; i<so->getExcludes().size(); i++)
+        PyTuple_SET_ITEM(list, i, pyPlasma_convert(so->getExcludes()[i]));
+    return list;
+}
+
+PY_GETSET_SETTER_DECL(SynchedObject, excludes) {
+    PY_PROPERTY_CHECK_NULL(excludes)
+    pySequenceFastRef seq(value);
+    if (!seq.isSequence()) {
+        PyErr_SetString(PyExc_TypeError, "excludes should be a sequence of strings");
+        return -1;
+    }
+    Py_ssize_t count = seq.size();
+    for (Py_ssize_t i=0; i<count; i++) {
+        PyObject* item = seq.get(i);
+        if (!pyPlasma_check<plString>(item)) {
+            PyErr_SetString(PyExc_TypeError, "excludes should be a list of strings");
+            return -1;
+        }
+        self->fThis->setExclude(pyPlasma_get<plString>(item));
+    }
+    return 0;
+}
+
+PY_PROPERTY_GETSET_DECL(SynchedObject, excludes)
+
+PY_GETSET_GETTER_DECL(SynchedObject, volatiles) {
+    plSynchedObject* so = self->fThis;
+    PyObject* list = PyTuple_New(so->getVolatiles().size());
+    for (size_t i=0; i<so->getVolatiles().size(); i++)
+        PyTuple_SET_ITEM(list, i, pyPlasma_convert(so->getVolatiles()[i]));
+    return list;
+}
+
+PY_GETSET_SETTER_DECL(SynchedObject, volatiles) {
+    PY_PROPERTY_CHECK_NULL(volatiles)
+    pySequenceFastRef seq(value);
+    if (!seq.isSequence()) {
+        PyErr_SetString(PyExc_TypeError, "volatiles should be a list of strings");
+        return -1;
+    }
+    Py_ssize_t count = seq.size();
+    for (Py_ssize_t i=0; i<count; i++) {
+        PyObject* item = seq.get(i);
+        if (!pyPlasma_check<plString>(item)) {
+            PyErr_SetString(PyExc_TypeError, "volatiles should be a list of strings");
+            return -1;
+        }
+        self->fThis->setVolatile(pyPlasma_get<plString>(item));
+    }
+    return 0;
+}
+
+PY_PROPERTY_GETSET_DECL(SynchedObject, volatiles)
+
 PY_PROPERTY(int, SynchedObject, synchFlags, getSynchFlags, setSynchFlags)
 
 static PyGetSetDef pySynchedObject_GetSet[] = {
     pySynchedObject_synchFlags_getset,
-    { _pycs("excludes"), (getter)pySynchedObject_getExcludes,
-        (setter)pySynchedObject_setExcludes, _pycs("SDL Exclude States"), NULL },
-    { _pycs("volatiles"), (getter)pySynchedObject_getVolatiles,
-        (setter)pySynchedObject_setVolatiles, _pycs("SDL Volatile States"), NULL },
+    pySynchedObject_excludes_getset,
+    pySynchedObject_volatiles_getset,
     PY_GETSET_TERMINATOR
 };
 

--- a/Python/PRP/Physics/pyDetectorModifier.cpp
+++ b/Python/PRP/Physics/pyDetectorModifier.cpp
@@ -35,7 +35,7 @@ PY_METHOD_VA(DetectorModifier, addReceiver,
         return NULL;
     }
 
-    self->fThis->addReceiver(*((pyKey*)receiver)->fThis);
+    self->fThis->addReceiver(pyPlasma_get<plKey>(receiver));
     Py_RETURN_NONE;
 }
 
@@ -67,7 +67,7 @@ static PyMethodDef pyDetectorModifier_Methods[] = {
     PY_METHOD_TERMINATOR
 };
 
-static PyObject* pyDetectorModifier_getReceivers(pyDetectorModifier* self, void*) {
+PY_GETSET_GETTER_DECL(DetectorModifier, receivers) {
     plDetectorModifier* mod = self->fThis;
     PyObject* sequence = PyTuple_New(mod->getReceivers().size());
     for (size_t i = 0; i < mod->getReceivers().size(); ++i)
@@ -75,17 +75,14 @@ static PyObject* pyDetectorModifier_getReceivers(pyDetectorModifier* self, void*
     return sequence;
 }
 
-static int pyDetectorModifier_setReceivers(pyDetectorModifier* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "To add receivers, use addReceiver");
-    return -1;
-}
+PY_PROPERTY_SETTER_MSG(DetectorModifier, receivers, "To add receivers, use addReceiver")
+PY_PROPERTY_GETSET_DECL(DetectorModifier, receivers)
 
 PY_PROPERTY(plKey, DetectorModifier, remoteMod, getRemoteMod, setRemoteMod)
 PY_PROPERTY(plKey, DetectorModifier, proxy, getProxy, setProxy)
 
 static PyGetSetDef pyDetectorModifier_GetSet[] = {
-    { _pycs("receivers"), (getter)pyDetectorModifier_getReceivers,
-        (setter)pyDetectorModifier_setReceivers, NULL, NULL },
+    pyDetectorModifier_receivers_getset,
     pyDetectorModifier_remoteMod_getset,
     pyDetectorModifier_proxy_getset,
     PY_GETSET_TERMINATOR

--- a/Python/PRP/Physics/pyGenericPhysical.cpp
+++ b/Python/PRP/Physics/pyGenericPhysical.cpp
@@ -134,10 +134,8 @@ static PyObject* pyGenericPhysical_getIndices(pyGenericPhysical* self, void*) {
 }
 
 static int pyGenericPhysical_setVerts(pyGenericPhysical* self, PyObject* value, void*) {
-    if (value == NULL) {
-        self->fThis->setVerts(0, NULL);
-        return 0;
-    } else if (!PyList_Check(value)) {
+    PY_PROPERTY_CHECK_NULL(verts)
+    if (!PyList_Check(value)) {
         PyErr_SetString(PyExc_TypeError, "verts should be list of hsVector3s");
         return -1;
     }
@@ -162,10 +160,8 @@ static int pyGenericPhysical_setVerts(pyGenericPhysical* self, PyObject* value, 
 }
 
 static int pyGenericPhysical_setIndices(pyGenericPhysical* self, PyObject* value, void*) {
-    if (value == NULL) {
-        self->fThis->setIndices(0, NULL);
-        return 0;
-    } else if (!PyList_Check(value)) {
+    PY_PROPERTY_CHECK_NULL(indices)
+    if (!PyList_Check(value)) {
         PyErr_SetString(PyExc_TypeError, "indices should be list of ints");
         return -1;
     }
@@ -218,10 +214,8 @@ PY_GETSET_GETTER_DECL(GenericPhysical, TMDBuffer) {
 }
 
 PY_GETSET_SETTER_DECL(GenericPhysical, TMDBuffer) {
-    if (value == NULL) {
-        PyErr_SetString(PyExc_RuntimeError, "TMDBuffer cannot be deleted");
-        return -1;
-    } else if (value == Py_None) {
+    PY_PROPERTY_CHECK_NULL(TMDBuffer)
+    if (value == Py_None) {
         self->fThis->setTMDBuffer(0, NULL);
         return 0;
     } else if (!PyBytes_Check(value)) {

--- a/Python/PRP/Region/pyBounds.h
+++ b/Python/PRP/Region/pyBounds.h
@@ -34,10 +34,8 @@ PyObject* ICreateBounds(const class hsBounds&);
 
 #define PY_PROPERTY_BOUNDS_WRITE(pyType, myType, name, setter)          \
     PY_GETSET_SETTER_DECL(myType, name) {                               \
-        if (value == NULL) {                                            \
-            PyErr_SetString(PyExc_RuntimeError, #name " cannot be deleted"); \
-            return -1;                                                  \
-        } else if (!py##pyType##_Check(value)) {                        \
+        PY_PROPERTY_CHECK_NULL(name)                                    \
+        if (!py##pyType##_Check(value)) {                               \
             PyErr_SetString(PyExc_TypeError, #name " expected type hs" #pyType); \
             return -1;                                                  \
         }                                                               \

--- a/Python/PRP/Region/pyBounds3Ext.cpp
+++ b/Python/PRP/Region/pyBounds3Ext.cpp
@@ -94,10 +94,8 @@ PyMethodDef pyBounds3Ext_Methods[] = {
         return pyPlasma_convert(self->fThis->getAxis(id));              \
     }                                                                   \
     PY_GETSET_SETTER_DECL(Bounds3Ext, axis##id) {                       \
-        if (value == NULL) {                                            \
-            PyErr_SetString(PyExc_RuntimeError, "axis" #id " cannot be deleted"); \
-            return -1;                                                  \
-        } else if (!pyPlasma_check<hsVector3>(value)) {                 \
+        PY_PROPERTY_CHECK_NULL(axis##id)                                \
+        if (!pyPlasma_check<hsVector3>(value)) {                        \
             PyErr_SetString(PyExc_TypeError, "axis" #id " expected type hsVector3"); \
             return -1;                                                  \
         }                                                               \
@@ -116,10 +114,8 @@ BOUNDS_GETSET_AXIS(2)
         return Py_BuildValue("ff", dist.X, dist.Y);                     \
     }                                                                   \
     PY_GETSET_SETTER_DECL(Bounds3Ext, dist##id) {                       \
-        if (value == NULL) {                                            \
-            PyErr_SetString(PyExc_RuntimeError, "dist" #id " cannot be deleted"); \
-            return -1;                                                  \
-        } else if (!PyTuple_Check(value) || (PyTuple_Size(value) != 2)) { \
+        PY_PROPERTY_CHECK_NULL(dist##id)                                \
+        if (!PyTuple_Check(value) || (PyTuple_Size(value) != 2)) {      \
             PyErr_SetString(PyExc_TypeError, "dist" #id " expected type tuple(float, float)"); \
             return -1;                                                  \
         }                                                               \

--- a/Python/PRP/Region/pySoftVolumeComplex.cpp
+++ b/Python/PRP/Region/pySoftVolumeComplex.cpp
@@ -33,7 +33,7 @@ PY_METHOD_VA(SoftVolumeComplex, addSubVolume,
         PyErr_SetString(PyExc_TypeError, "addSubVolume expects a plKey");
         return NULL;
     }
-    self->fThis->addSubVolume(*((pyKey*)key)->fThis);
+    self->fThis->addSubVolume(pyPlasma_get<plKey>(key));
     Py_RETURN_NONE;
 }
 
@@ -68,7 +68,7 @@ static PyMethodDef pySoftVolumeComplex_Methods[] = {
     PY_METHOD_TERMINATOR
 };
 
-static PyObject* pySoftVolumeComplex_getSubVolumes(pySoftVolumeComplex* self, void*) {
+PY_GETSET_GETTER_DECL(SoftVolumeComplex, subVolumes) {
     const std::vector<plKey>& sv = self->fThis->getSubVolumes();
     PyObject* tup = PyTuple_New(sv.size());
     for (size_t i = 0; i < sv.size(); ++i)
@@ -76,14 +76,11 @@ static PyObject* pySoftVolumeComplex_getSubVolumes(pySoftVolumeComplex* self, vo
     return tup;
 }
 
-static int pySoftVolumeComplex_setSubVolumes(pySoftVolumeComplex*, PyObject*, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "To add subvolumes, use addSubVolume");
-    return -1;
-}
+PY_PROPERTY_SETTER_MSG(SoftVolumeComplex, subVolumes, "To add subvolumes, use addSubVolume")
+PY_PROPERTY_GETSET_DECL(SoftVolumeComplex, subVolumes)
 
 PyGetSetDef pySoftVolumeComplex_GetSet[] = {
-    { _pycs("subVolumes"), (getter)pySoftVolumeComplex_getSubVolumes,
-      (setter)pySoftVolumeComplex_setSubVolumes, NULL, NULL },
+    pySoftVolumeComplex_subVolumes_getset,
     PY_GETSET_TERMINATOR
 };
 

--- a/Python/PRP/Surface/pyBitmap.cpp
+++ b/Python/PRP/Surface/pyBitmap.cpp
@@ -56,10 +56,8 @@ PY_GETSET_GETTER_DECL(Bitmap, modTime) {
 }
 
 PY_GETSET_SETTER_DECL(Bitmap, modTime) {
-    if (value == NULL) {
-        PyErr_SetString(PyExc_RuntimeError, "modTime cannot be deleted");
-        return -1;
-    } else if (!PyTuple_Check(value) || (PyTuple_Size(value) != 2)) {
+    PY_PROPERTY_CHECK_NULL(modTime)
+    if (!PyTuple_Check(value) || (PyTuple_Size(value) != 2)) {
         PyErr_SetString(PyExc_TypeError, "modTime should be a tuple (int, int)");
         return -1;
     }

--- a/Python/PRP/Surface/pyCubicEnvironmap.cpp
+++ b/Python/PRP/Surface/pyCubicEnvironmap.cpp
@@ -29,11 +29,9 @@ PY_PLASMA_NEW(CubicEnvironmap, plCubicEnvironmap)
         return ICreate(self->fThis->getFace(plCubicEnvironmap::Faces::k##faceName##Face)); \
     }                                                                   \
     PY_GETSET_SETTER_DECL(CubicEnvironmap, propName) {                  \
-        if (value == NULL) {                                            \
-            PyErr_SetString(PyExc_RuntimeError, #propName " cannot be deleted"); \
-            return -1;                                                  \
-        } else if (!pyMipmap_Check(value)) {                            \
-            PyErr_SetString(PyExc_TypeError, #propName " should be a plMipmap"); \
+        PY_PROPERTY_CHECK_NULL(propName)                                \
+        if (!pyMipmap_Check(value)) {                                   \
+            PyErr_SetString(PyExc_TypeError, #propName " expected type plMipmap"); \
             return -1;                                                  \
         }                                                               \
         self->fThis->setFace(plCubicEnvironmap::Faces::k##faceName##Face, \

--- a/Python/PRP/Surface/pyDistOpacityMod.cpp
+++ b/Python/PRP/Surface/pyDistOpacityMod.cpp
@@ -28,10 +28,8 @@ PY_PLASMA_NEW(DistOpacityMod, plDistOpacityMod)
         return pyPlasma_convert(self->fThis->getDistance(plDistOpacityMod::distEnum)); \
     }                                                                   \
     PY_GETSET_SETTER_DECL(DistOpacityMod, propName) {                   \
-        if (value == NULL) {                                            \
-            PyErr_SetString(PyExc_RuntimeError, #propName " cannot be deleted"); \
-            return -1;                                                  \
-        } else if (!pyPlasma_check<float>(value)) {                     \
+        PY_PROPERTY_CHECK_NULL(propName)                                \
+        if (!pyPlasma_check<float>(value)) {                            \
             PyErr_SetString(PyExc_TypeError, #propName " expected type float"); \
             return -1;                                                  \
         }                                                               \

--- a/Python/PRP/Surface/pyDynamicCamMap.cpp
+++ b/Python/PRP/Surface/pyDynamicCamMap.cpp
@@ -35,7 +35,7 @@ PY_METHOD_VA(DynamicCamMap, addMatLayer,
         PyErr_SetString(PyExc_TypeError, "addMatLayer expects a plKey");
         return NULL;
     }
-    self->fThis->addMatLayer(*((pyKey*)key)->fThis);
+    self->fThis->addMatLayer(pyPlasma_get<plKey>(key));
     Py_RETURN_NONE;
 }
 
@@ -66,7 +66,7 @@ PY_METHOD_VA(DynamicCamMap, addTargetNode,
         PyErr_SetString(PyExc_TypeError, "addTargetNode expects a plKey");
         return NULL;
     }
-    self->fThis->addTargetNode(*((pyKey*)key)->fThis);
+    self->fThis->addTargetNode(pyPlasma_get<plKey>(key));
     Py_RETURN_NONE;
 }
 
@@ -99,7 +99,7 @@ PY_METHOD_VA(DynamicCamMap, addVisRegion,
         PyErr_SetString(PyExc_TypeError, "addVisRegion expects a plKey");
         return NULL;
     }
-    self->fThis->addVisRegion(*((pyKey*)key)->fThis);
+    self->fThis->addVisRegion(pyPlasma_get<plKey>(key));
     Py_RETURN_NONE;
 }
 
@@ -128,11 +128,11 @@ PY_METHOD_VA(DynamicCamMap, addVisRegionName,
     "Adds a VisRegion name")
 {
     PyObject* name;
-    if (!(PyArg_ParseTuple(args, "O", &name) && PyAnyStr_Check(name))) {
+    if (!(PyArg_ParseTuple(args, "O", &name) && pyPlasma_check<plString>(name))) {
         PyErr_SetString(PyExc_TypeError, "addVisRegionName expects a string");
         return NULL;
     }
-    self->fThis->addVisRegionName(PyStr_To_PlStr(name));
+    self->fThis->addVisRegionName(pyPlasma_get<plString>(name));
     Py_RETURN_NONE;
 }
 
@@ -156,118 +156,6 @@ PY_METHOD_VA(DynamicCamMap, delVisRegionName,
     Py_RETURN_NONE;
 }
 
-static PyObject* pyDynamicCamMap_getVisRegions(pyDynamicCamMap* self, void*) {
-    const std::vector<plKey>& keys = self->fThis->getVisRegions();
-    PyObject* regionList = PyList_New(keys.size());
-    for (size_t i=0; i<keys.size(); i++)
-        PyList_SET_ITEM(regionList, i, pyKey_FromKey(keys[i]));
-    return regionList;
-}
-
-static PyObject* pyDynamicCamMap_getTargetNodes(pyDynamicCamMap* self, void*) {
-    const std::vector<plKey>& keys = self->fThis->getTargetNodes();
-    PyObject* nodeList = PyList_New(keys.size());
-    for (size_t i=0; i<keys.size(); i++)
-        PyList_SET_ITEM(nodeList, i, pyKey_FromKey(keys[i]));
-    return nodeList;
-}
-
-static PyObject* pyDynamicCamMap_getMatLayers(pyDynamicCamMap* self, void*) {
-    const std::vector<plKey>& keys = self->fThis->getMatLayers();
-    PyObject* layerList = PyList_New(keys.size());
-    for (size_t i=0; i<keys.size(); i++)
-        PyList_SET_ITEM(layerList, i, pyKey_FromKey(keys[i]));
-    return layerList;
-}
-
-static PyObject* pyDynamicCamMap_getVisRegionNames(pyDynamicCamMap* self, void*) {
-    const std::vector<plString>& names = self->fThis->getVisRegionNames();
-    PyObject* regionNameList = PyList_New(names.size());
-    for (size_t i=0; i<names.size(); i++)
-        PyList_SET_ITEM(regionNameList, i, PlasmaString_To_PyString(names[i]));
-    return regionNameList;
-}
-
-static int pyDynamicCamMap_setVisRegions(pyDynamicCamMap* self, PyObject* value, void*) {
-    if (value == NULL || !PySequence_Check(value)) {
-        PyErr_SetString(PyExc_TypeError, "visRegions should be a sequence of plKeys");
-        return -1;
-    }
-    std::vector<plKey> regions;
-    regions.resize(PySequence_Size(value));
-    for (Py_ssize_t i=0; i<PySequence_Size(value); i++) {
-        PyObject* region = PySequence_GetItem(value, i);
-        if (pyKey_Check(region)){
-            regions[i] = *(reinterpret_cast<pyKey *>(region)->fThis);
-        } else {
-            PyErr_SetString(PyExc_TypeError, "visRegions should be a sequence of plKeys");
-            return -1;
-        }
-    }
-    self->fThis->setVisRegions(regions);
-    return 0;
-}
-
-static int pyDynamicCamMap_setTargetNodes(pyDynamicCamMap* self, PyObject* value, void*) {
-    if (value == NULL || !PySequence_Check(value)) {
-        PyErr_SetString(PyExc_TypeError, "targetNodes should be a sequence of plKeys");
-        return -1;
-    }
-    std::vector<plKey> nodes;
-    nodes.resize(PySequence_Size(value));
-    for (Py_ssize_t i=0; i<PySequence_Size(value); i++) {
-        PyObject* node = PySequence_GetItem(value, i);
-        if (pyKey_Check(node)){
-            nodes[i] = *(reinterpret_cast<pyKey *>(node)->fThis);
-        } else {
-            PyErr_SetString(PyExc_TypeError, "targetNodes should be a sequence of plKeys");
-            return -1;
-        }
-    }
-    self->fThis->setTargetNodes(nodes);
-    return 0;
-}
-
-static int pyDynamicCamMap_setMatLayers(pyDynamicCamMap* self, PyObject* value, void*) {
-    if (value == NULL || !PySequence_Check(value)) {
-        PyErr_SetString(PyExc_TypeError, "matLayers should be a sequence of plKeys");
-        return -1;
-    }
-    std::vector<plKey> layers;
-    layers.resize(PySequence_Size(value));
-    for (Py_ssize_t i=0; i<PySequence_Size(value); i++) {
-        PyObject* layer = PySequence_GetItem(value, i);
-        if (pyKey_Check(layer)){
-            layers[i] = *(reinterpret_cast<pyKey *>(layer)->fThis);
-        } else {
-            PyErr_SetString(PyExc_TypeError, "matLayers should be a sequence of plKeys");
-            return -1;
-        }
-    }
-    self->fThis->setMatLayers(layers);
-    return 0;
-}
-
-static int pyDynamicCamMap_setVisRegionNames(pyDynamicCamMap* self, PyObject* value, void*) {
-    if (value == NULL || !PySequence_Check(value)) {
-        PyErr_SetString(PyExc_TypeError, "visRegionNames should be a sequence of strings");
-        return -1;
-    }
-    std::vector<plString> names;
-    names.resize(PySequence_Size(value));
-    for (Py_ssize_t i=0; i<PySequence_Size(value); i++) {
-        PyObject* name = PySequence_GetItem(value, i);
-        if (PyAnyStr_Check(name)) {
-            names[i] = PyString_To_PlasmaString(name);
-        } else {
-            PyErr_SetString(PyExc_TypeError, "visRegionNames should be a sequence of strings");
-            return -1;
-        }
-    }
-    self->fThis->setVisRegionNames(names);
-    return 0;
-}
-
 static PyMethodDef pyDynamicCamMap_Methods[] = {
     pyDynamicCamMap_addMatLayer_method,
     pyDynamicCamMap_clearMatLayers_method,
@@ -283,6 +171,134 @@ static PyMethodDef pyDynamicCamMap_Methods[] = {
     pyDynamicCamMap_delVisRegionName_method,
     PY_METHOD_TERMINATOR
 };
+
+PY_GETSET_GETTER_DECL(DynamicCamMap, visRegions) {
+    const std::vector<plKey>& keys = self->fThis->getVisRegions();
+    PyObject* regionList = PyTuple_New(keys.size());
+    for (size_t i=0; i<keys.size(); i++)
+        PyTuple_SET_ITEM(regionList, i, pyPlasma_convert(keys[i]));
+    return regionList;
+}
+
+PY_GETSET_SETTER_DECL(DynamicCamMap, visRegions) {
+    PY_PROPERTY_CHECK_NULL(visRegions)
+    pySequenceFastRef seq(value);
+    if (!seq.isSequence()) {
+        PyErr_SetString(PyExc_TypeError, "visRegions should be a sequence of plKeys");
+        return -1;
+    }
+    Py_ssize_t count = seq.size();
+    std::vector<plKey> regions(count);
+    for (Py_ssize_t i=0; i<count; i++) {
+        PyObject* region = seq.get(i);
+        if (pyKey_Check(region)) {
+            regions[i] = pyPlasma_get<plKey>(region);
+        } else {
+            PyErr_SetString(PyExc_TypeError, "visRegions should be a sequence of plKeys");
+            return -1;
+        }
+    }
+    self->fThis->setVisRegions(regions);
+    return 0;
+}
+
+PY_PROPERTY_GETSET_DECL(DynamicCamMap, visRegions)
+
+PY_GETSET_GETTER_DECL(DynamicCamMap, targetNodes) {
+    const std::vector<plKey>& keys = self->fThis->getTargetNodes();
+    PyObject* nodeList = PyTuple_New(keys.size());
+    for (size_t i=0; i<keys.size(); i++)
+        PyTuple_SET_ITEM(nodeList, i, pyPlasma_convert(keys[i]));
+    return nodeList;
+}
+
+PY_GETSET_SETTER_DECL(DynamicCamMap, targetNodes) {
+    PY_PROPERTY_CHECK_NULL(targetNodes)
+    pySequenceFastRef seq(value);
+    if (!seq.isSequence()) {
+        PyErr_SetString(PyExc_TypeError, "targetNodes should be a sequence of plKeys");
+        return -1;
+    }
+    Py_ssize_t count = seq.size();
+    std::vector<plKey> nodes(count);
+    for (Py_ssize_t i=0; i<count; i++) {
+        PyObject* node = seq.get(i);
+        if (pyKey_Check(node)){
+            nodes[i] = pyPlasma_get<plKey>(node);
+        } else {
+            PyErr_SetString(PyExc_TypeError, "targetNodes should be a sequence of plKeys");
+            return -1;
+        }
+    }
+    self->fThis->setTargetNodes(nodes);
+    return 0;
+}
+
+PY_PROPERTY_GETSET_DECL(DynamicCamMap, targetNodes)
+
+PY_GETSET_GETTER_DECL(DynamicCamMap, matLayers) {
+    const std::vector<plKey>& keys = self->fThis->getMatLayers();
+    PyObject* layerList = PyTuple_New(keys.size());
+    for (size_t i=0; i<keys.size(); i++)
+        PyTuple_SET_ITEM(layerList, i, pyPlasma_convert(keys[i]));
+    return layerList;
+}
+
+PY_GETSET_SETTER_DECL(DynamicCamMap, matLayers) {
+    PY_PROPERTY_CHECK_NULL(matLayers)
+    pySequenceFastRef seq(value);
+    if (!seq.isSequence()) {
+        PyErr_SetString(PyExc_TypeError, "matLayers should be a sequence of plKeys");
+        return -1;
+    }
+    Py_ssize_t count = seq.size();
+    std::vector<plKey> layers(count);
+    for (Py_ssize_t i=0; i<count; i++) {
+        PyObject* layer = seq.get(i);
+        if (pyKey_Check(layer)){
+            layers[i] = pyPlasma_get<plKey>(layer);
+        } else {
+            PyErr_SetString(PyExc_TypeError, "matLayers should be a sequence of plKeys");
+            return -1;
+        }
+    }
+    self->fThis->setMatLayers(layers);
+    return 0;
+}
+
+PY_PROPERTY_GETSET_DECL(DynamicCamMap, matLayers)
+
+PY_GETSET_GETTER_DECL(DynamicCamMap, visRegionNames) {
+    const std::vector<plString>& names = self->fThis->getVisRegionNames();
+    PyObject* regionNameList = PyTuple_New(names.size());
+    for (size_t i=0; i<names.size(); i++)
+        PyTuple_SET_ITEM(regionNameList, i, pyPlasma_convert(names[i]));
+    return regionNameList;
+}
+
+PY_GETSET_SETTER_DECL(DynamicCamMap, visRegionNames) {
+    PY_PROPERTY_CHECK_NULL(visRegionNames)
+    pySequenceFastRef seq(value);
+    if (!seq.isSequence()) {
+        PyErr_SetString(PyExc_TypeError, "visRegionNames should be a sequence of strings");
+        return -1;
+    }
+    Py_ssize_t count = seq.size();
+    std::vector<plString> names(count);
+    for (Py_ssize_t i=0; i<count; i++) {
+        PyObject* name = seq.get(i);
+        if (pyPlasma_check<plString>(name)) {
+            names[i] = pyPlasma_get<plString>(name);
+        } else {
+            PyErr_SetString(PyExc_TypeError, "visRegionNames should be a sequence of strings");
+            return -1;
+        }
+    }
+    self->fThis->setVisRegionNames(names);
+    return 0;
+}
+
+PY_PROPERTY_GETSET_DECL(DynamicCamMap, visRegionNames)
 
 PY_PROPERTY(float, DynamicCamMap, hither, getHither, setHither)
 PY_PROPERTY(float, DynamicCamMap, yon, getYon, setYon)
@@ -301,10 +317,10 @@ static PyGetSetDef pyDynamicCamMap_GetSet[] = {
     pyDynamicCamMap_fogStart_getset,
     pyDynamicCamMap_color_getset,
     pyDynamicCamMap_refreshRate_getset,
-    { _pycs("visRegions"), (getter)pyDynamicCamMap_getVisRegions, (setter)pyDynamicCamMap_setVisRegions, NULL, NULL },
-    { _pycs("targetNodes"), (getter)pyDynamicCamMap_getTargetNodes, (setter)pyDynamicCamMap_setTargetNodes, NULL, NULL },
-    { _pycs("matLayers"), (getter)pyDynamicCamMap_getMatLayers, (setter)pyDynamicCamMap_setMatLayers, NULL, NULL },
-    { _pycs("visRegionNames"), (getter)pyDynamicCamMap_getVisRegionNames, (setter)pyDynamicCamMap_setVisRegionNames, NULL, NULL },
+    pyDynamicCamMap_visRegions_getset,
+    pyDynamicCamMap_targetNodes_getset,
+    pyDynamicCamMap_matLayers_getset,
+    pyDynamicCamMap_visRegionNames_getset,
     pyDynamicCamMap_incCharacters_getset,
     pyDynamicCamMap_camera_getset,
     pyDynamicCamMap_rootNode_getset,

--- a/Python/PRP/Surface/pyDynamicEnvMap.cpp
+++ b/Python/PRP/Surface/pyDynamicEnvMap.cpp
@@ -48,7 +48,8 @@ static PyObject* pyDynamicEnvMap_getVisRegionNames(pyDynamicEnvMap* self, void*)
 }
 
 static int pyDynamicEnvMap_setVisRegions(pyDynamicEnvMap* self, PyObject* value, void*) {
-    if (value == NULL || !PySequence_Check(value)) {
+    PY_PROPERTY_CHECK_NULL(visRegions)
+    if (!PySequence_Check(value)) {
         PyErr_SetString(PyExc_TypeError, "visRegions should be a sequence of plKeys");
         return -1;
     }
@@ -57,7 +58,7 @@ static int pyDynamicEnvMap_setVisRegions(pyDynamicEnvMap* self, PyObject* value,
     for (Py_ssize_t i=0; i<PySequence_Size(value); i++) {
         PyObject* region = PySequence_GetItem(value, i);
         if (pyKey_Check(region)){
-            regions[i] = *(reinterpret_cast<pyKey *>(region)->fThis);
+            regions[i] = pyPlasma_get<plKey>(region);
         } else {
             PyErr_SetString(PyExc_TypeError, "visRegions should be a sequence of plKeys");
             return -1;
@@ -68,7 +69,8 @@ static int pyDynamicEnvMap_setVisRegions(pyDynamicEnvMap* self, PyObject* value,
 }
 
 static int pyDynamicEnvMap_setVisRegionNames(pyDynamicEnvMap* self, PyObject* value, void*) {
-    if (value == NULL || !PySequence_Check(value)) {
+    PY_PROPERTY_CHECK_NULL(visRegionNames)
+    if (!PySequence_Check(value)) {
         PyErr_SetString(PyExc_TypeError, "visRegionNames should be a sequence of strings");
         return -1;
     }

--- a/Python/PRP/Surface/pyFadeOpacityMod.cpp
+++ b/Python/PRP/Surface/pyFadeOpacityMod.cpp
@@ -32,10 +32,8 @@ PY_GETSET_GETTER_DECL(FadeOpacityMod, boundsCenter) {
 }
 
 PY_GETSET_SETTER_DECL(FadeOpacityMod, boundsCenter) {
-    if (value == NULL) {
-        PyErr_SetString(PyExc_RuntimeError, "boundsCenter cannot be deleted");
-        return -1;
-    } else if (!pyPlasma_check<bool>(value)) {
+    PY_PROPERTY_CHECK_NULL(boundsCenter)
+    if (!pyPlasma_check<bool>(value)) {
         PyErr_SetString(PyExc_TypeError, "boundsCenter should be a bool");
         return -1;
     }

--- a/Python/PRP/Surface/pyGMaterial.cpp
+++ b/Python/PRP/Surface/pyGMaterial.cpp
@@ -97,30 +97,6 @@ PY_METHOD_VA(GMaterial, delPiggyBack,
     Py_RETURN_NONE;
 }
 
-static PyObject* pyGMaterial_getLayers(pyGMaterial* self, void*) {
-    PyObject* list = PyList_New(self->fThis->getLayers().size());
-    for (size_t i=0; i<self->fThis->getLayers().size(); i++)
-        PyList_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getLayers()[i]));
-    return list;
-}
-
-static PyObject* pyGMaterial_getPBs(pyGMaterial* self, void*) {
-    PyObject* list = PyList_New(self->fThis->getPiggyBacks().size());
-    for (size_t i=0; i<self->fThis->getPiggyBacks().size(); i++)
-        PyList_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getPiggyBacks()[i]));
-    return list;
-}
-
-static int pyGMaterial_setLayers(pyGMaterial* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "To add layers, use addLayer()");
-    return -1;
-}
-
-static int pyGMaterial_setPBs(pyGMaterial* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "To add piggy-backs, use addPiggyBack()");
-    return -1;
-}
-
 static PyMethodDef pyGMaterial_Methods[] = {
     pyGMaterial_clearLayers_method,
     pyGMaterial_addLayer_method,
@@ -131,14 +107,32 @@ static PyMethodDef pyGMaterial_Methods[] = {
     PY_METHOD_TERMINATOR
 };
 
+PY_GETSET_GETTER_DECL(GMaterial, layers) {
+    PyObject* list = PyTuple_New(self->fThis->getLayers().size());
+    for (size_t i=0; i<self->fThis->getLayers().size(); i++)
+        PyTuple_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getLayers()[i]));
+    return list;
+}
+
+PY_PROPERTY_SETTER_MSG(GMaterial, layers, "To add layers, use addLayer()")
+PY_PROPERTY_GETSET_DECL(GMaterial, layers)
+
+PY_GETSET_GETTER_DECL(GMaterial, piggyBacks) {
+    PyObject* list = PyTuple_New(self->fThis->getPiggyBacks().size());
+    for (size_t i=0; i<self->fThis->getPiggyBacks().size(); i++)
+        PyTuple_SET_ITEM(list, i, pyKey_FromKey(self->fThis->getPiggyBacks()[i]));
+    return list;
+}
+
+PY_PROPERTY_SETTER_MSG(GMaterial, piggyBacks, "To add piggy-backs, use addPiggyBack()")
+PY_PROPERTY_GETSET_DECL(GMaterial, piggyBacks)
+
 PY_PROPERTY(unsigned int, GMaterial, compFlags, getCompFlags, setCompFlags)
 PY_PROPERTY(unsigned int, GMaterial, loadFlags, getLoadFlags, setLoadFlags)
 
 static PyGetSetDef pyGMaterial_GetSet[] = {
-    { _pycs("layers"), (getter)pyGMaterial_getLayers,
-        (setter)pyGMaterial_setLayers, NULL, NULL },
-    { _pycs("piggyBacks"), (getter)pyGMaterial_getPBs,
-        (setter)pyGMaterial_setPBs, NULL, NULL },
+    pyGMaterial_layers_getset,
+    pyGMaterial_piggyBacks_getset,
     pyGMaterial_compFlags_getset,
     pyGMaterial_loadFlags_getset,
     PY_GETSET_TERMINATOR

--- a/Python/PRP/Surface/pyRenderTarget.cpp
+++ b/Python/PRP/Surface/pyRenderTarget.cpp
@@ -38,11 +38,7 @@ PY_PROPERTY(bool, RenderTarget, proportionalViewport, getProportionalViewport,
             return pyPlasma_convert(rt->getAbsoluteViewport##direction()); \
     }                                                                   \
     PY_GETSET_SETTER_DECL(RenderTarget, viewport##direction) {          \
-        if (value == NULL) {                                            \
-            PyErr_SetString(PyExc_RuntimeError,                         \
-                            "viewport" #direction " cannot be deleted"); \
-            return -1;                                                  \
-        }                                                               \
+        PY_PROPERTY_CHECK_NULL(viewport##direction)                     \
         plRenderTarget* rt = self->fThis;                               \
         if (rt->getProportionalViewport()) {                            \
             if (!pyPlasma_check<float>(value)) {                        \

--- a/Python/PRP/Surface/pyWaveSet7.cpp
+++ b/Python/PRP/Surface/pyWaveSet7.cpp
@@ -104,7 +104,7 @@ static PyMethodDef pyWaveSet7_Methods[] = {
     PY_METHOD_TERMINATOR
 };
 
-static PyObject* pyWaveSet7_getShores(pyWaveSet7* self, void*) {
+PY_GETSET_GETTER_DECL(WaveSet7, shores) {
     const std::vector<plKey>& shores = self->fThis->getShores();
     PyObject* tuple = PyTuple_New(shores.size());
     for (size_t i = 0; i < shores.size(); ++i)
@@ -112,7 +112,10 @@ static PyObject* pyWaveSet7_getShores(pyWaveSet7* self, void*) {
     return tuple;
 }
 
-static PyObject* pyWaveSet7_getDecals(pyWaveSet7* self, void*) {
+PY_PROPERTY_SETTER_MSG(WaveSet7, shores, "To add shores, use addShore")
+PY_PROPERTY_GETSET_DECL(WaveSet7, shores)
+
+PY_GETSET_GETTER_DECL(WaveSet7, decals) {
     const std::vector<plKey>& decals = self->fThis->getDecals();
     PyObject* tuple = PyTuple_New(decals.size());
     for (size_t i = 0; i < decals.size(); ++i)
@@ -120,15 +123,8 @@ static PyObject* pyWaveSet7_getDecals(pyWaveSet7* self, void*) {
     return tuple;
 }
 
-static int pyWaveSet7_setShores(pyWaveSet7* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "to add shores, use addShore");
-    return -1;
-}
-
-static int pyWaveSet7_setDecals(pyWaveSet7* self, PyObject* value, void*) {
-    PyErr_SetString(PyExc_RuntimeError, "to add decals, use addDecal");
-    return -1;
-}
+PY_PROPERTY_SETTER_MSG(WaveSet7, decals, "To add decals, use addDecal")
+PY_PROPERTY_GETSET_DECL(WaveSet7, decals)
 
 PY_PROPERTY_PROXY(plFixedWaterState7, WaveSet7, state, getState)
 PY_PROPERTY(float, WaveSet7, maxLen, getMaxLen, setMaxLen)
@@ -137,8 +133,8 @@ PY_PROPERTY(plKey, WaveSet7, refObj, getRefObj, setRefObj)
 
 static PyGetSetDef pyWaveSet7_GetSet[] = {
     pyWaveSet7_state_getset,
-    { _pycs("shores"), (getter)pyWaveSet7_getShores, (setter)pyWaveSet7_setShores, NULL, NULL },
-    { _pycs("decals"), (getter)pyWaveSet7_getDecals, (setter)pyWaveSet7_setDecals, NULL, NULL },
+    pyWaveSet7_shores_getset,
+    pyWaveSet7_decals_getset,
     pyWaveSet7_maxLen_getset,
     pyWaveSet7_envMap_getset,
     pyWaveSet7_refObj_getset,

--- a/Python/PRP/pyCreatable.h
+++ b/Python/PRP/pyCreatable.h
@@ -32,10 +32,8 @@ PyObject* ICreate(class plCreatable* pCre);
 
 #define PY_PROPERTY_CREATABLE_WRITE(plType, pyType, myType, name, setter) \
     PY_GETSET_SETTER_DECL(myType, name) {                               \
-        if (value == NULL) {                                            \
-            PyErr_SetString(PyExc_RuntimeError, #name " cannot be deleted"); \
-            return -1;                                                  \
-        } else if (value == Py_None) {                                  \
+        PY_PROPERTY_CHECK_NULL(name)                                    \
+        if (value == Py_None) {                                         \
             self->fThis->setter(NULL);                                  \
             return 0;                                                   \
         } else if (!py##pyType##_Check(value)) {                        \
@@ -63,10 +61,8 @@ PyObject* ICreate(class plCreatable* pCre);
 
 #define PY_PROPERTY_CREATABLE_MEMBER_WRITE(plType, pyType, myType, name, member) \
     PY_GETSET_SETTER_DECL(myType, name) {                               \
-        if (value == NULL) {                                            \
-            PyErr_SetString(PyExc_RuntimeError, #name " cannot be deleted"); \
-            return -1;                                                  \
-        } else if (value == Py_None) {                                  \
+        PY_PROPERTY_CHECK_NULL(name)                                    \
+        if (value == Py_None) {                                         \
             self->fThis->member = NULL;                                 \
             return 0;                                                   \
         } else if (!py##pyType##_Check(value)) {                        \

--- a/Python/PyPlasma.cpp
+++ b/Python/PyPlasma.cpp
@@ -17,15 +17,15 @@
 #include "PyPlasma.h"
 #include <unordered_set>
 
-PyObject* PlasmaString_To_PyString(const plString& str) {
+PyObject* PyString_FromPlasmaString(const plString& str) {
     return PyString_FromString(str.cstr());
 }
 
-PyObject* PlasmaString_To_PyUnicode(const plString& str) {
+PyObject* PyUnicode_FromPlasmaString(const plString& str) {
     return PyUnicode_DecodeUTF8(str.cstr(), str.len(), NULL);
 }
 
-plString PyString_To_PlasmaString(PyObject* str) {
+plString PyAnyString_AsPlasmaString(PyObject* str) {
     if (PyUnicode_Check(str)) {
         PyObject* utfStr = PyUnicode_AsUTF8String(str);
         plString plstr = PyBytes_AsString(utfStr);

--- a/Python/PyPlasma.h
+++ b/Python/PyPlasma.h
@@ -33,6 +33,24 @@ int PyType_CheckAndReady(PyTypeObject* type);
 template <size_t size>
 inline char* _pycs(const char (&str)[size]) { return const_cast<char*>(str); }
 
+/* Helper object for managing and accessing the reference that is returned by
+ * PySequence_Fast() to allow fast access to arbitrary sequence-type objects */
+struct pySequenceFastRef
+{
+    PyObject* fObj;
+
+    pySequenceFastRef(PyObject* o)
+        : fObj(PySequence_Fast(o, "Object is not a sequence")) { }
+    ~pySequenceFastRef() { Py_XDECREF(fObj); }
+
+    bool isSequence() const { return fObj != NULL; }
+
+    Py_ssize_t size() { return PySequence_Fast_GET_SIZE(fObj); }
+
+    /** Returns a borrowed reference within the sequence FAST storage */
+    PyObject* get(Py_ssize_t idx) { return PySequence_Fast_GET_ITEM(fObj, idx); }
+};
+
 // Python 3.x does things differently...  This should help to keep things
 // under control with both 2.x and 3.0 somewhat seamlessly.
 #if (PY_MAJOR_VERSION >= 3)

--- a/Python/PyPlasma.h
+++ b/Python/PyPlasma.h
@@ -350,12 +350,18 @@ template <> inline plKeyDef pyPlasma_get(PyObject* value) { return (plKeyDef)PyI
         return pyPlasma_convert(self->fThis->getter());                 \
     }
 
+/* Place this at the beginning of a property SETTER to ensure the value
+ * is not NULL (i.e. that the caller didn't try to delete the property) */
+#define PY_PROPERTY_CHECK_NULL(name)                                    \
+    if (value == NULL) {                                                \
+        PyErr_SetString(PyExc_RuntimeError, #name " cannot be deleted"); \
+        return -1;                                                      \
+    }
+
 #define PY_PROPERTY_WRITE(type, pyType, name, setter)                   \
     PY_GETSET_SETTER_DECL(pyType, name) {                               \
-        if (value == NULL) {                                            \
-            PyErr_SetString(PyExc_RuntimeError, #name " cannot be deleted"); \
-            return -1;                                                  \
-        } else if (!pyPlasma_check<type>(value)) {                      \
+        PY_PROPERTY_CHECK_NULL(name)                                    \
+        if (!pyPlasma_check<type>(value)) {                             \
             PyErr_SetString(PyExc_TypeError, #name " expected type " #type); \
             return -1;                                                  \
         }                                                               \
@@ -389,10 +395,8 @@ template <> inline plKeyDef pyPlasma_get(PyObject* value) { return (plKeyDef)PyI
 
 #define PY_PROPERTY_MEMBER_WRITE(type, pyType, name, member)            \
     PY_GETSET_SETTER_DECL(pyType, name) {                               \
-        if (value == NULL) {                                            \
-            PyErr_SetString(PyExc_RuntimeError, #name " cannot be deleted"); \
-            return -1;                                                  \
-        } else if (!pyPlasma_check<type>(value)) {                      \
+        PY_PROPERTY_CHECK_NULL(name)                                    \
+        if (!pyPlasma_check<type>(value)) {                             \
             PyErr_SetString(PyExc_TypeError, #name " expected type " #type); \
             return -1;                                                  \
         }                                                               \
@@ -414,10 +418,8 @@ template <> inline plKeyDef pyPlasma_get(PyObject* value) { return (plKeyDef)PyI
 
 #define PY_PROPERTY_PROXY_WRITE(type, pyType, name, getter)             \
     PY_GETSET_SETTER_DECL(pyType, name) {                               \
-        if (value == NULL) {                                            \
-            PyErr_SetString(PyExc_RuntimeError, #name " cannot be deleted"); \
-            return -1;                                                  \
-        } else if (!pyPlasma_check<type>(value)) {                      \
+        PY_PROPERTY_CHECK_NULL(name)                                    \
+        if (!pyPlasma_check<type>(value)) {                             \
             PyErr_SetString(PyExc_TypeError, #name " expected type " #type); \
             return -1;                                                  \
         }                                                               \

--- a/Python/ResManager/pyAgeInfo.cpp
+++ b/Python/ResManager/pyAgeInfo.cpp
@@ -261,9 +261,9 @@ PY_PLASMA_TYPE_INIT(AgeInfo) {
     PY_TYPE_ADD_CONST(AgeInfo, "kPageGlobal", plAgeInfo::kGlobal);
     PY_TYPE_ADD_CONST(AgeInfo, "kNumCommonPages", plAgeInfo::kNumCommonPages);
 
-    PyObject* list = PyList_New(plAgeInfo::kNumCommonPages);
+    PyObject* list = PyTuple_New(plAgeInfo::kNumCommonPages);
     for (size_t i=0; i<plAgeInfo::kNumCommonPages; i++)
-        PyList_SET_ITEM(list, i, PlStr_To_PyStr(plAgeInfo::kCommonPages[i]));
+        PyTuple_SET_ITEM(list, i, pyPlasma_convert(plAgeInfo::kCommonPages[i]));
     PyDict_SetItemString(pyAgeInfo_Type.tp_dict, "kCommonPages", list);
 
     Py_INCREF(&pyAgeInfo_Type);

--- a/Python/ResManager/pyResManager.cpp
+++ b/Python/ResManager/pyResManager.cpp
@@ -398,9 +398,9 @@ PY_METHOD_VA(ResManager, getSceneNode,
 
 PY_METHOD_NOARGS(ResManager, getLocations, "Returns a list of all loaded locations") {
     std::vector<plLocation> locs = self->fThis->getLocations();
-    PyObject* list = PyList_New(locs.size());
+    PyObject* list = PyTuple_New(locs.size());
     for (size_t i=0; i<locs.size(); i++)
-        PyList_SET_ITEM(list, i, pyLocation_FromLocation(locs[i]));
+        PyTuple_SET_ITEM(list, i, pyLocation_FromLocation(locs[i]));
     return list;
 }
 
@@ -420,9 +420,9 @@ PY_METHOD_VA(ResManager, getTypes,
     }
 
     std::vector<short> types = self->fThis->getTypes(*loc->fThis, (checkKeys != 0));
-    PyObject* list = PyList_New(types.size());
+    PyObject* list = PyTuple_New(types.size());
     for (size_t i=0; i<types.size(); i++)
-        PyList_SET_ITEM(list, i, pyPlasma_convert(types[i]));
+        PyTuple_SET_ITEM(list, i, pyPlasma_convert(types[i]));
     return list;
 }
 
@@ -443,9 +443,9 @@ PY_METHOD_VA(ResManager, getKeys,
     }
 
     std::vector<plKey> keys = self->fThis->getKeys(*loc->fThis, type, (checkKeys != 0));
-    PyObject* list = PyList_New(keys.size());
+    PyObject* list = PyTuple_New(keys.size());
     for (size_t i=0; i<keys.size(); i++)
-        PyList_SET_ITEM(list, i, pyKey_FromKey(keys[i]));
+        PyTuple_SET_ITEM(list, i, pyKey_FromKey(keys[i]));
     return list;
 }
 

--- a/Python/Sys/pyColor32.cpp
+++ b/Python/Sys/pyColor32.cpp
@@ -63,7 +63,7 @@ PY_PLASMA_VALUE_NEW(Color32, hsColor32)
 PY_PLASMA_REPR_DECL(Color32) {
     plString repr = plString::Format("hsColor32(%u, %u, %u, %u)",
         self->fThis->r, self->fThis->g, self->fThis->b, self->fThis->a);
-    return PlStr_To_PyStr(repr);
+    return pyPlasma_convert(repr);
 }
 
 PY_METHOD_VA(Color32, read32,

--- a/Python/Util/pyDDSurface.cpp
+++ b/Python/Util/pyDDSurface.cpp
@@ -82,8 +82,7 @@ PY_METHOD_VA(DDSurface, setFromMipmap,
 PY_METHOD_NOARGS(DDSurface, createMipmap,
     "Create a new plMipmap from this plDDSurface")
 {
-    plMipmap* tex = self->fThis->createMipmap();
-    return ICreate(tex);
+    return ICreate(self->fThis->createMipmap());
 }
 
 PY_METHOD_VA(DDSurface, calcBufferSize,
@@ -102,15 +101,13 @@ PY_METHOD_VA(DDSurface, calcBufferSize,
 PY_METHOD_NOARGS(DDSurface, calcNumLevels,
     "Calculates the total number of mipmap levels for one surface buffer")
 {
-    size_t levels = self->fThis->calcNumLevels();
-    return pyPlasma_convert(levels);
+    return pyPlasma_convert(self->fThis->calcNumLevels());
 }
 
 PY_METHOD_NOARGS(DDSurface, calcTotalBufferSize,
     "Calculates the total size needed to store all buffers in this surface")
 {
-    size_t totSize = self->fThis->calcTotalBufferSize();
-    return pyPlasma_convert(totSize);
+    return pyPlasma_convert(self->fThis->calcTotalBufferSize());
 }
 
 static PyMethodDef pyDDSurface_Methods[] = {

--- a/Python/Util/pyDDSurface.cpp
+++ b/Python/Util/pyDDSurface.cpp
@@ -143,10 +143,7 @@ PY_PROPERTY_MEMBER(unsigned int, DDSurface, alphaDepth, fAlphaDepth)
                                    self->fThis->member.fColorSpaceHigh); \
     }                                                                   \
     PY_GETSET_SETTER_DECL(DDSurface, name) {                            \
-        if (value == NULL) {                                            \
-            PyErr_SetString(PyExc_RuntimeError, #name " cannot be deleted"); \
-            return -1;                                                  \
-        }                                                               \
+        PY_PROPERTY_CHECK_NULL(name)                                    \
         if (!PyTuple_Check(value) || PyTuple_GET_SIZE(value) != 2) {    \
             PyErr_SetString(PyExc_TypeError, #name " should be a tuple (int, int)"); \
             return -1;                                                  \
@@ -195,10 +192,7 @@ PY_GETSET_GETTER_DECL(DDSurface, pf_multiSampleCaps) {
 }
 
 PY_GETSET_SETTER_DECL(DDSurface, pf_multiSampleCaps) {
-    if (value == NULL) {
-        PyErr_SetString(PyExc_RuntimeError, "pf_multiSampleCaps cannot be deleted");
-        return -1;
-    }
+    PY_PROPERTY_CHECK_NULL(pf_multiSampleCaps)
     if (!PyTuple_Check(value) || PyTuple_GET_SIZE(value) != 2) {
         PyErr_SetString(PyExc_TypeError, "pf_multiSampleCaps should be a tuple (int, int)");
         return -1;
@@ -229,10 +223,8 @@ PY_GETSET_GETTER_DECL(DDSurface, data) {
 }
 
 PY_GETSET_SETTER_DECL(DDSurface, data) {
-    if (value == NULL) {
-        PyErr_SetString(PyExc_RuntimeError, "data cannot be deleted");
-        return -1;
-    } else if (value == Py_None) {
+    PY_PROPERTY_CHECK_NULL(data)
+    if (value == Py_None) {
         self->fThis->setData(0, NULL);
     } else if (PyBytes_Check(value)) {
         char* data;


### PR DESCRIPTION
The third and final part of the Python bindings refactor.  This one adds a few minor tweaks (some methods in `hsBounds3Ext`, a macro for checking deleted properties, rename string conversion helpers, etc), but the primary change is to unify the patterns for using vectors/arrays with Python:
* Now, everything that returns a non-map collection will use a Python tuple.
  * This protects against "silent" bugs like trying to append to or modify the temporary returned object, since tuples cannot be modified directly.
  * Ideally we would use a proxy to the underlying vector to make it more Pythonic, but that would be a much larger change, and would likely break backwards compatibility if it wasn't done carefully.
* Everything that accepts a variable-sized collection from Python can now accept any sequence object, using Python's PySequence_Fast API.  This means it uses fast access for lists and tuples, and only performs one conversion for other types of sequences.
  * In order to simplify this, a new wrapper object is created for creating and managing the lifetime of the PySequence_Fast returned object: `pySequenceFastRef`
  * Some fixed-size and all mixed-type receivers will still only allow a tuple, since those are handled differently and are not iterated over in the same manner.