### PR TITLE
Fix for size_t overloading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,8 @@ try_compile(HAVE_OVERRIDE ${PROJECT_BINARY_DIR}
             ${PROJECT_SOURCE_DIR}/cmake/check_override.cpp)
 try_compile(HAVE_NOEXCEPT ${PROJECT_BINARY_DIR}
             ${PROJECT_SOURCE_DIR}/cmake/check_noexcept.cpp)
+try_compile(NEED_SIZE_T_OVERLOAD ${PROJECT_BINARY_DIR}
+            ${PROJECT_SOURCE_DIR}/cmake/check_size_t_overload.cpp)
 
 configure_file(${PROJECT_SOURCE_DIR}/cmake/PlasmaConfig.h.in
                ${PROJECT_BINARY_DIR}/PlasmaConfig.h)

--- a/Python/PyPlasma.h
+++ b/Python/PyPlasma.h
@@ -339,6 +339,12 @@ template <> inline CallbackEvent pyPlasma_get(PyObject* value) { return (Callbac
 template <> inline ControlEventCode pyPlasma_get(PyObject* value) { return (ControlEventCode)PyInt_AsLong(value); }
 template <> inline plKeyDef pyPlasma_get(PyObject* value) { return (plKeyDef)PyInt_AsLong(value); }
 
+#ifdef NEED_SIZE_T_OVERLOAD
+inline PyObject* pyPlasma_convert(size_t value) { return PyInt_FromLong((long)(unsigned long)value); }
+template <> inline int pyPlasma_check<size_t>(PyObject* value) { return PyInt_Check(value); }
+template <> inline size_t pyPlasma_get(PyObject* value) { return (size_t)(unsigned long)PyInt_AsLong(value); }
+#endif
+
 /* Helpers for properties (GetSet objects in the Python/C API) */
 #define PY_GETSET_GETTER_DECL(pyType, name)                             \
     static PyObject* py##pyType##_get_##name(py##pyType* self, void*)

--- a/cmake/PlasmaConfig.h.in
+++ b/cmake/PlasmaConfig.h.in
@@ -19,5 +19,6 @@
 
 #cmakedefine HAVE_OVERRIDE
 #cmakedefine HAVE_NOEXCEPT
+#cmakedefine NEED_SIZE_T_OVERLOAD
 
 #endif

--- a/cmake/check_size_t_overload.cpp
+++ b/cmake/check_size_t_overload.cpp
@@ -1,0 +1,13 @@
+#include <cstdint>
+#include <cstddef>
+
+void overloaded(uint16_t) { }
+void overloaded(uint32_t) { }
+void overloaded(uint64_t) { }
+void overloaded(size_t) { }
+
+int main(int, char**) {
+    size_t x = 5;
+    overloaded(x);
+    return 0;
+}


### PR DESCRIPTION
Fix platforms where size_t is typedeffed differently from uint##_t (e.g. Mac)