### PR TITLE
Linkage cleanup

### DIFF
--- a/Python/Debug/pyDebug.cpp
+++ b/Python/Debug/pyDebug.cpp
@@ -19,8 +19,6 @@
 #include <Debug/plDebug.h>
 #include "Stream/pyStream.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(Debug, "plDebug is static")
 
 PY_METHOD_STATIC_VA(Debug, Init,
@@ -120,6 +118,4 @@ PY_PLASMA_TYPE_INIT(Debug) {
 
     Py_INCREF(&pyDebug_Type);
     return (PyObject*)&pyDebug_Type;
-}
-
 }

--- a/Python/Debug/pyDebug.h
+++ b/Python/Debug/pyDebug.h
@@ -19,11 +19,7 @@
 
 #include "PyPlasma.h"
 
-extern "C" {
-
 extern PyTypeObject pyDebug_Type;
 PyObject* Init_pyDebug_Type();
-
-}
 
 #endif

--- a/Python/Math/pyAffineParts.cpp
+++ b/Python/Math/pyAffineParts.cpp
@@ -19,8 +19,6 @@
 #include <Math/hsAffineParts.h>
 #include "Stream/pyStream.h"
 
-extern "C" {
-
 PY_PLASMA_VALUE_DEALLOC(AffineParts)
 PY_PLASMA_EMPTY_INIT(AffineParts)
 PY_PLASMA_VALUE_NEW(AffineParts, hsAffineParts)
@@ -104,5 +102,3 @@ PY_PLASMA_TYPE_INIT(AffineParts) {
 }
 
 PY_PLASMA_VALUE_IFC_METHODS(AffineParts, hsAffineParts)
-
-}

--- a/Python/Math/pyMatrix33.cpp
+++ b/Python/Math/pyMatrix33.cpp
@@ -19,8 +19,6 @@
 #include <Math/hsMatrix33.h>
 #include "Stream/pyStream.h"
 
-extern "C" {
-
 PY_PLASMA_VALUE_DEALLOC(Matrix33)
 
 PY_PLASMA_INIT_DECL(Matrix33) {
@@ -154,5 +152,3 @@ PY_PLASMA_TYPE_INIT(Matrix33) {
 }
 
 PY_PLASMA_VALUE_IFC_METHODS(Matrix33, hsMatrix33)
-
-}

--- a/Python/Math/pyMatrix44.cpp
+++ b/Python/Math/pyMatrix44.cpp
@@ -20,8 +20,6 @@
 #include "pyGeometry3.h"
 #include "Stream/pyStream.h"
 
-extern "C" {
-
 PY_PLASMA_VALUE_DEALLOC(Matrix44)
 
 PY_PLASMA_INIT_DECL(Matrix44) {
@@ -408,5 +406,3 @@ PY_PLASMA_TYPE_INIT(Matrix44) {
 }
 
 PY_PLASMA_VALUE_IFC_METHODS(Matrix44, hsMatrix44)
-
-}

--- a/Python/Math/pyPlane3.cpp
+++ b/Python/Math/pyPlane3.cpp
@@ -20,8 +20,6 @@
 #include "Stream/pyStream.h"
 #include <string_theory/format>
 
-extern "C" {
-
 PY_PLASMA_VALUE_DEALLOC(Plane3)
 
 PY_PLASMA_INIT_DECL(Plane3) {
@@ -128,5 +126,3 @@ PY_PLASMA_TYPE_INIT(Plane3) {
 }
 
 PY_PLASMA_VALUE_IFC_METHODS(Plane3, hsPlane3)
-
-}

--- a/Python/Math/pyQuat.cpp
+++ b/Python/Math/pyQuat.cpp
@@ -20,8 +20,6 @@
 #include "Stream/pyStream.h"
 #include <string_theory/format>
 
-extern "C" {
-
 PY_PLASMA_VALUE_DEALLOC(Quat)
 
 PY_PLASMA_INIT_DECL(Quat) {
@@ -218,5 +216,3 @@ PY_PLASMA_TYPE_INIT(Quat) {
 }
 
 PY_PLASMA_VALUE_IFC_METHODS(Quat, hsQuat)
-
-}

--- a/Python/Math/pyVector3.cpp
+++ b/Python/Math/pyVector3.cpp
@@ -20,8 +20,6 @@
 #include "Stream/pyStream.h"
 #include <string_theory/format>
 
-extern "C" {
-
 PY_PLASMA_VALUE_DEALLOC(Vector3)
 
 PY_PLASMA_INIT_DECL(Vector3) {
@@ -242,5 +240,3 @@ PY_PLASMA_TYPE_INIT(Vector3) {
 }
 
 PY_PLASMA_VALUE_IFC_METHODS(Vector3, hsVector3)
-
-}

--- a/Python/PRP/Animation/pyATCEaseCurve.cpp
+++ b/Python/PRP/Animation/pyATCEaseCurve.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Animation/plATCEaseCurves.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ATCEaseCurve, plATCEaseCurve)
 
 PY_PROPERTY(float, ATCEaseCurve, startSpeed, getStartSpeed, setStartSpeed)
@@ -54,5 +52,3 @@ PY_PLASMA_TYPE_INIT(ATCEaseCurve) {
 }
 
 PY_PLASMA_IFC_METHODS(ATCEaseCurve, plATCEaseCurve)
-
-}

--- a/Python/PRP/Animation/pyAnimTimeConvert.cpp
+++ b/Python/PRP/Animation/pyAnimTimeConvert.cpp
@@ -21,8 +21,6 @@
 #include "PRP/Message/pyEventCallbackMsg.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(AnimTimeConvert, plAnimTimeConvert)
 
 PY_METHOD_VA(AnimTimeConvert, addCallback,
@@ -172,5 +170,3 @@ PY_PLASMA_TYPE_INIT(AnimTimeConvert) {
 }
 
 PY_PLASMA_IFC_METHODS(AnimTimeConvert, plAnimTimeConvert)
-
-}

--- a/Python/PRP/Animation/pyCompoundController.cpp
+++ b/Python/PRP/Animation/pyCompoundController.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Animation/plTMController.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_EMPTY_INIT(CompoundController)
 PY_PLASMA_NEW(CompoundController, plCompoundController)
 
@@ -65,5 +63,3 @@ PY_PLASMA_TYPE_INIT(CompoundController) {
 }
 
 PY_PLASMA_IFC_METHODS(CompoundController, plCompoundController)
-
-}

--- a/Python/PRP/Animation/pyCompoundPosController.cpp
+++ b/Python/PRP/Animation/pyCompoundPosController.cpp
@@ -20,8 +20,6 @@
 #include "pyLeafController.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_EMPTY_INIT(CompoundPosController)
 PY_PLASMA_NEW(CompoundPosController, plCompoundPosController)
 
@@ -55,5 +53,3 @@ PY_PLASMA_TYPE_INIT(CompoundPosController) {
 }
 
 PY_PLASMA_IFC_METHODS(CompoundPosController, plCompoundPosController)
-
-}

--- a/Python/PRP/Animation/pyCompoundRotController.cpp
+++ b/Python/PRP/Animation/pyCompoundRotController.cpp
@@ -20,8 +20,6 @@
 #include "pyLeafController.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_EMPTY_INIT(CompoundRotController)
 PY_PLASMA_NEW(CompoundRotController, plCompoundRotController)
 
@@ -55,5 +53,3 @@ PY_PLASMA_TYPE_INIT(CompoundRotController) {
 }
 
 PY_PLASMA_IFC_METHODS(CompoundRotController, plCompoundRotController)
-
-}

--- a/Python/PRP/Animation/pyCompressedQuatKey32.cpp
+++ b/Python/PRP/Animation/pyCompressedQuatKey32.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Animation/hsKeys.h>
 #include "Math/pyGeometry3.h"
 
-extern "C" {
-
 PY_PLASMA_EMPTY_INIT(CompressedQuatKey32)
 PY_PLASMA_NEW(CompressedQuatKey32, hsCompressedQuatKey32)
 
@@ -79,5 +77,3 @@ PY_PLASMA_TYPE_INIT(CompressedQuatKey32) {
 }
 
 PY_PLASMA_IFC_METHODS(CompressedQuatKey32, hsCompressedQuatKey32)
-
-}

--- a/Python/PRP/Animation/pyCompressedQuatKey64.cpp
+++ b/Python/PRP/Animation/pyCompressedQuatKey64.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Animation/hsKeys.h>
 #include "Math/pyGeometry3.h"
 
-extern "C" {
-
 PY_PLASMA_EMPTY_INIT(CompressedQuatKey64)
 PY_PLASMA_NEW(CompressedQuatKey64, hsCompressedQuatKey64)
 
@@ -79,5 +77,3 @@ PY_PLASMA_TYPE_INIT(CompressedQuatKey64) {
 }
 
 PY_PLASMA_IFC_METHODS(CompressedQuatKey64, hsCompressedQuatKey64)
-
-}

--- a/Python/PRP/Animation/pyConstAccelEaseCurve.cpp
+++ b/Python/PRP/Animation/pyConstAccelEaseCurve.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Animation/plATCEaseCurves.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ConstAccelEaseCurve, plConstAccelEaseCurve)
 
 PY_PLASMA_TYPE(ConstAccelEaseCurve, plConstAccelEaseCurve,
@@ -37,5 +35,3 @@ PY_PLASMA_TYPE_INIT(ConstAccelEaseCurve) {
 }
 
 PY_PLASMA_IFC_METHODS(ConstAccelEaseCurve, plConstAccelEaseCurve)
-
-}

--- a/Python/PRP/Animation/pyController.cpp
+++ b/Python/PRP/Animation/pyController.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Animation/plController.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(Controller, "plController is abstract")
 
 PY_PLASMA_TYPE(Controller, plController, "plController wrapper")
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(Controller) {
 }
 
 PY_PLASMA_IFC_METHODS(Controller, plController)
-
-}

--- a/Python/PRP/Animation/pyEaseController.cpp
+++ b/Python/PRP/Animation/pyEaseController.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Animation/plKeyControllers.hpp>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_EMPTY_INIT(EaseController)
 PY_PLASMA_NEW(EaseController, plEaseController)
 
@@ -38,5 +36,3 @@ PY_PLASMA_TYPE_INIT(EaseController) {
 }
 
 PY_PLASMA_IFC_METHODS(EaseController, plEaseController)
-
-}

--- a/Python/PRP/Animation/pyG3DSMaxKeyFrame.cpp
+++ b/Python/PRP/Animation/pyG3DSMaxKeyFrame.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Animation/hsKeys.h>
 #include "Math/pyGeometry3.h"
 
-extern "C" {
-
 PY_PLASMA_EMPTY_INIT(G3DSMaxKeyFrame)
 PY_PLASMA_NEW(G3DSMaxKeyFrame, hsG3DSMaxKeyFrame)
 
@@ -46,5 +44,3 @@ PY_PLASMA_TYPE_INIT(G3DSMaxKeyFrame) {
 }
 
 PY_PLASMA_IFC_METHODS(G3DSMaxKeyFrame, hsG3DSMaxKeyFrame)
-
-}

--- a/Python/PRP/Animation/pyKeyFrame.cpp
+++ b/Python/PRP/Animation/pyKeyFrame.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Animation/hsKeys.h>
 #include "Stream/pyStream.h"
 
-extern "C" {
-
 PY_PLASMA_DEALLOC(KeyFrame)
 PY_PLASMA_NEW_MSG(KeyFrame, "hsKeyFrame is abstract")
 
@@ -105,5 +103,3 @@ PY_PLASMA_TYPE_INIT(KeyFrame) {
 }
 
 PY_PLASMA_IFC_METHODS(KeyFrame, hsKeyFrame)
-
-}

--- a/Python/PRP/Animation/pyLeafController.cpp
+++ b/Python/PRP/Animation/pyLeafController.cpp
@@ -22,8 +22,6 @@
 #include "pyKeys.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_EMPTY_INIT(LeafController)
 PY_PLASMA_NEW(LeafController, plLeafController)
 
@@ -162,5 +160,3 @@ PY_PLASMA_TYPE_INIT(LeafController) {
 }
 
 PY_PLASMA_IFC_METHODS(LeafController, plLeafController)
-
-}

--- a/Python/PRP/Animation/pyMatrix33Controller.cpp
+++ b/Python/PRP/Animation/pyMatrix33Controller.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Animation/plKeyControllers.hpp>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_EMPTY_INIT(Matrix33Controller)
 PY_PLASMA_NEW(Matrix33Controller, plMatrix33Controller)
 
@@ -39,5 +37,3 @@ PY_PLASMA_TYPE_INIT(Matrix33Controller) {
 }
 
 PY_PLASMA_IFC_METHODS(Matrix33Controller, plMatrix33Controller)
-
-}

--- a/Python/PRP/Animation/pyMatrix33Key.cpp
+++ b/Python/PRP/Animation/pyMatrix33Key.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Animation/hsKeys.h>
 #include "Math/pyMatrix.h"
 
-extern "C" {
-
 PY_PLASMA_EMPTY_INIT(Matrix33Key)
 PY_PLASMA_NEW(Matrix33Key, hsMatrix33Key)
 
@@ -46,5 +44,3 @@ PY_PLASMA_TYPE_INIT(Matrix33Key) {
 }
 
 PY_PLASMA_IFC_METHODS(Matrix33Key, hsMatrix33Key)
-
-}

--- a/Python/PRP/Animation/pyMatrix44Controller.cpp
+++ b/Python/PRP/Animation/pyMatrix44Controller.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Animation/plKeyControllers.hpp>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_EMPTY_INIT(Matrix44Controller)
 PY_PLASMA_NEW(Matrix44Controller, plMatrix44Controller)
 
@@ -39,5 +37,3 @@ PY_PLASMA_TYPE_INIT(Matrix44Controller) {
 }
 
 PY_PLASMA_IFC_METHODS(Matrix44Controller, plMatrix44Controller)
-
-}

--- a/Python/PRP/Animation/pyMatrix44Key.cpp
+++ b/Python/PRP/Animation/pyMatrix44Key.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Animation/hsKeys.h>
 #include "Math/pyMatrix.h"
 
-extern "C" {
-
 PY_PLASMA_EMPTY_INIT(Matrix44Key)
 PY_PLASMA_NEW(Matrix44Key, hsMatrix44Key)
 
@@ -46,5 +44,3 @@ PY_PLASMA_TYPE_INIT(Matrix44Key) {
 }
 
 PY_PLASMA_IFC_METHODS(Matrix44Key, hsMatrix44Key)
-
-}

--- a/Python/PRP/Animation/pyPoint3Controller.cpp
+++ b/Python/PRP/Animation/pyPoint3Controller.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Animation/plKeyControllers.hpp>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_EMPTY_INIT(Point3Controller)
 PY_PLASMA_NEW(Point3Controller, plPoint3Controller)
 
@@ -38,5 +36,3 @@ PY_PLASMA_TYPE_INIT(Point3Controller) {
 }
 
 PY_PLASMA_IFC_METHODS(Point3Controller, plPoint3Controller)
-
-}

--- a/Python/PRP/Animation/pyPoint3Key.cpp
+++ b/Python/PRP/Animation/pyPoint3Key.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Animation/hsKeys.h>
 #include "Math/pyGeometry3.h"
 
-extern "C" {
-
 PY_PLASMA_EMPTY_INIT(Point3Key)
 PY_PLASMA_NEW(Point3Key, hsPoint3Key)
 
@@ -50,5 +48,3 @@ PY_PLASMA_TYPE_INIT(Point3Key) {
 }
 
 PY_PLASMA_IFC_METHODS(Point3Key, hsPoint3Key)
-
-}

--- a/Python/PRP/Animation/pyPosController.cpp
+++ b/Python/PRP/Animation/pyPosController.cpp
@@ -20,8 +20,6 @@
 #include "pyController.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(PosController, "plPosController is abstract")
 
 PY_PROPERTY_RO(PosController, type, getType)
@@ -48,5 +46,3 @@ PY_PLASMA_TYPE_INIT(PosController) {
 }
 
 PY_PLASMA_IFC_METHODS(PosController, plPosController)
-
-}

--- a/Python/PRP/Animation/pyQuatController.cpp
+++ b/Python/PRP/Animation/pyQuatController.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Animation/plKeyControllers.hpp>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_EMPTY_INIT(QuatController)
 PY_PLASMA_NEW(QuatController, plQuatController)
 
@@ -38,5 +36,3 @@ PY_PLASMA_TYPE_INIT(QuatController) {
 }
 
 PY_PLASMA_IFC_METHODS(QuatController, plQuatController)
-
-}

--- a/Python/PRP/Animation/pyQuatKey.cpp
+++ b/Python/PRP/Animation/pyQuatKey.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Animation/hsKeys.h>
 #include "Math/pyGeometry3.h"
 
-extern "C" {
-
 PY_PLASMA_EMPTY_INIT(QuatKey)
 PY_PLASMA_NEW(QuatKey, hsQuatKey)
 
@@ -46,5 +44,3 @@ PY_PLASMA_TYPE_INIT(QuatKey) {
 }
 
 PY_PLASMA_IFC_METHODS(QuatKey, hsQuatKey)
-
-}

--- a/Python/PRP/Animation/pyRotController.cpp
+++ b/Python/PRP/Animation/pyRotController.cpp
@@ -20,8 +20,6 @@
 #include "pyController.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(RotController, "plRotController is abstract")
 
 PY_PROPERTY_RO(RotController, type, getType)
@@ -48,5 +46,3 @@ PY_PLASMA_TYPE_INIT(RotController) {
 }
 
 PY_PLASMA_IFC_METHODS(RotController, plRotController)
-
-}

--- a/Python/PRP/Animation/pyScalarController.cpp
+++ b/Python/PRP/Animation/pyScalarController.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Animation/plKeyControllers.hpp>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_EMPTY_INIT(ScalarController)
 PY_PLASMA_NEW(ScalarController, plScalarController)
 
@@ -38,5 +36,3 @@ PY_PLASMA_TYPE_INIT(ScalarController) {
 }
 
 PY_PLASMA_IFC_METHODS(ScalarController, plScalarController)
-
-}

--- a/Python/PRP/Animation/pyScalarKey.cpp
+++ b/Python/PRP/Animation/pyScalarKey.cpp
@@ -18,8 +18,6 @@
 
 #include <PRP/Animation/hsKeys.h>
 
-extern "C" {
-
 PY_PLASMA_EMPTY_INIT(ScalarKey)
 PY_PLASMA_NEW(ScalarKey, hsScalarKey)
 
@@ -49,5 +47,3 @@ PY_PLASMA_TYPE_INIT(ScalarKey) {
 }
 
 PY_PLASMA_IFC_METHODS(ScalarKey, hsScalarKey)
-
-}

--- a/Python/PRP/Animation/pyScaleController.cpp
+++ b/Python/PRP/Animation/pyScaleController.cpp
@@ -20,8 +20,6 @@
 #include "pyController.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(ScaleController, "plScaleController is abstract")
 
 PY_PROPERTY_RO(ScaleController, type, getType)
@@ -47,5 +45,3 @@ PY_PLASMA_TYPE_INIT(ScaleController) {
 }
 
 PY_PLASMA_IFC_METHODS(ScaleController, plScaleController)
-
-}

--- a/Python/PRP/Animation/pyScaleKey.cpp
+++ b/Python/PRP/Animation/pyScaleKey.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Animation/hsKeys.h>
 #include "Math/pyGeometry3.h"
 
-extern "C" {
-
 PY_PLASMA_EMPTY_INIT(ScaleKey)
 PY_PLASMA_NEW(ScaleKey, hsScaleKey)
 
@@ -74,5 +72,3 @@ PY_PLASMA_TYPE_INIT(ScaleKey) {
 }
 
 PY_PLASMA_IFC_METHODS(ScaleKey, hsScaleKey)
-
-}

--- a/Python/PRP/Animation/pyScaleValueController.cpp
+++ b/Python/PRP/Animation/pyScaleValueController.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Animation/plKeyControllers.hpp>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_EMPTY_INIT(ScaleValueController)
 PY_PLASMA_NEW(ScaleValueController, plScaleValueController)
 
@@ -39,5 +37,3 @@ PY_PLASMA_TYPE_INIT(ScaleValueController) {
 }
 
 PY_PLASMA_IFC_METHODS(ScaleValueController, plScaleValueController)
-
-}

--- a/Python/PRP/Animation/pySimplePosController.cpp
+++ b/Python/PRP/Animation/pySimplePosController.cpp
@@ -20,8 +20,6 @@
 #include "pyLeafController.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_EMPTY_INIT(SimplePosController)
 PY_PLASMA_NEW(SimplePosController, plSimplePosController)
 
@@ -49,5 +47,3 @@ PY_PLASMA_TYPE_INIT(SimplePosController) {
 }
 
 PY_PLASMA_IFC_METHODS(SimplePosController, plSimplePosController)
-
-}

--- a/Python/PRP/Animation/pySimpleRotController.cpp
+++ b/Python/PRP/Animation/pySimpleRotController.cpp
@@ -20,8 +20,6 @@
 #include "pyLeafController.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_EMPTY_INIT(SimpleRotController)
 PY_PLASMA_NEW(SimpleRotController, plSimpleRotController)
 
@@ -49,5 +47,3 @@ PY_PLASMA_TYPE_INIT(SimpleRotController) {
 }
 
 PY_PLASMA_IFC_METHODS(SimpleRotController, plSimpleRotController)
-
-}

--- a/Python/PRP/Animation/pySimpleScaleController.cpp
+++ b/Python/PRP/Animation/pySimpleScaleController.cpp
@@ -20,8 +20,6 @@
 #include "pyLeafController.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_EMPTY_INIT(SimpleScaleController)
 PY_PLASMA_NEW(SimpleScaleController, plSimpleScaleController)
 
@@ -49,5 +47,3 @@ PY_PLASMA_TYPE_INIT(SimpleScaleController) {
 }
 
 PY_PLASMA_IFC_METHODS(SimpleScaleController, plSimpleScaleController)
-
-}

--- a/Python/PRP/Animation/pySplineEaseCurve.cpp
+++ b/Python/PRP/Animation/pySplineEaseCurve.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Animation/plATCEaseCurves.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(SplineEaseCurve, plSplineEaseCurve)
 
 PY_GETSET_GETTER_DECL(SplineEaseCurve, splineCoef) {
@@ -68,5 +66,3 @@ PY_PLASMA_TYPE_INIT(SplineEaseCurve) {
 }
 
 PY_PLASMA_IFC_METHODS(SplineEaseCurve, plSplineEaseCurve)
-
-}

--- a/Python/PRP/Animation/pyTMController.cpp
+++ b/Python/PRP/Animation/pyTMController.cpp
@@ -22,8 +22,6 @@
 #include "pyScaleController.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_EMPTY_INIT(TMController)
 PY_PLASMA_NEW(TMController, plTMController)
 
@@ -68,5 +66,3 @@ PY_PLASMA_TYPE_INIT(TMController) {
 }
 
 PY_PLASMA_IFC_METHODS(TMController, plTMController)
-
-}

--- a/Python/PRP/Animation/pyViewFaceModifier.cpp
+++ b/Python/PRP/Animation/pyViewFaceModifier.cpp
@@ -24,8 +24,6 @@
 #include "Math/pyGeometry3.h"
 #include "Math/pyMatrix.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ViewFaceModifier, plViewFaceModifier)
 
 PY_PROPERTY(hsVector3, ViewFaceModifier, scale, getScale, setScale)
@@ -72,5 +70,3 @@ PY_PLASMA_TYPE_INIT(ViewFaceModifier) {
 }
 
 PY_PLASMA_IFC_METHODS(ViewFaceModifier, plViewFaceModifier)
-
-}

--- a/Python/PRP/Audio/py2WayWinAudible.cpp
+++ b/Python/PRP/Audio/py2WayWinAudible.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Audio/plAudible.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(2WayWinAudible, pl2WayWinAudible)
 
 PY_PLASMA_TYPE(2WayWinAudible, pl2WayWinAudible, "pl2WayWinAudible wrapper")
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(2WayWinAudible) {
 }
 
 PY_PLASMA_IFC_METHODS(2WayWinAudible, pl2WayWinAudible)
-
-}

--- a/Python/PRP/Audio/pyAudible.cpp
+++ b/Python/PRP/Audio/pyAudible.cpp
@@ -20,8 +20,6 @@
 #include "PRP/KeyedObject/pyKeyedObject.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(Audible, plAudible)
 
 PY_PLASMA_TYPE(Audible, plAudible, "plAudible wrapper")
@@ -37,5 +35,3 @@ PY_PLASMA_TYPE_INIT(Audible) {
 }
 
 PY_PLASMA_IFC_METHODS(Audible, plAudible)
-
-}

--- a/Python/PRP/Audio/pyAudibleNull.cpp
+++ b/Python/PRP/Audio/pyAudibleNull.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Audio/plAudible.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(AudibleNull, plAudibleNull)
 
 PY_PLASMA_TYPE(AudibleNull, "plAudibleNull", "plAudibleNull wrapper")
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(AudibleNull) {
 }
 
 PY_PLASMA_IFC_METHODS(AudibleNull, plAudibleNull)
-
-}

--- a/Python/PRP/Audio/pyFadeParams.cpp
+++ b/Python/PRP/Audio/pyFadeParams.cpp
@@ -16,8 +16,6 @@
 
 #include "pySound.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(FadeParams, "Cannot construct plFadeParams objects in Python")
 
 PY_PROPERTY_MEMBER(float, FadeParams, lengthInSecs, fLengthInSecs)
@@ -56,5 +54,3 @@ PY_PLASMA_TYPE_INIT(FadeParams) {
 }
 
 PY_PLASMA_IFC_METHODS(FadeParams, plSound::plFadeParams)
-
-}

--- a/Python/PRP/Audio/pySound.cpp
+++ b/Python/PRP/Audio/pySound.cpp
@@ -20,8 +20,6 @@
 #include "PRP/pyCreatable.h"
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(Sound, "plSound is abstract")
 
 PY_PROPERTY(unsigned char, Sound, type, getType, setType)
@@ -102,5 +100,3 @@ PY_PLASMA_TYPE_INIT(Sound) {
 }
 
 PY_PLASMA_IFC_METHODS(Sound, plSound)
-
-}

--- a/Python/PRP/Audio/pySoundBuffer.cpp
+++ b/Python/PRP/Audio/pySoundBuffer.cpp
@@ -20,8 +20,6 @@
 #include "PRP/KeyedObject/pyKeyedObject.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(SoundBuffer, plSoundBuffer)
 
 PY_PROPERTY_PROXY(plWAVHeader, SoundBuffer, header, getHeader)
@@ -85,5 +83,3 @@ PY_PLASMA_TYPE_INIT(SoundBuffer) {
 }
 
 PY_PLASMA_IFC_METHODS(SoundBuffer, plSoundBuffer)
-
-}

--- a/Python/PRP/Audio/pyWAVHeader.cpp
+++ b/Python/PRP/Audio/pyWAVHeader.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Audio/plSoundBuffer.h>
 #include "Stream/pyStream.h"
 
-extern "C" {
-
 PY_PLASMA_DEALLOC(WAVHeader)
 PY_PLASMA_NEW(WAVHeader, plWAVHeader)
 
@@ -98,5 +96,3 @@ PY_PLASMA_TYPE_INIT(WAVHeader) {
 }
 
 PY_PLASMA_IFC_METHODS(WAVHeader, plWAVHeader)
-
-}

--- a/Python/PRP/Audio/pyWin32Sound.cpp
+++ b/Python/PRP/Audio/pyWin32Sound.cpp
@@ -20,8 +20,6 @@
 #include "pySound.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(Win32Sound, "plWin32Sound is abstract")
 
 PY_PROPERTY(unsigned char, Win32Sound, channel, getChannel, setChannel)
@@ -48,5 +46,3 @@ PY_PLASMA_TYPE_INIT(Win32Sound) {
 }
 
 PY_PLASMA_IFC_METHODS(Win32Sound, plWin32Sound)
-
-}

--- a/Python/PRP/Audio/pyWin32StaticSound.cpp
+++ b/Python/PRP/Audio/pyWin32StaticSound.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Audio/plWin32StaticSound.h>
 #include "pyWin32Sound.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(Win32StaticSound, plWin32StaticSound)
 
 PY_PLASMA_TYPE(Win32StaticSound, plWin32StaticSound, "plWin32StaticSound wrapper")
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(Win32StaticSound) {
 }
 
 PY_PLASMA_IFC_METHODS(Win32StaticSound, plWin32StaticSound)
-
-}

--- a/Python/PRP/Audio/pyWin32StreamingSound.cpp
+++ b/Python/PRP/Audio/pyWin32StreamingSound.cpp
@@ -18,8 +18,6 @@
 
 #include <PRP/Audio/plWin32Sound.h>
 
-extern "C" {
-
 PY_PLASMA_NEW(Win32StreamingSound, plWin32StreamingSound)
 
 PY_PLASMA_TYPE(Win32StreamingSound, plWin32StreamingSound,
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(Win32StreamingSound) {
 }
 
 PY_PLASMA_IFC_METHODS(Win32StreamingSound, plWin32StreamingSound)
-
-}

--- a/Python/PRP/Audio/pyWinAudible.cpp
+++ b/Python/PRP/Audio/pyWinAudible.cpp
@@ -20,8 +20,6 @@
 #include "PRP/KeyedObject/pyKey.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(WinAudible, plWinAudible)
 
 PY_METHOD_VA(WinAudible, addSound,
@@ -100,5 +98,3 @@ PY_PLASMA_TYPE_INIT(WinAudible) {
 }
 
 PY_PLASMA_IFC_METHODS(WinAudible, plWinAudible)
-
-}

--- a/Python/PRP/Avatar/pyAGAnim.cpp
+++ b/Python/PRP/Avatar/pyAGAnim.cpp
@@ -21,8 +21,6 @@
 #include "PRP/pyCreatable.h"
 #include "PRP/Object/pySynchedObject.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(AGAnim, plAGAnim)
 
 PY_METHOD_NOARGS(AGAnim, clearApplicators, "Remove all plAGApplicators from the anim") {
@@ -114,5 +112,3 @@ PY_PLASMA_TYPE_INIT(AGAnim) {
 }
 
 PY_PLASMA_IFC_METHODS(AGAnim, plAGAnim)
-
-}

--- a/Python/PRP/Avatar/pyAGAnimBink.cpp
+++ b/Python/PRP/Avatar/pyAGAnimBink.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plATCAnim.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(AGAnimBink, plAGAnimBink)
 
 PY_PROPERTY(ST::string, AGAnimBink, binkFilename, getBinkFilename, setBinkFilename)
@@ -48,5 +46,3 @@ PY_PLASMA_TYPE_INIT(AGAnimBink) {
 }
 
 PY_PLASMA_IFC_METHODS(AGAnimBink, plAGAnimBink)
-
-}

--- a/Python/PRP/Avatar/pyAGApplicator.cpp
+++ b/Python/PRP/Avatar/pyAGApplicator.cpp
@@ -20,8 +20,6 @@
 #include "pyAGChannel.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(AGApplicator, "plAGApplicator is abstract")
 
 PY_PROPERTY_CREATABLE(plAGChannel, AGChannel, AGApplicator, channel,
@@ -50,5 +48,3 @@ PY_PLASMA_TYPE_INIT(AGApplicator) {
 }
 
 PY_PLASMA_IFC_METHODS(AGApplicator, plAGApplicator)
-
-}

--- a/Python/PRP/Avatar/pyAGChannel.cpp
+++ b/Python/PRP/Avatar/pyAGChannel.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plAGChannel.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(AGChannel, "plAGChannel is abstract")
 
 PY_PROPERTY(ST::string, AGChannel, name, getName, setName)
@@ -44,5 +42,3 @@ PY_PLASMA_TYPE_INIT(AGChannel) {
 }
 
 PY_PLASMA_IFC_METHODS(AGChannel, plAGChannel)
-
-}

--- a/Python/PRP/Avatar/pyAGMasterMod.cpp
+++ b/Python/PRP/Avatar/pyAGMasterMod.cpp
@@ -20,8 +20,6 @@
 #include "PRP/Modifier/pyModifier.h"
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(AGMasterMod, plAGMasterMod)
 
 PY_METHOD_VA(AGMasterMod, addPrivateAnim,
@@ -149,5 +147,3 @@ PY_PLASMA_TYPE_INIT(AGMasterMod) {
 }
 
 PY_PLASMA_IFC_METHODS(AGMasterMod, plAGMasterMod)
-
-};

--- a/Python/PRP/Avatar/pyAGModifier.cpp
+++ b/Python/PRP/Avatar/pyAGModifier.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plAGModifier.h>
 #include "PRP/Modifier/pyModifier.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(AGModifier, plAGModifier)
 
 PY_PROPERTY(ST::string, AGModifier, channelName, getChannelName, setChannelName)
@@ -48,5 +46,3 @@ PY_PLASMA_TYPE_INIT(AGModifier) {
 }
 
 PY_PLASMA_IFC_METHODS(AGModifier, plAGModifier)
-
-};

--- a/Python/PRP/Avatar/pyATCAnim.cpp
+++ b/Python/PRP/Avatar/pyATCAnim.cpp
@@ -20,8 +20,6 @@
 #include "pyAGAnim.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ATCAnim, plATCAnim)
 
 PY_METHOD_NOARGS(ATCAnim, clearMarkers, "Remove all named markers from the anim") {
@@ -173,5 +171,3 @@ PY_PLASMA_TYPE_INIT(ATCAnim) {
 }
 
 PY_PLASMA_IFC_METHODS(ATCAnim, plATCAnim)
-
-}

--- a/Python/PRP/Avatar/pyATCChannel.cpp
+++ b/Python/PRP/Avatar/pyATCChannel.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plScalarChannel.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ATCChannel, plATCChannel)
 
 PY_PLASMA_TYPE(ATCChannel, plATCChannel, "plATCChannel wrapper")
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(ATCChannel) {
 }
 
 PY_PLASMA_IFC_METHODS(ATCChannel, plATCChannel)
-
-}

--- a/Python/PRP/Avatar/pyAgeGlobalAnim.cpp
+++ b/Python/PRP/Avatar/pyAgeGlobalAnim.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plAGAnim.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(AgeGlobalAnim, plAgeGlobalAnim)
 
 PY_PROPERTY(ST::string, AgeGlobalAnim, globalVarName, getGlobalVarName, setGlobalVarName)
@@ -44,5 +42,3 @@ PY_PLASMA_TYPE_INIT(AgeGlobalAnim) {
 }
 
 PY_PLASMA_IFC_METHODS(AgeGlobalAnim, plAgeGlobalAnim)
-
-}

--- a/Python/PRP/Avatar/pyAnimStage.cpp
+++ b/Python/PRP/Avatar/pyAnimStage.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plAnimStage.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_EMPTY_INIT(AnimStage)
 PY_PLASMA_NEW(AnimStage, plAnimStage)
 
@@ -122,5 +120,3 @@ PY_PLASMA_TYPE_INIT(AnimStage) {
 }
 
 PY_PLASMA_IFC_METHODS(AnimStage, plAnimStage)
-
-}

--- a/Python/PRP/Avatar/pyClothingItem.cpp
+++ b/Python/PRP/Avatar/pyClothingItem.cpp
@@ -21,8 +21,6 @@
 #include "PRP/KeyedObject/pyKeyedObject.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ClothingItem, plClothingItem)
 
 PY_METHOD_VA(ClothingItem, getMesh,
@@ -92,5 +90,3 @@ PY_PLASMA_TYPE_INIT(ClothingItem) {
 }
 
 PY_PLASMA_IFC_METHODS(ClothingItem, plClothingItem)
-
-}

--- a/Python/PRP/Avatar/pyEmoteAnim.cpp
+++ b/Python/PRP/Avatar/pyEmoteAnim.cpp
@@ -20,8 +20,6 @@
 #include "PRP/pyCreatable.h"
 #include "PRP/Avatar/pyAGAnim.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(EmoteAnim, plEmoteAnim)
 
 PY_PROPERTY(plAGAnim::BodyUsage, EmoteAnim, bodyUsage, getBodyUsage, setBodyUsage)
@@ -49,5 +47,3 @@ PY_PLASMA_TYPE_INIT(EmoteAnim) {
 }
 
 PY_PLASMA_IFC_METHODS(EmoteAnim, plEmoteAnim)
-
-}

--- a/Python/PRP/Avatar/pyLightAmbientApplicator.cpp
+++ b/Python/PRP/Avatar/pyLightAmbientApplicator.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plAGApplicator.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(LightAmbientApplicator, plLightAmbientApplicator)
 
 PY_PLASMA_TYPE(LightAmbientApplicator, plLightAmbientApplicator,
@@ -37,5 +35,3 @@ PY_PLASMA_TYPE_INIT(LightAmbientApplicator) {
 }
 
 PY_PLASMA_IFC_METHODS(LightAmbientApplicator, plLightAmbientApplicator)
-
-}

--- a/Python/PRP/Avatar/pyLightDiffuseApplicator.cpp
+++ b/Python/PRP/Avatar/pyLightDiffuseApplicator.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plAGApplicator.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(LightDiffuseApplicator, plLightDiffuseApplicator)
 
 PY_PLASMA_TYPE(LightDiffuseApplicator, plLightDiffuseApplicator,
@@ -37,5 +35,3 @@ PY_PLASMA_TYPE_INIT(LightDiffuseApplicator) {
 }
 
 PY_PLASMA_IFC_METHODS(LightDiffuseApplicator, plLightDiffuseApplicator)
-
-}

--- a/Python/PRP/Avatar/pyLightSpecularApplicator.cpp
+++ b/Python/PRP/Avatar/pyLightSpecularApplicator.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plAGApplicator.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(LightSpecularApplicator, plLightSpecularApplicator)
 
 PY_PLASMA_TYPE(LightSpecularApplicator, plLightSpecularApplicator,
@@ -37,5 +35,3 @@ PY_PLASMA_TYPE_INIT(LightSpecularApplicator) {
 }
 
 PY_PLASMA_IFC_METHODS(LightSpecularApplicator, plLightSpecularApplicator)
-
-}

--- a/Python/PRP/Avatar/pyMatrixBlend.cpp
+++ b/Python/PRP/Avatar/pyMatrixBlend.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plMatrixChannel.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(MatrixBlend, plMatrixBlend)
 
 PY_PLASMA_TYPE(MatrixBlend, plMatrixBlend, "plMatrixBlend wrapper")
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(MatrixBlend) {
 }
 
 PY_PLASMA_IFC_METHODS(MatrixBlend, plMatrixBlend)
-
-}

--- a/Python/PRP/Avatar/pyMatrixChannel.cpp
+++ b/Python/PRP/Avatar/pyMatrixChannel.cpp
@@ -20,8 +20,6 @@
 #include "PRP/pyCreatable.h"
 #include "Math/pyGeometry3.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(MatrixChannel, plMatrixChannel)
 
 PY_PROPERTY(hsAffineParts, MatrixChannel, affine, getAffine, setAffine)
@@ -45,5 +43,3 @@ PY_PLASMA_TYPE_INIT(MatrixChannel) {
 }
 
 PY_PLASMA_IFC_METHODS(MatrixChannel, plMatrixChannel)
-
-}

--- a/Python/PRP/Avatar/pyMatrixChannelApplicator.cpp
+++ b/Python/PRP/Avatar/pyMatrixChannelApplicator.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plMatrixChannel.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(MatrixChannelApplicator, plMatrixChannelApplicator)
 
 PY_PLASMA_TYPE(MatrixChannelApplicator, plMatrixChannelApplicator,
@@ -37,5 +35,3 @@ PY_PLASMA_TYPE_INIT(MatrixChannelApplicator) {
 }
 
 PY_PLASMA_IFC_METHODS(MatrixChannelApplicator, plMatrixChannelApplicator)
-
-}

--- a/Python/PRP/Avatar/pyMatrixConstant.cpp
+++ b/Python/PRP/Avatar/pyMatrixConstant.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plMatrixChannel.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(MatrixConstant, plMatrixConstant)
 
 PY_PLASMA_TYPE(MatrixConstant, plMatrixConstant, "plMatrixConstant wrapper")
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(MatrixConstant) {
 }
 
 PY_PLASMA_IFC_METHODS(MatrixConstant, plMatrixConstant)
-
-}

--- a/Python/PRP/Avatar/pyMatrixControllerCacheChannel.cpp
+++ b/Python/PRP/Avatar/pyMatrixControllerCacheChannel.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plMatrixChannel.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(MatrixControllerCacheChannel, plMatrixControllerCacheChannel)
 
 PY_PLASMA_TYPE(MatrixControllerCacheChannel, plMatrixControllerCacheChannel,
@@ -37,5 +35,3 @@ PY_PLASMA_TYPE_INIT(MatrixControllerCacheChannel) {
 }
 
 PY_PLASMA_IFC_METHODS(MatrixControllerCacheChannel, plMatrixControllerCacheChannel)
-
-}

--- a/Python/PRP/Avatar/pyMatrixControllerChannel.cpp
+++ b/Python/PRP/Avatar/pyMatrixControllerChannel.cpp
@@ -20,8 +20,6 @@
 #include "PRP/pyCreatable.h"
 #include "PRP/Animation/pyController.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(MatrixControllerChannel, plMatrixControllerChannel)
 
 PY_PROPERTY_CREATABLE(plController, Controller, MatrixControllerChannel,
@@ -47,5 +45,3 @@ PY_PLASMA_TYPE_INIT(MatrixControllerChannel) {
 }
 
 PY_PLASMA_IFC_METHODS(MatrixControllerChannel, plMatrixControllerChannel)
-
-}

--- a/Python/PRP/Avatar/pyMatrixDelayedCorrectionApplicator.cpp
+++ b/Python/PRP/Avatar/pyMatrixDelayedCorrectionApplicator.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plMatrixChannel.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(MatrixDelayedCorrectionApplicator, plMatrixDelayedCorrectionApplicator)
 
 PY_PLASMA_TYPE(MatrixDelayedCorrectionApplicator, plMatrixDelayedCorrectionApplicator,
@@ -37,5 +35,3 @@ PY_PLASMA_TYPE_INIT(MatrixDelayedCorrectionApplicator) {
 }
 
 PY_PLASMA_IFC_METHODS(MatrixDelayedCorrectionApplicator, plMatrixDelayedCorrectionApplicator)
-
-}

--- a/Python/PRP/Avatar/pyMatrixDifferenceApp.cpp
+++ b/Python/PRP/Avatar/pyMatrixDifferenceApp.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plMatrixChannel.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(MatrixDifferenceApp, plMatrixDifferenceApp)
 
 PY_PLASMA_TYPE(MatrixDifferenceApp, plMatrixDifferenceApp,
@@ -37,5 +35,3 @@ PY_PLASMA_TYPE_INIT(MatrixDifferenceApp) {
 }
 
 PY_PLASMA_IFC_METHODS(MatrixDifferenceApp, plMatrixDifferenceApp)
-
-}

--- a/Python/PRP/Avatar/pyMatrixTimeScale.cpp
+++ b/Python/PRP/Avatar/pyMatrixTimeScale.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plMatrixChannel.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(MatrixTimeScale, plMatrixTimeScale)
 
 PY_PLASMA_TYPE(MatrixTimeScale, plMatrixTimeScale, "plMatrixTimeScale wrapper")
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(MatrixTimeScale) {
 }
 
 PY_PLASMA_IFC_METHODS(MatrixTimeScale, plMatrixTimeScale)
-
-}

--- a/Python/PRP/Avatar/pyMultistageBehMod.cpp
+++ b/Python/PRP/Avatar/pyMultistageBehMod.cpp
@@ -21,8 +21,6 @@
 #include "PRP/KeyedObject/pyKey.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(MultistageBehMod, plMultistageBehMod)
 
 PY_METHOD_VA(MultistageBehMod, addStage,
@@ -159,5 +157,3 @@ PY_PLASMA_TYPE_INIT(MultistageBehMod) {
 }
 
 PY_PLASMA_IFC_METHODS(MultistageBehMod, plMultistageBehMod)
-
-}

--- a/Python/PRP/Avatar/pyOmniApplicator.cpp
+++ b/Python/PRP/Avatar/pyOmniApplicator.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plAGApplicator.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(OmniApplicator, plOmniApplicator)
 
 PY_PLASMA_TYPE(OmniApplicator, plOmniApplicator, "plOmniApplicator wrapper")
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(OmniApplicator) {
 }
 
 PY_PLASMA_IFC_METHODS(OmniApplicator, plOmniApplicator)
-
-}

--- a/Python/PRP/Avatar/pyOmniCutoffApplicator.cpp
+++ b/Python/PRP/Avatar/pyOmniCutoffApplicator.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plAGApplicator.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(OmniCutoffApplicator, plOmniCutoffApplicator)
 
 PY_PLASMA_TYPE(OmniCutoffApplicator, plOmniCutoffApplicator,
@@ -37,5 +35,3 @@ PY_PLASMA_TYPE_INIT(OmniCutoffApplicator) {
 }
 
 PY_PLASMA_IFC_METHODS(OmniCutoffApplicator, plOmniCutoffApplicator)
-
-}

--- a/Python/PRP/Avatar/pyOmniSqApplicator.cpp
+++ b/Python/PRP/Avatar/pyOmniSqApplicator.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plAGApplicator.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(OmniSqApplicator, plOmniSqApplicator)
 
 PY_PLASMA_TYPE(OmniSqApplicator, plOmniSqApplicator, "plOmniSqApplicator wrapper")
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(OmniSqApplicator) {
 }
 
 PY_PLASMA_IFC_METHODS(OmniSqApplicator, plOmniSqApplicator)
-
-}

--- a/Python/PRP/Avatar/pyPointBlend.cpp
+++ b/Python/PRP/Avatar/pyPointBlend.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plPointChannel.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(PointBlend, plPointBlend)
 
 PY_PLASMA_TYPE(PointBlend, plPointBlend, "plPointBlend wrapper")
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(PointBlend) {
 }
 
 PY_PLASMA_IFC_METHODS(PointBlend, plPointBlend)
-
-}

--- a/Python/PRP/Avatar/pyPointChannel.cpp
+++ b/Python/PRP/Avatar/pyPointChannel.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plPointChannel.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(PointChannel, plPointChannel)
 
 PY_PLASMA_TYPE(PointChannel, plPointChannel, "plPointChannel wrapper")
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(PointChannel) {
 }
 
 PY_PLASMA_IFC_METHODS(PointChannel, plPointChannel)
-
-}

--- a/Python/PRP/Avatar/pyPointChannelApplicator.cpp
+++ b/Python/PRP/Avatar/pyPointChannelApplicator.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plPointChannel.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(PointChannelApplicator, plPointChannelApplicator)
 
 PY_PLASMA_TYPE(PointChannelApplicator, plPointChannelApplicator,
@@ -37,5 +35,3 @@ PY_PLASMA_TYPE_INIT(PointChannelApplicator) {
 }
 
 PY_PLASMA_IFC_METHODS(PointChannelApplicator, plPointChannelApplicator)
-
-}

--- a/Python/PRP/Avatar/pyPointConstant.cpp
+++ b/Python/PRP/Avatar/pyPointConstant.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plPointChannel.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(PointConstant, plPointConstant)
 
 PY_PLASMA_TYPE(PointConstant, plPointConstant, "plPointConstant wrapper")
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(PointConstant) {
 }
 
 PY_PLASMA_IFC_METHODS(PointConstant, plPointConstant)
-
-}

--- a/Python/PRP/Avatar/pyPointControllerCacheChannel.cpp
+++ b/Python/PRP/Avatar/pyPointControllerCacheChannel.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plPointChannel.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(PointControllerCacheChannel, plPointControllerCacheChannel)
 
 PY_PLASMA_TYPE(PointControllerCacheChannel, plPointControllerCacheChannel,
@@ -37,5 +35,3 @@ PY_PLASMA_TYPE_INIT(PointControllerCacheChannel) {
 }
 
 PY_PLASMA_IFC_METHODS(PointControllerCacheChannel, plPointControllerCacheChannel)
-
-}

--- a/Python/PRP/Avatar/pyPointControllerChannel.cpp
+++ b/Python/PRP/Avatar/pyPointControllerChannel.cpp
@@ -20,8 +20,6 @@
 #include "PRP/pyCreatable.h"
 #include "PRP/Animation/pyController.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(PointControllerChannel, plPointControllerChannel)
 
 PY_PROPERTY_CREATABLE(plController, Controller, PointControllerChannel,
@@ -47,5 +45,3 @@ PY_PLASMA_TYPE_INIT(PointControllerChannel) {
 }
 
 PY_PLASMA_IFC_METHODS(PointControllerChannel, plPointControllerChannel)
-
-}

--- a/Python/PRP/Avatar/pyPointTimeScale.cpp
+++ b/Python/PRP/Avatar/pyPointTimeScale.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plPointChannel.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(PointTimeScale, plPointTimeScale)
 
 PY_PLASMA_TYPE(PointTimeScale, plPointTimeScale, "plPointTimeScale wrapper")
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(PointTimeScale) {
 }
 
 PY_PLASMA_IFC_METHODS(PointTimeScale, plPointTimeScale)
-
-}

--- a/Python/PRP/Avatar/pyQuatBlend.cpp
+++ b/Python/PRP/Avatar/pyQuatBlend.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plQuatChannel.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(QuatBlend, plQuatBlend)
 
 PY_PLASMA_TYPE(QuatBlend, plQuatBlend, "plQuatBlend wrapper")
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(QuatBlend) {
 }
 
 PY_PLASMA_IFC_METHODS(QuatBlend, plQuatBlend)
-
-}

--- a/Python/PRP/Avatar/pyQuatChannel.cpp
+++ b/Python/PRP/Avatar/pyQuatChannel.cpp
@@ -20,8 +20,6 @@
 #include "PRP/pyCreatable.h"
 #include "Math/pyGeometry3.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(QuatChannel, plQuatChannel)
 
 PY_PROPERTY(hsQuat, QuatChannel, result, getResult, setResult)
@@ -45,5 +43,3 @@ PY_PLASMA_TYPE_INIT(QuatChannel) {
 }
 
 PY_PLASMA_IFC_METHODS(QuatChannel, plQuatChannel)
-
-}

--- a/Python/PRP/Avatar/pyQuatChannelApplicator.cpp
+++ b/Python/PRP/Avatar/pyQuatChannelApplicator.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plQuatChannel.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(QuatChannelApplicator, plQuatChannelApplicator)
 
 PY_PLASMA_TYPE(QuatChannelApplicator, plQuatChannelApplicator,
@@ -37,5 +35,3 @@ PY_PLASMA_TYPE_INIT(QuatChannelApplicator) {
 }
 
 PY_PLASMA_IFC_METHODS(QuatChannelApplicator, plQuatChannelApplicator)
-
-}

--- a/Python/PRP/Avatar/pyQuatConstant.cpp
+++ b/Python/PRP/Avatar/pyQuatConstant.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plQuatChannel.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(QuatConstant, plQuatConstant)
 
 PY_PLASMA_TYPE(QuatConstant, plQuatConstant, "plQuatConstant wrapper")
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(QuatConstant) {
 }
 
 PY_PLASMA_IFC_METHODS(QuatConstant, plQuatConstant)
-
-}

--- a/Python/PRP/Avatar/pyQuatPointCombine.cpp
+++ b/Python/PRP/Avatar/pyQuatPointCombine.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plMatrixChannel.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(QuatPointCombine, plQuatPointCombine)
 
 PY_PLASMA_TYPE(QuatPointCombine, plQuatPointCombine, "plQuatPointCombine wrapper")
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(QuatPointCombine) {
 }
 
 PY_PLASMA_IFC_METHODS(QuatPointCombine, plQuatPointCombine)
-
-}

--- a/Python/PRP/Avatar/pyQuatTimeScale.cpp
+++ b/Python/PRP/Avatar/pyQuatTimeScale.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plQuatChannel.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(QuatTimeScale, plQuatTimeScale)
 
 PY_PLASMA_TYPE(QuatTimeScale, plQuatTimeScale, "plQuatTimeScale wrapper")
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(QuatTimeScale) {
 }
 
 PY_PLASMA_IFC_METHODS(QuatTimeScale, plQuatTimeScale)
-
-}

--- a/Python/PRP/Avatar/pyRelativeMatrixChannelApplicator.cpp
+++ b/Python/PRP/Avatar/pyRelativeMatrixChannelApplicator.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plMatrixChannel.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(RelativeMatrixChannelApplicator, plRelativeMatrixChannelApplicator)
 
 PY_PLASMA_TYPE(RelativeMatrixChannelApplicator, plRelativeMatrixChannelApplicator,
@@ -37,5 +35,3 @@ PY_PLASMA_TYPE_INIT(RelativeMatrixChannelApplicator) {
 }
 
 PY_PLASMA_IFC_METHODS(RelativeMatrixChannelApplicator, plRelativeMatrixChannelApplicator)
-
-}

--- a/Python/PRP/Avatar/pyScalarBlend.cpp
+++ b/Python/PRP/Avatar/pyScalarBlend.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plScalarChannel.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ScalarBlend, plScalarBlend)
 
 PY_PLASMA_TYPE(ScalarBlend, plScalarBlend, "plScalarBlend wrapper")
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(ScalarBlend) {
 }
 
 PY_PLASMA_IFC_METHODS(ScalarBlend, plScalarBlend)
-
-}

--- a/Python/PRP/Avatar/pyScalarChannel.cpp
+++ b/Python/PRP/Avatar/pyScalarChannel.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plScalarChannel.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ScalarChannel, plScalarChannel)
 
 PY_PROPERTY(float, ScalarChannel, result, getResult, setResult)
@@ -44,5 +42,3 @@ PY_PLASMA_TYPE_INIT(ScalarChannel) {
 }
 
 PY_PLASMA_IFC_METHODS(ScalarChannel, plScalarChannel)
-
-}

--- a/Python/PRP/Avatar/pyScalarChannelApplicator.cpp
+++ b/Python/PRP/Avatar/pyScalarChannelApplicator.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plScalarChannel.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ScalarChannelApplicator, plScalarChannelApplicator)
 
 PY_PLASMA_TYPE(ScalarChannelApplicator, plScalarChannelApplicator,
@@ -37,5 +35,3 @@ PY_PLASMA_TYPE_INIT(ScalarChannelApplicator) {
 }
 
 PY_PLASMA_IFC_METHODS(ScalarChannelApplicator, plScalarChannelApplicator)
-
-}

--- a/Python/PRP/Avatar/pyScalarConstant.cpp
+++ b/Python/PRP/Avatar/pyScalarConstant.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plScalarChannel.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ScalarConstant, plScalarConstant)
 
 PY_PLASMA_TYPE(ScalarConstant, plScalarConstant, "plScalarConstant wrapper")
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(ScalarConstant) {
 }
 
 PY_PLASMA_IFC_METHODS(ScalarConstant, plScalarConstant)
-
-}

--- a/Python/PRP/Avatar/pyScalarControllerCacheChannel.cpp
+++ b/Python/PRP/Avatar/pyScalarControllerCacheChannel.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plScalarChannel.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ScalarControllerCacheChannel, plScalarControllerCacheChannel)
 
 PY_PLASMA_TYPE(ScalarControllerCacheChannel, plScalarControllerCacheChannel,
@@ -37,5 +35,3 @@ PY_PLASMA_TYPE_INIT(ScalarControllerCacheChannel) {
 }
 
 PY_PLASMA_IFC_METHODS(ScalarControllerCacheChannel, plScalarControllerCacheChannel)
-
-}

--- a/Python/PRP/Avatar/pyScalarControllerChannel.cpp
+++ b/Python/PRP/Avatar/pyScalarControllerChannel.cpp
@@ -20,8 +20,6 @@
 #include "PRP/pyCreatable.h"
 #include "PRP/Animation/pyController.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ScalarControllerChannel, plScalarControllerChannel)
 
 PY_PROPERTY_CREATABLE(plController, Controller, ScalarControllerChannel,
@@ -47,5 +45,3 @@ PY_PLASMA_TYPE_INIT(ScalarControllerChannel) {
 }
 
 PY_PLASMA_IFC_METHODS(ScalarControllerChannel, plScalarControllerChannel)
-
-}

--- a/Python/PRP/Avatar/pyScalarSDLChannel.cpp
+++ b/Python/PRP/Avatar/pyScalarSDLChannel.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plScalarChannel.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ScalarSDLChannel, plScalarSDLChannel)
 
 PY_PLASMA_TYPE(ScalarSDLChannel, plScalarSDLChannel, "plScalarSDLChannel wrapper")
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(ScalarSDLChannel) {
 }
 
 PY_PLASMA_IFC_METHODS(ScalarSDLChannel, plScalarSDLChannel)
-
-}

--- a/Python/PRP/Avatar/pyScalarTimeScale.cpp
+++ b/Python/PRP/Avatar/pyScalarTimeScale.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plScalarChannel.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ScalarTimeScale, plScalarTimeScale)
 
 PY_PLASMA_TYPE(ScalarTimeScale, plScalarTimeScale, "plScalarTimeScale wrapper")
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(ScalarTimeScale) {
 }
 
 PY_PLASMA_IFC_METHODS(ScalarTimeScale, plScalarTimeScale)
-
-}

--- a/Python/PRP/Avatar/pySittingModifier.cpp
+++ b/Python/PRP/Avatar/pySittingModifier.cpp
@@ -20,8 +20,6 @@
 #include "PRP/Modifier/pyModifier.h"
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(SittingModifier, plSittingModifier)
 
 PY_METHOD_VA(SittingModifier, addNotifyKey,
@@ -103,5 +101,3 @@ PY_PLASMA_TYPE_INIT(SittingModifier) {
 }
 
 PY_PLASMA_IFC_METHODS(SittingModifier, plSittingModifier)
-
-};

--- a/Python/PRP/Avatar/pySoundVolumeApplicator.cpp
+++ b/Python/PRP/Avatar/pySoundVolumeApplicator.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plAGApplicator.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(SoundVolumeApplicator, plSoundVolumeApplicator)
 
 PY_PROPERTY(unsigned int, SoundVolumeApplicator, index, getIndex, setIndex)
@@ -45,5 +43,3 @@ PY_PLASMA_TYPE_INIT(SoundVolumeApplicator) {
 }
 
 PY_PLASMA_IFC_METHODS(SoundVolumeApplicator, plSoundVolumeApplicator)
-
-}

--- a/Python/PRP/Avatar/pySpotInnerApplicator.cpp
+++ b/Python/PRP/Avatar/pySpotInnerApplicator.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plAGApplicator.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(SpotInnerApplicator, plSpotInnerApplicator)
 
 PY_PLASMA_TYPE(SpotInnerApplicator, plSpotInnerApplicator,
@@ -37,5 +35,3 @@ PY_PLASMA_TYPE_INIT(SpotInnerApplicator) {
 }
 
 PY_PLASMA_IFC_METHODS(SpotInnerApplicator, plSpotInnerApplicator)
-
-}

--- a/Python/PRP/Avatar/pySpotOuterApplicator.cpp
+++ b/Python/PRP/Avatar/pySpotOuterApplicator.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Avatar/plAGApplicator.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(SpotOuterApplicator, plSpotOuterApplicator)
 
 PY_PLASMA_TYPE(SpotOuterApplicator, plSpotOuterApplicator,
@@ -37,5 +35,3 @@ PY_PLASMA_TYPE_INIT(SpotOuterApplicator) {
 }
 
 PY_PLASMA_IFC_METHODS(SpotOuterApplicator, plSpotOuterApplicator)
-
-}

--- a/Python/PRP/ConditionalObject/pyANDConditionalObject.cpp
+++ b/Python/PRP/ConditionalObject/pyANDConditionalObject.cpp
@@ -20,8 +20,6 @@
 #include "pyConditionalObject.h"
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ANDConditionalObject, plANDConditionalObject)
 
 PY_METHOD_VA(ANDConditionalObject, addChild,
@@ -95,5 +93,3 @@ PY_PLASMA_TYPE_INIT(ANDConditionalObject) {
 }
 
 PY_PLASMA_IFC_METHODS(ANDConditionalObject, plANDConditionalObject)
-
-};

--- a/Python/PRP/ConditionalObject/pyActivatorActivatorConditionalObject.cpp
+++ b/Python/PRP/ConditionalObject/pyActivatorActivatorConditionalObject.cpp
@@ -19,8 +19,6 @@
 #include <PRP/ConditionalObject/plActivatorConditionalObject.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ActivatorActivatorConditionalObject, plActivatorActivatorConditionalObject)
 
 PY_PLASMA_TYPE(ActivatorActivatorConditionalObject, plActivatorActivatorConditionalObject,
@@ -37,5 +35,3 @@ PY_PLASMA_TYPE_INIT(ActivatorActivatorConditionalObject) {
 }
 
 PY_PLASMA_IFC_METHODS(ActivatorActivatorConditionalObject, plActivatorActivatorConditionalObject)
-
-};

--- a/Python/PRP/ConditionalObject/pyActivatorConditionalObject.cpp
+++ b/Python/PRP/ConditionalObject/pyActivatorConditionalObject.cpp
@@ -21,8 +21,6 @@
 #include "PRP/pyCreatable.h"
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ActivatorConditionalObject, plActivatorConditionalObject)
 
 PY_METHOD_VA(ActivatorConditionalObject, addActivator,
@@ -98,5 +96,3 @@ PY_PLASMA_TYPE_INIT(ActivatorConditionalObject) {
 }
 
 PY_PLASMA_IFC_METHODS(ActivatorConditionalObject, plActivatorConditionalObject)
-
-};

--- a/Python/PRP/ConditionalObject/pyAnimationEventConditionalObject.cpp
+++ b/Python/PRP/ConditionalObject/pyAnimationEventConditionalObject.cpp
@@ -20,8 +20,6 @@
 #include "pyConditionalObject.h"
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(AnimationEventConditionalObject, plAnimationEventConditionalObject)
 
 PY_PROPERTY(CallbackEvent, AnimationEventConditionalObject, action, getAction, setAction)
@@ -48,5 +46,3 @@ PY_PLASMA_TYPE_INIT(AnimationEventConditionalObject) {
 }
 
 PY_PLASMA_IFC_METHODS(AnimationEventConditionalObject, plAnimationEventConditionalObject)
-
-};

--- a/Python/PRP/ConditionalObject/pyConditionalObject.cpp
+++ b/Python/PRP/ConditionalObject/pyConditionalObject.cpp
@@ -20,8 +20,6 @@
 #include "PRP/KeyedObject/pyKeyedObject.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(ConditionalObject, "plConditionalObject is abstract")
 
 PY_PROPERTY(bool, ConditionalObject, satisfied, getSatisfied, setSatisfied)
@@ -47,5 +45,3 @@ PY_PLASMA_TYPE_INIT(ConditionalObject) {
 }
 
 PY_PLASMA_IFC_METHODS(ConditionalObject, plConditionalObject)
-
-};

--- a/Python/PRP/ConditionalObject/pyControlEventConditionalObject.cpp
+++ b/Python/PRP/ConditionalObject/pyControlEventConditionalObject.cpp
@@ -19,8 +19,6 @@
 #include <PRP/ConditionalObject/plControlEventConditionalObject.h>
 #include "pyConditionalObject.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ControlEventConditionalObject, plControlEventConditionalObject)
 
 PY_PROPERTY(ControlEventCode, ControlEventConditionalObject, controlEvent,
@@ -46,5 +44,3 @@ PY_PLASMA_TYPE_INIT(ControlEventConditionalObject) {
 }
 
 PY_PLASMA_IFC_METHODS(ControlEventConditionalObject, plControlEventConditionalObject)
-
-};

--- a/Python/PRP/ConditionalObject/pyFacingConditionalObject.cpp
+++ b/Python/PRP/ConditionalObject/pyFacingConditionalObject.cpp
@@ -19,8 +19,6 @@
 #include <PRP/ConditionalObject/plFacingConditionalObject.h>
 #include "pyConditionalObject.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(FacingConditionalObject, plFacingConditionalObject)
 
 PY_PROPERTY(float, FacingConditionalObject, tolerance, getTolerance, setTolerance)
@@ -47,5 +45,3 @@ PY_PLASMA_TYPE_INIT(FacingConditionalObject) {
 }
 
 PY_PLASMA_IFC_METHODS(FacingConditionalObject, plFacingConditionalObject)
-
-};

--- a/Python/PRP/ConditionalObject/pyKeyPressConditionalObject.cpp
+++ b/Python/PRP/ConditionalObject/pyKeyPressConditionalObject.cpp
@@ -19,8 +19,6 @@
 #include <PRP/ConditionalObject/plKeyPressConditionalObject.h>
 #include "pyConditionalObject.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(KeyPressConditionalObject, plKeyPressConditionalObject)
 
 PY_PROPERTY(plKeyDef, KeyPressConditionalObject, keyEvent, getKeyEvent, setKeyEvent)
@@ -45,5 +43,3 @@ PY_PLASMA_TYPE_INIT(KeyPressConditionalObject) {
 }
 
 PY_PLASMA_IFC_METHODS(KeyPressConditionalObject, plKeyPressConditionalObject)
-
-};

--- a/Python/PRP/ConditionalObject/pyLocalPlayerInBoxConditionalObject.cpp
+++ b/Python/PRP/ConditionalObject/pyLocalPlayerInBoxConditionalObject.cpp
@@ -19,8 +19,6 @@
 #include <PRP/ConditionalObject/plDetectConditionalObjects.hpp>
 #include "pyConditionalObject.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(LocalPlayerInBoxConditionalObject, plLocalPlayerInBoxConditionalObject)
 
 PY_PLASMA_TYPE(LocalPlayerInBoxConditionalObject, plLocalPlayerInBoxConditionalObject,
@@ -37,5 +35,3 @@ PY_PLASMA_TYPE_INIT(LocalPlayerInBoxConditionalObject) {
 }
 
 PY_PLASMA_IFC_METHODS(LocalPlayerInBoxConditionalObject, plLocalPlayerInBoxConditionalObject)
-
-};

--- a/Python/PRP/ConditionalObject/pyLocalPlayerIntersectPlaneConditionalObject.cpp
+++ b/Python/PRP/ConditionalObject/pyLocalPlayerIntersectPlaneConditionalObject.cpp
@@ -19,8 +19,6 @@
 #include <PRP/ConditionalObject/plDetectConditionalObjects.hpp>
 #include "pyConditionalObject.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(LocalPlayerIntersectPlaneConditionalObject,
               plLocalPlayerIntersectPlaneConditionalObject)
 
@@ -40,5 +38,3 @@ PY_PLASMA_TYPE_INIT(LocalPlayerIntersectPlaneConditionalObject) {
 
 PY_PLASMA_IFC_METHODS(LocalPlayerIntersectPlaneConditionalObject,
                       plLocalPlayerIntersectPlaneConditionalObject)
-
-};

--- a/Python/PRP/ConditionalObject/pyORConditionalObject.cpp
+++ b/Python/PRP/ConditionalObject/pyORConditionalObject.cpp
@@ -20,8 +20,6 @@
 #include "pyConditionalObject.h"
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ORConditionalObject, plORConditionalObject)
 
 PY_METHOD_VA(ORConditionalObject, addChild,
@@ -95,5 +93,3 @@ PY_PLASMA_TYPE_INIT(ORConditionalObject) {
 }
 
 PY_PLASMA_IFC_METHODS(ORConditionalObject, plORConditionalObject)
-
-};

--- a/Python/PRP/ConditionalObject/pyObjectInBoxConditionalObject.cpp
+++ b/Python/PRP/ConditionalObject/pyObjectInBoxConditionalObject.cpp
@@ -19,8 +19,6 @@
 #include <PRP/ConditionalObject/plDetectConditionalObjects.hpp>
 #include "pyConditionalObject.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ObjectInBoxConditionalObject, plObjectInBoxConditionalObject)
 
 PY_PLASMA_TYPE(ObjectInBoxConditionalObject, plObjectInBoxConditionalObject,
@@ -37,5 +35,3 @@ PY_PLASMA_TYPE_INIT(ObjectInBoxConditionalObject) {
 }
 
 PY_PLASMA_IFC_METHODS(ObjectInBoxConditionalObject, plObjectInBoxConditionalObject)
-
-};

--- a/Python/PRP/ConditionalObject/pyObjectIntersectPlaneConditionalObject.cpp
+++ b/Python/PRP/ConditionalObject/pyObjectIntersectPlaneConditionalObject.cpp
@@ -19,8 +19,6 @@
 #include <PRP/ConditionalObject/plDetectConditionalObjects.hpp>
 #include "pyConditionalObject.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ObjectIntersectPlaneConditionalObject, plObjectIntersectPlaneConditionalObject)
 
 PY_PLASMA_TYPE(ObjectIntersectPlaneConditionalObject, plObjectIntersectPlaneConditionalObject,
@@ -37,5 +35,3 @@ PY_PLASMA_TYPE_INIT(ObjectIntersectPlaneConditionalObject) {
 }
 
 PY_PLASMA_IFC_METHODS(ObjectIntersectPlaneConditionalObject, plObjectIntersectPlaneConditionalObject)
-
-};

--- a/Python/PRP/ConditionalObject/pyVolActivatorConditionalObject.cpp
+++ b/Python/PRP/ConditionalObject/pyVolActivatorConditionalObject.cpp
@@ -19,8 +19,6 @@
 #include <PRP/ConditionalObject/plActivatorConditionalObject.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(VolActivatorConditionalObject, plVolActivatorConditionalObject)
 
 PY_PLASMA_TYPE(VolActivatorConditionalObject, plVolActivatorConditionalObject,
@@ -37,5 +35,3 @@ PY_PLASMA_TYPE_INIT(VolActivatorConditionalObject) {
 }
 
 PY_PLASMA_IFC_METHODS(VolActivatorConditionalObject, plVolActivatorConditionalObject)
-
-};

--- a/Python/PRP/ConditionalObject/pyVolumeSensorConditionalObject.cpp
+++ b/Python/PRP/ConditionalObject/pyVolumeSensorConditionalObject.cpp
@@ -20,8 +20,6 @@
 #include "pyConditionalObject.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(VolumeSensorConditionalObject, plVolumeSensorConditionalObject)
 
 PY_PROPERTY(int, VolumeSensorConditionalObject, trigNum, getTrigNum, setTrigNum)
@@ -55,5 +53,3 @@ PY_PLASMA_TYPE_INIT(VolumeSensorConditionalObject) {
 }
 
 PY_PLASMA_IFC_METHODS(VolumeSensorConditionalObject, plVolumeSensorConditionalObject)
-
-};

--- a/Python/PRP/ConditionalObject/pyVolumeSensorConditionalObjectNoArbitration.cpp
+++ b/Python/PRP/ConditionalObject/pyVolumeSensorConditionalObjectNoArbitration.cpp
@@ -18,8 +18,6 @@
 
 #include <PRP/ConditionalObject/plVolumeSensorConditionalObject.h>
 
-extern "C" {
-
 PY_PLASMA_NEW(VolumeSensorConditionalObjectNoArbitration,
               plVolumeSensorConditionalObjectNoArbitration)
 
@@ -39,5 +37,3 @@ PY_PLASMA_TYPE_INIT(VolumeSensorConditionalObjectNoArbitration) {
 
 PY_PLASMA_IFC_METHODS(VolumeSensorConditionalObjectNoArbitration,
                       plVolumeSensorConditionalObjectNoArbitration)
-
-};

--- a/Python/PRP/GUI/pyGUIButtonMod.cpp
+++ b/Python/PRP/GUI/pyGUIButtonMod.cpp
@@ -20,8 +20,6 @@
 #include "PRP/KeyedObject/pyKey.h"
 
 /* pyGUIButtonMod */
-extern "C" {
-
 PY_PLASMA_NEW(GUIButtonMod, pfGUIButtonMod)
 
 PY_METHOD_VA(GUIButtonMod, addAnimationKey,
@@ -141,7 +139,7 @@ static PyGetSetDef pyGUIButtonMod_GetSet[] = {
     PY_GETSET_TERMINATOR
 };
 
-PY_PLASMA_TYPE(GUIButtonMod, pfGUIButtonMod, "pfGUIButtonMod wrapper");
+PY_PLASMA_TYPE(GUIButtonMod, pfGUIButtonMod, "pfGUIButtonMod wrapper")
 
 PY_PLASMA_TYPE_INIT(GUIButtonMod) {
     pyGUIButtonMod_Type.tp_new = pyGUIButtonMod_new;
@@ -162,14 +160,11 @@ PY_PLASMA_TYPE_INIT(GUIButtonMod) {
 
 PY_PLASMA_IFC_METHODS(GUIButtonMod, pfGUIButtonMod)
 
-}
 
 /* pyGUIMenuItem */
-extern "C" {
-
 PY_PLASMA_NEW(GUIMenuItem, pfGUIMenuItem)
 
-PY_PLASMA_TYPE(GUIMenuItem, pfGUIMenuItem, "pfGUIMenuItem wrapper");
+PY_PLASMA_TYPE(GUIMenuItem, pfGUIMenuItem, "pfGUIMenuItem wrapper")
 
 PY_PLASMA_TYPE_INIT(GUIMenuItem) {
     pyGUIMenuItem_Type.tp_new = pyGUIMenuItem_new;
@@ -186,5 +181,3 @@ PY_PLASMA_TYPE_INIT(GUIMenuItem) {
 }
 
 PY_PLASMA_IFC_METHODS(GUIMenuItem, pfGUIMenuItem)
-
-}

--- a/Python/PRP/GUI/pyGUICheckBoxCtrl.cpp
+++ b/Python/PRP/GUI/pyGUICheckBoxCtrl.cpp
@@ -19,8 +19,6 @@
 #include "PRP/GUI/pyGUIControlMod.h"
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(GUICheckBoxCtrl, pfGUICheckBoxCtrl)
 
 PY_METHOD_VA(GUICheckBoxCtrl, addAnimKey,
@@ -86,8 +84,7 @@ static PyGetSetDef pyGUICheckBoxCtrl_GetSet[] = {
     PY_GETSET_TERMINATOR
 };
 
-PY_PLASMA_TYPE(GUICheckBoxCtrl, pfGUICheckBoxCtrl, "pfGUICheckBoxCtrl wrapper");
-
+PY_PLASMA_TYPE(GUICheckBoxCtrl, pfGUICheckBoxCtrl, "pfGUICheckBoxCtrl wrapper")
 
 PY_PLASMA_TYPE_INIT(GUICheckBoxCtrl) {
     pyGUICheckBoxCtrl_Type.tp_new = pyGUICheckBoxCtrl_new;
@@ -102,5 +99,3 @@ PY_PLASMA_TYPE_INIT(GUICheckBoxCtrl) {
 }
 
 PY_PLASMA_IFC_METHODS(GUICheckBoxCtrl, pfGUICheckBoxCtrl)
-
-}

--- a/Python/PRP/GUI/pyGUICloseDlgProc.cpp
+++ b/Python/PRP/GUI/pyGUICloseDlgProc.cpp
@@ -18,8 +18,6 @@
 
 #include <PRP/GUI/pfGUIControlHandlers.h>
 
-extern "C" {
-
 PY_PLASMA_NEW(GUICloseDlgProc, pfGUICloseDlgProc)
 
 PY_PLASMA_TYPE(GUICloseDlgProc, pfGUICloseDlgProc, "pfGUICloseDlgProc wrapper")
@@ -35,5 +33,3 @@ PY_PLASMA_TYPE_INIT(GUICloseDlgProc) {
 }
 
 PY_PLASMA_IFC_METHODS(GUICloseDlgProc, pfGUICloseDlgProc)
-
-}

--- a/Python/PRP/GUI/pyGUIConsoleCmdProc.cpp
+++ b/Python/PRP/GUI/pyGUIConsoleCmdProc.cpp
@@ -18,8 +18,6 @@
 
 #include <PRP/GUI/pfGUIControlHandlers.h>
 
-extern "C" {
-
 PY_PLASMA_NEW(GUIConsoleCmdProc, pfGUIConsoleCmdProc)
 
 PY_PROPERTY(ST::string, GUIConsoleCmdProc, command, getCommand, setCommand)
@@ -43,5 +41,3 @@ PY_PLASMA_TYPE_INIT(GUIConsoleCmdProc) {
 }
 
 PY_PLASMA_IFC_METHODS(GUIConsoleCmdProc, pfGUIConsoleCmdProc)
-
-}

--- a/Python/PRP/GUI/pyGUIControlMod.cpp
+++ b/Python/PRP/GUI/pyGUIControlMod.cpp
@@ -22,8 +22,6 @@
 #include "pyGUIControlHandlers.h"
 
 /* pyGUIColorScheme */
-extern "C" {
-
 PY_PLASMA_NEW(GUIColorScheme, pfGUIColorScheme)
 
 PY_PROPERTY(hsColorRGBA, GUIColorScheme, foreColor, getForeColor, setForeColor)
@@ -47,7 +45,7 @@ static PyGetSetDef pyGUIColorScheme_GetSet[] = {
     PY_GETSET_TERMINATOR
 };
 
-PY_PLASMA_TYPE(GUIColorScheme, pfGUIColorScheme, "pfGUIColorScheme wrapper");
+PY_PLASMA_TYPE(GUIColorScheme, pfGUIColorScheme, "pfGUIColorScheme wrapper")
 
 PY_PLASMA_TYPE_INIT(GUIColorScheme) {
     pyGUIColorScheme_Type.tp_new = pyGUIColorScheme_new;
@@ -66,11 +64,8 @@ PY_PLASMA_TYPE_INIT(GUIColorScheme) {
 
 PY_PLASMA_IFC_METHODS(GUIColorScheme, pfGUIColorScheme)
 
-}
 
 /* pyGUIControlMod */
-extern "C" {
-
 PY_PLASMA_NEW(GUIControlMod, pfGUIControlMod)
 
 PY_METHOD_NOARGS(GUIControlMod, clearSoundIndices, "Remove all sound indices from the control") {
@@ -154,7 +149,7 @@ static PyGetSetDef pyGUIControlMod_GetSet[] = {
     PY_GETSET_TERMINATOR
 };
 
-PY_PLASMA_TYPE(GUIControlMod, pfGUIControlMod, "pfGUIControlMod wrapper");
+PY_PLASMA_TYPE(GUIControlMod, pfGUIControlMod, "pfGUIControlMod wrapper")
 
 PY_PLASMA_TYPE_INIT(GUIControlMod) {
     pyGUIControlMod_Type.tp_new = pyGUIControlMod_new;
@@ -179,5 +174,3 @@ PY_PLASMA_TYPE_INIT(GUIControlMod) {
 }
 
 PY_PLASMA_IFC_METHODS(GUIControlMod, pfGUIControlMod)
-
-}

--- a/Python/PRP/GUI/pyGUICtrlProcObject.cpp
+++ b/Python/PRP/GUI/pyGUICtrlProcObject.cpp
@@ -18,8 +18,6 @@
 
 #include <PRP/GUI/pfGUIControlHandlers.h>
 
-extern "C" {
-
 PY_PLASMA_DEALLOC(GUICtrlProcObject)
 PY_PLASMA_EMPTY_INIT(GUICtrlProcObject)
 PY_PLASMA_NEW_MSG(GUICtrlProcObject, "pfGUICtrlProcObject is abstract")
@@ -38,5 +36,3 @@ PY_PLASMA_TYPE_INIT(GUICtrlProcObject) {
 }
 
 PY_PLASMA_IFC_METHODS(GUICtrlProcObject, pfGUICtrlProcObject)
-
-}

--- a/Python/PRP/GUI/pyGUICtrlProcWriteableObject.cpp
+++ b/Python/PRP/GUI/pyGUICtrlProcWriteableObject.cpp
@@ -19,8 +19,6 @@
 #include <PRP/GUI/pfGUIControlHandlers.h>
 #include "Stream/pyStream.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(GUICtrlProcWriteableObject, "pfGUICtrlProcWriteableObject is abstract")
 
 PY_METHOD_STATIC_VA(GUICtrlProcWriteableObject, Read,
@@ -112,5 +110,3 @@ PY_PLASMA_TYPE_INIT(GUICtrlProcWriteableObject) {
 }
 
 PY_PLASMA_IFC_METHODS(GUICtrlProcWriteableObject, pfGUICtrlProcWriteableObject)
-
-}

--- a/Python/PRP/GUI/pyGUIDialogMod.cpp
+++ b/Python/PRP/GUI/pyGUIDialogMod.cpp
@@ -20,8 +20,6 @@
 #include "PRP/Modifier/pyModifier.h"
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(GUIDialogMod, pfGUIDialogMod)
 
 PY_METHOD_VA(GUIDialogMod, addControl,
@@ -97,7 +95,7 @@ static PyGetSetDef pyGUIDialogMod_GetSet[] = {
     PY_GETSET_TERMINATOR
 };
 
-PY_PLASMA_TYPE(GUIDialogMod, pfGUIDialogMod, "pfGUIDialogMod wrapper");
+PY_PLASMA_TYPE(GUIDialogMod, pfGUIDialogMod, "pfGUIDialogMod wrapper")
 
 PY_PLASMA_TYPE_INIT(GUIDialogMod) {
     pyGUIDialogMod_Type.tp_new = pyGUIDialogMod_new;
@@ -112,5 +110,3 @@ PY_PLASMA_TYPE_INIT(GUIDialogMod) {
 }
 
 PY_PLASMA_IFC_METHODS(GUIDialogMod, pfGUIDialogMod)
-
-}

--- a/Python/PRP/GUI/pyGUIDialogProc.cpp
+++ b/Python/PRP/GUI/pyGUIDialogProc.cpp
@@ -18,8 +18,6 @@
 
 #include <PRP/GUI/pfGUIControlHandlers.h>
 
-extern "C" {
-
 PY_PLASMA_NEW(GUIDialogProc, pfGUIDialogProc)
 
 PY_PLASMA_TYPE(GUIDialogProc, pfGUIDialogProc, "pfGUIDialogProc wrapper")
@@ -35,5 +33,3 @@ PY_PLASMA_TYPE_INIT(GUIDialogProc) {
 }
 
 PY_PLASMA_IFC_METHODS(GUIDialogProc, pfGUIDialogProc)
-
-}

--- a/Python/PRP/GUI/pyGUIDynDisplayCtrl.cpp
+++ b/Python/PRP/GUI/pyGUIDynDisplayCtrl.cpp
@@ -19,8 +19,6 @@
 #include "PRP/GUI/pyGUIControlMod.h"
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(GUIDynDisplayCtrl, pfGUIDynDisplayCtrl)
 
 PY_METHOD_VA(GUIDynDisplayCtrl, addTextMap,
@@ -181,7 +179,7 @@ static PyGetSetDef pyGUIDynDisplayCtrl_GetSet[] = {
     PY_GETSET_TERMINATOR
 };
 
-PY_PLASMA_TYPE(GUIDynDisplayCtrl, pfGUIDynDisplayCtrl, "pfGUIDynDisplayCtrl wrapper");
+PY_PLASMA_TYPE(GUIDynDisplayCtrl, pfGUIDynDisplayCtrl, "pfGUIDynDisplayCtrl wrapper")
 
 PY_PLASMA_TYPE_INIT(GUIDynDisplayCtrl) {
     pyGUIDynDisplayCtrl_Type.tp_new = pyGUIDynDisplayCtrl_new;
@@ -196,5 +194,3 @@ PY_PLASMA_TYPE_INIT(GUIDynDisplayCtrl) {
 }
 
 PY_PLASMA_IFC_METHODS(GUIDynDisplayCtrl, pfGUIDynDisplayCtrl)
-
-}

--- a/Python/PRP/GUI/pyGUIKnobCtrl.cpp
+++ b/Python/PRP/GUI/pyGUIKnobCtrl.cpp
@@ -20,8 +20,6 @@
 #include "PRP/KeyedObject/pyKey.h"
 #include "Math/pyGeometry3.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(GUIKnobCtrl, pfGUIKnobCtrl)
 
 PY_METHOD_VA(GUIKnobCtrl, addAnimationKey,
@@ -89,7 +87,7 @@ static PyGetSetDef pyGUIKnobCtrl_GetSet[] = {
     PY_GETSET_TERMINATOR
 };
 
-PY_PLASMA_TYPE(GUIKnobCtrl, pfGUIKnobCtrl, "pfGUIKnobCtrl wrapper");
+PY_PLASMA_TYPE(GUIKnobCtrl, pfGUIKnobCtrl, "pfGUIKnobCtrl wrapper")
 
 PY_PLASMA_TYPE_INIT(GUIKnobCtrl) {
     pyGUIKnobCtrl_Type.tp_new = pyGUIKnobCtrl_new;
@@ -111,5 +109,3 @@ PY_PLASMA_TYPE_INIT(GUIKnobCtrl) {
 }
 
 PY_PLASMA_IFC_METHODS(GUIKnobCtrl, pfGUIKnobCtrl)
-
-}

--- a/Python/PRP/GUI/pyGUIListBoxMod.cpp
+++ b/Python/PRP/GUI/pyGUIListBoxMod.cpp
@@ -20,8 +20,6 @@
 #include "PRP/GUI/pyGUIControlMod.h"
 
 /* pyGUIListElement */
-extern "C" {
-
 PY_PLASMA_VALUE_NEW(GUIListElement, pfGUIListElement)
 
 PY_PROPERTY(bool, GUIListElement, selected, isSelected, setSelected)
@@ -31,7 +29,7 @@ static PyGetSetDef pyGUIListElement_GetSet[] = {
     PY_GETSET_TERMINATOR
 };
 
-PY_PLASMA_TYPE(GUIListElement, pfGUIListElement, "pfGUIListElement wrapper");
+PY_PLASMA_TYPE(GUIListElement, pfGUIListElement, "pfGUIListElement wrapper")
 
 PY_PLASMA_TYPE_INIT(GUIListElement) {
     pyGUIListElement_Type.tp_new = pyGUIListElement_new;
@@ -50,11 +48,8 @@ PY_PLASMA_TYPE_INIT(GUIListElement) {
 
 PY_PLASMA_VALUE_IFC_METHODS(GUIListElement, pfGUIListElement)
 
-}
 
 /* pyGUIListBoxMod */
-extern "C" {
-
 PY_PLASMA_NEW(GUIListBoxMod, pfGUIListBoxMod)
 
 PY_PROPERTY(plKey, GUIListBoxMod, scrollCtrl, getScrollCtrl, setScrollCtrl)
@@ -64,7 +59,7 @@ static PyGetSetDef pyGUIListBoxMod_GetSet[] = {
     PY_GETSET_TERMINATOR
 };
 
-PY_PLASMA_TYPE(GUIListBoxMod, pfGUIListBoxMod, "pfGUIListBoxMod wrapper");
+PY_PLASMA_TYPE(GUIListBoxMod, pfGUIListBoxMod, "pfGUIListBoxMod wrapper")
 
 PY_PLASMA_TYPE_INIT(GUIListBoxMod) {
     pyGUIListBoxMod_Type.tp_new = pyGUIListBoxMod_new;
@@ -90,5 +85,3 @@ PY_PLASMA_TYPE_INIT(GUIListBoxMod) {
 }
 
 PY_PLASMA_IFC_METHODS(GUIListBoxMod, pfGUIListBoxMod)
-
-}

--- a/Python/PRP/GUI/pyGUIMisc.cpp
+++ b/Python/PRP/GUI/pyGUIMisc.cpp
@@ -20,11 +20,9 @@
 #include "PRP/GUI/pyGUIControlMod.h"
 
 /* pyGUIClickMapCtrl */
-extern "C" {
-
 PY_PLASMA_NEW(GUIClickMapCtrl, pfGUIClickMapCtrl)
 
-PY_PLASMA_TYPE(GUIClickMapCtrl, pfGUIClickMapCtrl, "pfGUIClickMapCtrl wrapper");
+PY_PLASMA_TYPE(GUIClickMapCtrl, pfGUIClickMapCtrl, "pfGUIClickMapCtrl wrapper")
 
 PY_PLASMA_TYPE_INIT(GUIClickMapCtrl) {
     pyGUIClickMapCtrl_Type.tp_new = pyGUIClickMapCtrl_new;
@@ -42,14 +40,11 @@ PY_PLASMA_TYPE_INIT(GUIClickMapCtrl) {
 
 PY_PLASMA_IFC_METHODS(GUIClickMapCtrl, pfGUIClickMapCtrl)
 
-}
 
 /* pyGUIDragBarCtrl */
-extern "C" {
-
 PY_PLASMA_NEW(GUIDragBarCtrl, pfGUIDragBarCtrl)
 
-PY_PLASMA_TYPE(GUIDragBarCtrl, pfGUIDragBarCtrl, "pfGUIDragBarCtrl wrapper");
+PY_PLASMA_TYPE(GUIDragBarCtrl, pfGUIDragBarCtrl, "pfGUIDragBarCtrl wrapper")
 
 PY_PLASMA_TYPE_INIT(GUIDragBarCtrl) {
     pyGUIDragBarCtrl_Type.tp_new = pyGUIDragBarCtrl_new;
@@ -63,14 +58,11 @@ PY_PLASMA_TYPE_INIT(GUIDragBarCtrl) {
 
 PY_PLASMA_IFC_METHODS(GUIDragBarCtrl, pfGUIDragBarCtrl)
 
-}
 
 /* pyGUIDraggableMod */
-extern "C" {
-
 PY_PLASMA_NEW(GUIDraggableMod, pfGUIDraggableMod)
 
-PY_PLASMA_TYPE(GUIDraggableMod, pfGUIDraggableMod, "pfGUIDraggableMod wrapper");
+PY_PLASMA_TYPE(GUIDraggableMod, pfGUIDraggableMod, "pfGUIDraggableMod wrapper")
 
 PY_PLASMA_TYPE_INIT(GUIDraggableMod) {
     pyGUIDraggableMod_Type.tp_new = pyGUIDraggableMod_new;
@@ -89,14 +81,11 @@ PY_PLASMA_TYPE_INIT(GUIDraggableMod) {
 
 PY_PLASMA_IFC_METHODS(GUIDraggableMod, pfGUIDraggableMod)
 
-}
 
 /* pyGUIEditBoxMod */
-extern "C" {
-
 PY_PLASMA_NEW(GUIEditBoxMod, pfGUIEditBoxMod)
 
-PY_PLASMA_TYPE(GUIEditBoxMod, pfGUIEditBoxMod, "pfGUIEditBoxMod wrapper");
+PY_PLASMA_TYPE(GUIEditBoxMod, pfGUIEditBoxMod, "pfGUIEditBoxMod wrapper")
 
 PY_PLASMA_TYPE_INIT(GUIEditBoxMod) {
     pyGUIEditBoxMod_Type.tp_new = pyGUIEditBoxMod_new;
@@ -109,5 +98,3 @@ PY_PLASMA_TYPE_INIT(GUIEditBoxMod) {
 }
 
 PY_PLASMA_IFC_METHODS(GUIEditBoxMod, pfGUIEditBoxMod)
-
-}

--- a/Python/PRP/GUI/pyGUIMultiLineEditCtrl.cpp
+++ b/Python/PRP/GUI/pyGUIMultiLineEditCtrl.cpp
@@ -19,8 +19,6 @@
 #include "PRP/KeyedObject/pyKey.h"
 #include "PRP/GUI/pyGUIControlMod.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(GUIMultiLineEditCtrl, pfGUIMultiLineEditCtrl)
 
 PY_PROPERTY(plKey, GUIMultiLineEditCtrl, scrollCtrl, getScrollCtrl, setScrollCtrl)
@@ -30,7 +28,7 @@ static PyGetSetDef pyGUIMultiLineEditCtrl_GetSet[] = {
     PY_GETSET_TERMINATOR
 };
 
-PY_PLASMA_TYPE(GUIMultiLineEditCtrl, pfGUIMultiLineEditCtrl, "pfGUIMultiLineEditCtrl wrapper");
+PY_PLASMA_TYPE(GUIMultiLineEditCtrl, pfGUIMultiLineEditCtrl, "pfGUIMultiLineEditCtrl wrapper")
 
 PY_PLASMA_TYPE_INIT(GUIMultiLineEditCtrl) {
     pyGUIMultiLineEditCtrl_Type.tp_new = pyGUIMultiLineEditCtrl_new;
@@ -44,5 +42,3 @@ PY_PLASMA_TYPE_INIT(GUIMultiLineEditCtrl) {
 }
 
 PY_PLASMA_IFC_METHODS(GUIMultiLineEditCtrl, pfGUIMultiLineEditCtrl)
-
-}

--- a/Python/PRP/GUI/pyGUIPopUpMenu.cpp
+++ b/Python/PRP/GUI/pyGUIPopUpMenu.cpp
@@ -19,8 +19,6 @@
 #include "PRP/GUI/pyGUIDialogMod.h"
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(GUIPopUpMenu, pfGUIPopUpMenu)
 
 PY_PROPERTY(unsigned short, GUIPopUpMenu, margin, getMargin, setMargin)
@@ -38,7 +36,7 @@ static PyGetSetDef pyGUIPopUpMenu_GetSet[] = {
     PY_GETSET_TERMINATOR
 };
 
-PY_PLASMA_TYPE(GUIPopUpMenu, pfGUIPopUpMenu, "pfGUIPopUpMenu wrapper");
+PY_PLASMA_TYPE(GUIPopUpMenu, pfGUIPopUpMenu, "pfGUIPopUpMenu wrapper")
 
 PY_PLASMA_TYPE_INIT(GUIPopUpMenu) {
     pyGUIPopUpMenu_Type.tp_new = pyGUIPopUpMenu_new;
@@ -63,5 +61,3 @@ PY_PLASMA_TYPE_INIT(GUIPopUpMenu) {
 }
 
 PY_PLASMA_IFC_METHODS(GUIPopUpMenu, pfGUIPopUpMenu)
-
-}

--- a/Python/PRP/GUI/pyGUIProgressCtrl.cpp
+++ b/Python/PRP/GUI/pyGUIProgressCtrl.cpp
@@ -19,8 +19,6 @@
 #include "PRP/GUI/pyGUIValueCtrl.h"
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(GUIProgressCtrl, pfGUIProgressCtrl)
 
 PY_METHOD_VA(GUIProgressCtrl, addAnimKey,
@@ -85,7 +83,7 @@ static PyGetSetDef pyGUIProgressCtrl_GetSet[] = {
     PY_GETSET_TERMINATOR
 };
 
-PY_PLASMA_TYPE(GUIProgressCtrl, pfGUIProgressCtrl, "pfGUIProgressCtrl wrapper");
+PY_PLASMA_TYPE(GUIProgressCtrl, pfGUIProgressCtrl, "pfGUIProgressCtrl wrapper")
 
 PY_PLASMA_TYPE_INIT(GUIProgressCtrl) {
     pyGUIProgressCtrl_Type.tp_new = pyGUIProgressCtrl_new;
@@ -107,5 +105,3 @@ PY_PLASMA_TYPE_INIT(GUIProgressCtrl) {
 }
 
 PY_PLASMA_IFC_METHODS(GUIProgressCtrl, pfGUIProgressCtrl)
-
-}

--- a/Python/PRP/GUI/pyGUIPythonScriptProc.cpp
+++ b/Python/PRP/GUI/pyGUIPythonScriptProc.cpp
@@ -18,8 +18,6 @@
 
 #include <PRP/GUI/pfGUIControlHandlers.h>
 
-extern "C" {
-
 PY_PLASMA_NEW(GUIPythonScriptProc, pfGUIPythonScriptProc)
 
 PY_PLASMA_TYPE(GUIPythonScriptProc, pfGUIPythonScriptProc,
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(GUIPythonScriptProc) {
 }
 
 PY_PLASMA_IFC_METHODS(GUIPythonScriptProc, pfGUIPythonScriptProc)
-
-}

--- a/Python/PRP/GUI/pyGUIRadioGroupCtrl.cpp
+++ b/Python/PRP/GUI/pyGUIRadioGroupCtrl.cpp
@@ -19,8 +19,6 @@
 #include "PRP/GUI/pyGUIControlMod.h"
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(GUIRadioGroupCtrl, pfGUIRadioGroupCtrl)
 
 PY_METHOD_VA(GUIRadioGroupCtrl, addControl,
@@ -85,7 +83,7 @@ static PyGetSetDef pyGUIRadioGroupCtrl_GetSet[] = {
     PY_GETSET_TERMINATOR
 };
 
-PY_PLASMA_TYPE(GUIRadioGroupCtrl, pfGUIRadioGroupCtrl, "pfGUIRadioGroupCtrl wrapper");
+PY_PLASMA_TYPE(GUIRadioGroupCtrl, pfGUIRadioGroupCtrl, "pfGUIRadioGroupCtrl wrapper")
 
 PY_PLASMA_TYPE_INIT(GUIRadioGroupCtrl) {
     pyGUIRadioGroupCtrl_Type.tp_new = pyGUIRadioGroupCtrl_new;
@@ -103,5 +101,3 @@ PY_PLASMA_TYPE_INIT(GUIRadioGroupCtrl) {
 }
 
 PY_PLASMA_IFC_METHODS(GUIRadioGroupCtrl, pfGUIRadioGroupCtrl)
-
-}

--- a/Python/PRP/GUI/pyGUISkin.cpp
+++ b/Python/PRP/GUI/pyGUISkin.cpp
@@ -19,8 +19,6 @@
 #include "PRP/KeyedObject/pyKey.h"
 #include "PRP/KeyedObject/pyKeyedObject.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(GUISkin, pfGUISkin)
 
 PY_PROPERTY(plKey, GUISkin, texture, getTexture, setTexture)
@@ -34,7 +32,7 @@ static PyGetSetDef pyGUISkin_GetSet[] = {
     PY_GETSET_TERMINATOR
 };
 
-PY_PLASMA_TYPE(GUISkin, pfGUISkin, "pfGUISkin wrapper");
+PY_PLASMA_TYPE(GUISkin, pfGUISkin, "pfGUISkin wrapper")
 
 PY_PLASMA_TYPE_INIT(GUISkin) {
     pyGUISkin_Type.tp_new = pyGUISkin_new;
@@ -64,5 +62,3 @@ PY_PLASMA_TYPE_INIT(GUISkin) {
 }
 
 PY_PLASMA_IFC_METHODS(GUISkin, pfGUISkin)
-
-}

--- a/Python/PRP/GUI/pyGUITextBoxMod.cpp
+++ b/Python/PRP/GUI/pyGUITextBoxMod.cpp
@@ -18,8 +18,6 @@
 #include "pyGUITextBoxMod.h"
 #include "PRP/GUI/pyGUIControlMod.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(GUITextBoxMod, pfGUITextBoxMod)
 
 PY_PROPERTY(ST::string, GUITextBoxMod, text, getText, setText)
@@ -31,7 +29,7 @@ static PyGetSetDef pyGUITextBoxMod_GetSet[] = {
     PY_GETSET_TERMINATOR
 };
 
-PY_PLASMA_TYPE(GUITextBoxMod, pfGUITextBoxMod, "pfGUITextBoxMod wrapper");
+PY_PLASMA_TYPE(GUITextBoxMod, pfGUITextBoxMod, "pfGUITextBoxMod wrapper")
 
 PY_PLASMA_TYPE_INIT(GUITextBoxMod) {
     pyGUITextBoxMod_Type.tp_new = pyGUITextBoxMod_new;
@@ -49,5 +47,3 @@ PY_PLASMA_TYPE_INIT(GUITextBoxMod) {
 }
 
 PY_PLASMA_IFC_METHODS(GUITextBoxMod, pfGUITextBoxMod)
-
-}

--- a/Python/PRP/GUI/pyGUIUpDownPairMod.cpp
+++ b/Python/PRP/GUI/pyGUIUpDownPairMod.cpp
@@ -19,8 +19,6 @@
 #include "PRP/KeyedObject/pyKey.h"
 #include "PRP/GUI/pyGUIValueCtrl.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(GUIUpDownPairMod, pfGUIUpDownPairMod)
 
 PY_PROPERTY(plKey, GUIUpDownPairMod, upControl, getUpControl, setUpControl)
@@ -32,7 +30,7 @@ static PyGetSetDef pyGUIUpDownPairMod_GetSet[] = {
     PY_GETSET_TERMINATOR
 };
 
-PY_PLASMA_TYPE(GUIUpDownPairMod, pfGUIUpDownPairMod, "pfGUIUpDownPairMod wrapper");
+PY_PLASMA_TYPE(GUIUpDownPairMod, pfGUIUpDownPairMod, "pfGUIUpDownPairMod wrapper")
 
 PY_PLASMA_TYPE_INIT(GUIUpDownPairMod) {
     pyGUIUpDownPairMod_Type.tp_new = pyGUIUpDownPairMod_new;
@@ -46,5 +44,3 @@ PY_PLASMA_TYPE_INIT(GUIUpDownPairMod) {
 }
 
 PY_PLASMA_IFC_METHODS(GUIUpDownPairMod, pfGUIUpDownPairMod)
-
-}

--- a/Python/PRP/GUI/pyGUIValueCtrl.cpp
+++ b/Python/PRP/GUI/pyGUIValueCtrl.cpp
@@ -18,8 +18,6 @@
 #include "pyGUIValueCtrl.h"
 #include "PRP/GUI/pyGUIControlMod.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(GUIValueCtrl, pfGUIValueCtrl)
 
 PY_PROPERTY(float, GUIValueCtrl, min, getMin, setMin)
@@ -33,7 +31,7 @@ static PyGetSetDef pyGUIValueCtrl_GetSet[] = {
     PY_GETSET_TERMINATOR
 };
 
-PY_PLASMA_TYPE(GUIValueCtrl, pfGUIValueCtrl, "pfGUIValueCtrl wrapper");
+PY_PLASMA_TYPE(GUIValueCtrl, pfGUIValueCtrl, "pfGUIValueCtrl wrapper")
 
 PY_PLASMA_TYPE_INIT(GUIValueCtrl) {
     pyGUIValueCtrl_Type.tp_new = pyGUIValueCtrl_new;
@@ -47,5 +45,3 @@ PY_PLASMA_TYPE_INIT(GUIValueCtrl) {
 }
 
 PY_PLASMA_IFC_METHODS(GUIValueCtrl, pfGUIValueCtrl)
-
-}

--- a/Python/PRP/GUI/pyImageLibMod.cpp
+++ b/Python/PRP/GUI/pyImageLibMod.cpp
@@ -19,8 +19,6 @@
 #include "PRP/Modifier/pyModifier.h"
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ImageLibMod, plImageLibMod)
 
 PY_METHOD_VA(ImageLibMod, addImage,
@@ -82,7 +80,7 @@ static PyGetSetDef pyImageLibMod_GetSet[] = {
     PY_GETSET_TERMINATOR
 };
 
-PY_PLASMA_TYPE(ImageLibMod, pfImageLibMod, "plImageLibMod wrapper");
+PY_PLASMA_TYPE(ImageLibMod, pfImageLibMod, "plImageLibMod wrapper")
 
 PY_PLASMA_TYPE_INIT(ImageLibMod) {
     pyImageLibMod_Type.tp_new = pyImageLibMod_new;
@@ -97,5 +95,3 @@ PY_PLASMA_TYPE_INIT(ImageLibMod) {
 }
 
 PY_PLASMA_IFC_METHODS(ImageLibMod, plImageLibMod)
-
-}

--- a/Python/PRP/Geometry/pyCluster.cpp
+++ b/Python/PRP/Geometry/pyCluster.cpp
@@ -23,8 +23,6 @@
 #include "pySpanInstance.h"
 #include "Stream/pyStream.h"
 
-extern "C" {
-
 PY_PLASMA_DEALLOC(Cluster)
 PY_PLASMA_EMPTY_INIT(Cluster)
 PY_PLASMA_NEW(Cluster, plCluster)
@@ -147,5 +145,3 @@ PY_PLASMA_TYPE_INIT(Cluster) {
 }
 
 PY_PLASMA_IFC_METHODS(Cluster, plCluster)
-
-}

--- a/Python/PRP/Geometry/pyClusterGroup.cpp
+++ b/Python/PRP/Geometry/pyClusterGroup.cpp
@@ -23,8 +23,6 @@
 #include "PRP/KeyedObject/pyKey.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ClusterGroup, plClusterGroup)
 
 PY_METHOD_VA(ClusterGroup, addCluster,
@@ -211,5 +209,3 @@ PY_PLASMA_TYPE_INIT(ClusterGroup) {
 }
 
 PY_PLASMA_IFC_METHODS(ClusterGroup, plClusterGroup)
-
-}

--- a/Python/PRP/Geometry/pyCullPoly.cpp
+++ b/Python/PRP/Geometry/pyCullPoly.cpp
@@ -20,8 +20,6 @@
 #include <Math/hsGeometry3.h>
 #include "Math/pyGeometry3.h"
 
-extern "C" {
-
 PY_PLASMA_VALUE_DEALLOC(CullPoly)
 PY_PLASMA_EMPTY_INIT(CullPoly)
 PY_PLASMA_VALUE_NEW(CullPoly, plCullPoly)
@@ -92,5 +90,3 @@ PY_PLASMA_TYPE_INIT(CullPoly) {
 }
 
 PY_PLASMA_VALUE_IFC_METHODS(CullPoly, plCullPoly)
-
-}

--- a/Python/PRP/Geometry/pyDISpanIndex.cpp
+++ b/Python/PRP/Geometry/pyDISpanIndex.cpp
@@ -18,8 +18,6 @@
 
 #include <PRP/Geometry/plDrawableSpans.h>
 
-extern "C" {
-
 PY_PLASMA_VALUE_DEALLOC(DISpanIndex)
 PY_PLASMA_EMPTY_INIT(DISpanIndex)
 PY_PLASMA_VALUE_NEW(DISpanIndex, plDISpanIndex)
@@ -79,5 +77,3 @@ PY_PLASMA_TYPE_INIT(DISpanIndex) {
 }
 
 PY_PLASMA_VALUE_IFC_METHODS(DISpanIndex, plDISpanIndex)
-
-}

--- a/Python/PRP/Geometry/pyDrawable.cpp
+++ b/Python/PRP/Geometry/pyDrawable.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Geometry/plDrawableSpans.h>
 #include "PRP/KeyedObject/pyKeyedObject.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(Drawable, "plDrawable is abstract")
 
 PY_PLASMA_TYPE(Drawable, plDrawable, "plDrawable wrapper")
@@ -81,5 +79,3 @@ PY_PLASMA_TYPE_INIT(Drawable) {
 }
 
 PY_PLASMA_IFC_METHODS(Drawable, plDrawable)
-
-}

--- a/Python/PRP/Geometry/pyDrawableSpans.cpp
+++ b/Python/PRP/Geometry/pyDrawableSpans.cpp
@@ -26,8 +26,6 @@
 #include "PRP/Region/pyBounds.h"
 #include "Math/pyMatrix.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(DrawableSpans, plDrawableSpans)
 
 PY_METHOD_NOARGS(DrawableSpans, clearSpans,
@@ -545,5 +543,3 @@ PY_PLASMA_TYPE_INIT(DrawableSpans) {
 }
 
 PY_PLASMA_IFC_METHODS(DrawableSpans, plDrawableSpans)
-
-}

--- a/Python/PRP/Geometry/pyGBufferCell.cpp
+++ b/Python/PRP/Geometry/pyGBufferCell.cpp
@@ -18,8 +18,6 @@
 
 #include <PRP/Geometry/plGBufferGroup.h>
 
-extern "C" {
-
 PY_PLASMA_VALUE_DEALLOC(GBufferCell)
 PY_PLASMA_EMPTY_INIT(GBufferCell)
 PY_PLASMA_VALUE_NEW(GBufferCell, plGBufferCell)
@@ -50,5 +48,3 @@ PY_PLASMA_TYPE_INIT(GBufferCell) {
 }
 
 PY_PLASMA_VALUE_IFC_METHODS(GBufferCell, plGBufferCell)
-
-}

--- a/Python/PRP/Geometry/pyGBufferGroup.cpp
+++ b/Python/PRP/Geometry/pyGBufferGroup.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Geometry/plGBufferGroup.h>
 #include "Stream/pyStream.h"
 
-extern "C" {
-
 PY_PLASMA_DEALLOC(GBufferGroup)
 
 PY_PLASMA_INIT_DECL(GBufferGroup) {
@@ -395,5 +393,3 @@ PY_PLASMA_TYPE_INIT(GBufferGroup) {
 }
 
 PY_PLASMA_IFC_METHODS(GBufferGroup, plGBufferGroup)
-
-}

--- a/Python/PRP/Geometry/pyGBufferTriangle.cpp
+++ b/Python/PRP/Geometry/pyGBufferTriangle.cpp
@@ -20,8 +20,6 @@
 #include "Math/pyGeometry3.h"
 #include "Stream/pyStream.h"
 
-extern "C" {
-
 PY_PLASMA_VALUE_DEALLOC(GBufferTriangle)
 PY_PLASMA_EMPTY_INIT(GBufferTriangle)
 PY_PLASMA_VALUE_NEW(GBufferTriangle, plGBufferTriangle)
@@ -97,5 +95,3 @@ PY_PLASMA_TYPE_INIT(GBufferTriangle) {
 }
 
 PY_PLASMA_VALUE_IFC_METHODS(GBufferTriangle, plGBufferTriangle)
-
-}

--- a/Python/PRP/Geometry/pyGBufferVertex.cpp
+++ b/Python/PRP/Geometry/pyGBufferVertex.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Geometry/plGBufferGroup.h>
 #include "Math/pyGeometry3.h"
 
-extern "C" {
-
 PY_PLASMA_VALUE_DEALLOC(GBufferVertex)
 PY_PLASMA_EMPTY_INIT(GBufferVertex)
 PY_PLASMA_VALUE_NEW(GBufferVertex, plGBufferVertex)
@@ -124,5 +122,3 @@ PY_PLASMA_TYPE_INIT(GBufferVertex) {
 }
 
 PY_PLASMA_VALUE_IFC_METHODS(GBufferVertex, plGBufferVertex)
-
-}

--- a/Python/PRP/Geometry/pyGeometrySpan.cpp
+++ b/Python/PRP/Geometry/pyGeometrySpan.cpp
@@ -21,8 +21,6 @@
 #include "PRP/KeyedObject/pyKey.h"
 #include "PRP/Region/pyBounds.h"
 
-extern "C" {
-
 PY_PLASMA_DEALLOC_DECL(GeometrySpan) {
     Py_TYPE(self)->tp_free(self);
 }
@@ -295,5 +293,3 @@ PyObject* pyGeometrySpan_FromGeometrySpan(const std::shared_ptr<plGeometrySpan>&
     pspan->fThis = span;
     return (PyObject*)pspan;
 }
-
-};

--- a/Python/PRP/Geometry/pyGeometrySpan.h
+++ b/Python/PRP/Geometry/pyGeometrySpan.h
@@ -20,8 +20,6 @@
 #include "PyPlasma.h"
 #include <memory>
 
-extern "C" {
-
 typedef struct {
     PyObject_HEAD
     std::shared_ptr<class plGeometrySpan> fThis;
@@ -31,7 +29,5 @@ extern PyTypeObject pyGeometrySpan_Type;
 PyObject* Init_pyGeometrySpan_Type();
 int pyGeometrySpan_Check(PyObject* obj);
 PyObject* pyGeometrySpan_FromGeometrySpan(const std::shared_ptr<class plGeometrySpan>& span);
-
-};
 
 #endif

--- a/Python/PRP/Geometry/pyIcicle.cpp
+++ b/Python/PRP/Geometry/pyIcicle.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Geometry/plIcicle.h>
 #include "pyGBufferGroup.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(Icicle, plIcicle)
 
 PY_GETSET_GETTER_DECL(Icicle, sortData) {
@@ -89,5 +87,3 @@ PY_PLASMA_TYPE_INIT(Icicle) {
 }
 
 PY_PLASMA_IFC_METHODS(Icicle, plIcicle)
-
-}

--- a/Python/PRP/Geometry/pyLODDist.cpp
+++ b/Python/PRP/Geometry/pyLODDist.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Geometry/plClusterGroup.h>
 #include "Stream/pyStream.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(LODDist, "Cannot create plLODDist objects from Python")
 
 PY_METHOD_VA(LODDist, read,
@@ -86,5 +84,3 @@ PY_PLASMA_TYPE_INIT(LODDist) {
 }
 
 PY_PLASMA_IFC_METHODS(LODDist, plLODDist)
-
-}

--- a/Python/PRP/Geometry/pyMobileOccluder.cpp
+++ b/Python/PRP/Geometry/pyMobileOccluder.cpp
@@ -21,8 +21,6 @@
 #include "PRP/pyCreatable.h"
 #include "Math/pyMatrix.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(MobileOccluder, plMobileOccluder)
 
 PY_PROPERTY(hsMatrix44, MobileOccluder, localToWorld, getLocalToWorld, setLocalToWorld)
@@ -50,5 +48,3 @@ PY_PLASMA_TYPE_INIT(MobileOccluder) {
 }
 
 PY_PLASMA_IFC_METHODS(MobileOccluder, plMobileOccluder)
-
-}

--- a/Python/PRP/Geometry/pyOccluder.cpp
+++ b/Python/PRP/Geometry/pyOccluder.cpp
@@ -22,8 +22,6 @@
 #include "PRP/KeyedObject/pyKey.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(Occluder, plOccluder)
 
 PY_METHOD_NOARGS(Occluder, clearPolys, "Remove all plCullPolys from the occluder") {
@@ -156,5 +154,3 @@ PY_PLASMA_TYPE_INIT(Occluder) {
 }
 
 PY_PLASMA_IFC_METHODS(Occluder, plOccluder)
-
-}

--- a/Python/PRP/Geometry/pyParticleSpan.cpp
+++ b/Python/PRP/Geometry/pyParticleSpan.cpp
@@ -18,8 +18,6 @@
 
 #include <PRP/Geometry/plIcicle.h>
 
-extern "C" {
-
 PY_PLASMA_NEW(ParticleSpan, plParticleSpan)
 
 PY_PLASMA_TYPE(ParticleSpan, plParticleSpan, "plParticleSpan wrapper")
@@ -35,5 +33,3 @@ PY_PLASMA_TYPE_INIT(ParticleSpan) {
 }
 
 PY_PLASMA_IFC_METHODS(ParticleSpan, plParticleSpan)
-
-}

--- a/Python/PRP/Geometry/pySpaceTree.cpp
+++ b/Python/PRP/Geometry/pySpaceTree.cpp
@@ -20,8 +20,6 @@
 #include "PRP/Region/pyBounds.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_EMPTY_INIT(SpaceTree)
 PY_PLASMA_NEW(SpaceTree, plSpaceTree)
 
@@ -103,5 +101,3 @@ PY_PLASMA_TYPE_INIT(SpaceTree) {
 }
 
 PY_PLASMA_IFC_METHODS(SpaceTree, plSpaceTree)
-
-}

--- a/Python/PRP/Geometry/pySpaceTreeNode.cpp
+++ b/Python/PRP/Geometry/pySpaceTreeNode.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Geometry/plSpaceTree.h>
 #include "PRP/Region/pyBounds.h"
 
-extern "C" {
-
 PY_PLASMA_VALUE_DEALLOC(SpaceTreeNode)
 PY_PLASMA_EMPTY_INIT(SpaceTreeNode)
 PY_PLASMA_VALUE_NEW(SpaceTreeNode, plSpaceTreeNode)
@@ -106,5 +104,3 @@ PY_PLASMA_TYPE_INIT(SpaceTreeNode) {
 }
 
 PY_PLASMA_VALUE_IFC_METHODS(SpaceTreeNode, plSpaceTreeNode)
-
-}

--- a/Python/PRP/Geometry/pySpan.cpp
+++ b/Python/PRP/Geometry/pySpan.cpp
@@ -22,8 +22,6 @@
 #include "Stream/pyStream.h"
 #include "Math/pyMatrix.h"
 
-extern "C" {
-
 PY_PLASMA_DEALLOC(Span)
 PY_PLASMA_EMPTY_INIT(Span)
 PY_PLASMA_NEW(Span, plSpan)
@@ -231,5 +229,3 @@ PY_PLASMA_TYPE_INIT(Span) {
 }
 
 PY_PLASMA_IFC_METHODS(Span, plSpan)
-
-}

--- a/Python/PRP/Geometry/pySpanEncoding.cpp
+++ b/Python/PRP/Geometry/pySpanEncoding.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Geometry/plSpanInstance.h>
 #include "Stream/pyStream.h"
 
-extern "C" {
-
 PY_PLASMA_DEALLOC(SpanEncoding)
 PY_PLASMA_EMPTY_INIT(SpanEncoding)
 PY_PLASMA_NEW(SpanEncoding, plSpanEncoding)
@@ -105,5 +103,3 @@ PY_PLASMA_TYPE_INIT(SpanEncoding) {
 }
 
 PY_PLASMA_IFC_METHODS(SpanEncoding, plSpanEncoding)
-
-}

--- a/Python/PRP/Geometry/pySpanInstance.cpp
+++ b/Python/PRP/Geometry/pySpanInstance.cpp
@@ -21,8 +21,6 @@
 #include "Math/pyMatrix.h"
 #include "Math/pyGeometry3.h"
 
-extern "C" {
-
 PY_PLASMA_DEALLOC(SpanInstance)
 PY_PLASMA_EMPTY_INIT(SpanInstance)
 PY_PLASMA_NEW(SpanInstance, plSpanInstance)
@@ -154,5 +152,3 @@ PY_PLASMA_TYPE_INIT(SpanInstance) {
 }
 
 PY_PLASMA_IFC_METHODS(SpanInstance, plSpanInstance)
-
-}

--- a/Python/PRP/Geometry/pySpanTemplate.cpp
+++ b/Python/PRP/Geometry/pySpanTemplate.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Geometry/plSpanTemplate.h>
 #include "Stream/pyStream.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(SpanTemplate, "Cannot create plSpanTemplate objects from Python")
 
 PY_METHOD_VA(SpanTemplate, read,
@@ -148,5 +146,3 @@ PY_PLASMA_TYPE_INIT(SpanTemplate) {
 }
 
 PY_PLASMA_IFC_METHODS(SpanTemplate, plSpanTemplate)
-
-}

--- a/Python/PRP/Geometry/pySpanTemplateVertex.cpp
+++ b/Python/PRP/Geometry/pySpanTemplateVertex.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Geometry/plSpanTemplate.h>
 #include "Math/pyGeometry3.h"
 
-extern "C" {
-
 PY_PLASMA_DEALLOC(SpanTemplateVertex)
 PY_PLASMA_EMPTY_INIT(SpanTemplateVertex)
 PY_PLASMA_NEW(SpanTemplateVertex, plSpanTemplate::Vertex)
@@ -125,5 +123,3 @@ PY_PLASMA_TYPE_INIT(SpanTemplateVertex) {
 }
 
 PY_PLASMA_IFC_METHODS(SpanTemplateVertex, plSpanTemplate::Vertex)
-
-}

--- a/Python/PRP/Geometry/pyTempVertex.cpp
+++ b/Python/PRP/Geometry/pyTempVertex.cpp
@@ -19,8 +19,6 @@
 #include "Math/pyGeometry3.h"
 #include "Sys/pyColor.h"
 
-extern "C" {
-
 PY_PLASMA_VALUE_DEALLOC(TempVertex)
 PY_PLASMA_VALUE_NEW(TempVertex, plGeometrySpan::TempVertex)
 
@@ -128,5 +126,3 @@ PY_PLASMA_TYPE_INIT(TempVertex) {
 }
 
 PY_PLASMA_VALUE_IFC_METHODS(TempVertex, plGeometrySpan::TempVertex)
-
-};

--- a/Python/PRP/Geometry/pyVertexSpan.cpp
+++ b/Python/PRP/Geometry/pyVertexSpan.cpp
@@ -18,8 +18,6 @@
 
 #include <PRP/Geometry/plVertexSpan.h>
 
-extern "C" {
-
 PY_PLASMA_NEW(VertexSpan, plVertexSpan)
 
 PY_PROPERTY(unsigned int, VertexSpan, groupIdx, getGroupIdx, setGroupIdx)
@@ -53,5 +51,3 @@ PY_PLASMA_TYPE_INIT(VertexSpan) {
 }
 
 PY_PLASMA_IFC_METHODS(VertexSpan, plVertexSpan)
-
-}

--- a/Python/PRP/KeyedObject/pyKey.cpp
+++ b/Python/PRP/KeyedObject/pyKey.cpp
@@ -21,8 +21,6 @@
 #include "pyKeyedObject.h"
 #include "Stream/pyStream.h"
 
-extern "C" {
-
 PY_PLASMA_VALUE_DEALLOC(Key)
 PY_PLASMA_NEW_MSG(Key, "Cannot construct Keys directly")
 
@@ -284,6 +282,4 @@ PyObject* pyKey_FromKey(const plKey& key) {
     pyKey* obj = PyObject_New(pyKey, &pyKey_Type);
     obj->fThis = new plKey(key);
     return (PyObject*)obj;
-}
-
 }

--- a/Python/PRP/KeyedObject/pyKeyedObject.cpp
+++ b/Python/PRP/KeyedObject/pyKeyedObject.cpp
@@ -20,8 +20,6 @@
 #include "pyKey.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_INIT_DECL(KeyedObject) {
     const char* name = "";
     if (!PyArg_ParseTuple(args, "|s", &name)) {
@@ -65,5 +63,3 @@ PY_PLASMA_TYPE_INIT(KeyedObject) {
 }
 
 PY_PLASMA_IFC_METHODS(KeyedObject, hsKeyedObject)
-
-}

--- a/Python/PRP/KeyedObject/pyKeyedObjectStub.cpp
+++ b/Python/PRP/KeyedObject/pyKeyedObjectStub.cpp
@@ -20,8 +20,6 @@
 #include "pyKey.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_INIT_DECL(KeyedObjectStub) {
     const char* name = "";
     if (!PyArg_ParseTuple(args, "|s", &name)) {
@@ -57,5 +55,3 @@ PY_PLASMA_TYPE_INIT(KeyedObjectStub) {
 }
 
 PY_PLASMA_IFC_METHODS(KeyedObjectStub, hsKeyedObjectStub)
-
-}

--- a/Python/PRP/KeyedObject/pyLocation.cpp
+++ b/Python/PRP/KeyedObject/pyLocation.cpp
@@ -20,8 +20,6 @@
 #include "Stream/pyStream.h"
 #include <string_theory/format>
 
-extern "C" {
-
 PY_PLASMA_VALUE_DEALLOC(Location)
 
 PY_PLASMA_INIT_DECL(Location) {
@@ -220,5 +218,3 @@ PY_PLASMA_TYPE_INIT(Location) {
 }
 
 PY_PLASMA_VALUE_IFC_METHODS(Location, plLocation)
-
-}

--- a/Python/PRP/Light/pyDirectShadowMaster.cpp
+++ b/Python/PRP/Light/pyDirectShadowMaster.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Light/plShadowMaster.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(DirectShadowMaster, plDirectShadowMaster)
 
 PY_PLASMA_TYPE(DirectShadowMaster, plDirectShadowMaster,
@@ -37,5 +35,3 @@ PY_PLASMA_TYPE_INIT(DirectShadowMaster) {
 }
 
 PY_PLASMA_IFC_METHODS(DirectShadowMaster, plDirectShadowMaster)
-
-}

--- a/Python/PRP/Light/pyDirectionalLightInfo.cpp
+++ b/Python/PRP/Light/pyDirectionalLightInfo.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Light/plDirectionalLightInfo.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(DirectionalLightInfo, plDirectionalLightInfo)
 
 PY_PLASMA_TYPE(DirectionalLightInfo, plDirectionalLightInfo,
@@ -37,5 +35,3 @@ PY_PLASMA_TYPE_INIT(DirectionalLightInfo) {
 }
 
 PY_PLASMA_IFC_METHODS(DirectionalLightInfo, plDirectionalLightInfo)
-
-}

--- a/Python/PRP/Light/pyLightInfo.cpp
+++ b/Python/PRP/Light/pyLightInfo.cpp
@@ -23,8 +23,6 @@
 #include "Sys/pyColor.h"
 #include "Math/pyMatrix.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(LightInfo, "plLightInfo is abstract")
 
 PY_METHOD_NOARGS(LightInfo, clearVisRegions, "Remove all VisRegions from the light") {
@@ -113,5 +111,3 @@ PY_PLASMA_TYPE_INIT(LightInfo) {
 }
 
 PY_PLASMA_IFC_METHODS(LightInfo, plLightInfo)
-
-}

--- a/Python/PRP/Light/pyLimitedDirLightInfo.cpp
+++ b/Python/PRP/Light/pyLimitedDirLightInfo.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Light/plDirectionalLightInfo.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(LimitedDirLightInfo, plLimitedDirLightInfo)
 
 PY_PROPERTY(float, LimitedDirLightInfo, width, getWidth, setWidth)
@@ -49,5 +47,3 @@ PY_PLASMA_TYPE_INIT(LimitedDirLightInfo) {
 }
 
 PY_PLASMA_IFC_METHODS(LimitedDirLightInfo, plLimitedDirLightInfo)
-
-}

--- a/Python/PRP/Light/pyOmniLightInfo.cpp
+++ b/Python/PRP/Light/pyOmniLightInfo.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Light/plOmniLightInfo.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(OmniLightInfo, plOmniLightInfo)
 
 PY_PROPERTY(float, OmniLightInfo, attenConst, getAttenConst, setAttenConst)
@@ -50,5 +48,3 @@ PY_PLASMA_TYPE_INIT(OmniLightInfo) {
 }
 
 PY_PLASMA_IFC_METHODS(OmniLightInfo, plOmniLightInfo)
-
-}

--- a/Python/PRP/Light/pyPointShadowMaster.cpp
+++ b/Python/PRP/Light/pyPointShadowMaster.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Light/plShadowMaster.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(PointShadowMaster, plPointShadowMaster)
 
 PY_PLASMA_TYPE(PointShadowMaster, plPointShadowMaster, "plPointShadowMaster wrapper")
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(PointShadowMaster) {
 }
 
 PY_PLASMA_IFC_METHODS(PointShadowMaster, plPointShadowMaster)
-
-}

--- a/Python/PRP/Light/pyShadowCaster.cpp
+++ b/Python/PRP/Light/pyShadowCaster.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Light/plShadowCaster.h>
 #include "PRP/Modifier/pyModifier.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ShadowCaster, plShadowCaster)
 
 PY_PROPERTY(unsigned char, ShadowCaster, castFlags, getCastFlags, setCastFlags)
@@ -57,5 +55,3 @@ PY_PLASMA_TYPE_INIT(ShadowCaster) {
 }
 
 PY_PLASMA_IFC_METHODS(ShadowCaster, plShadowCaster)
-
-}

--- a/Python/PRP/Light/pyShadowMaster.cpp
+++ b/Python/PRP/Light/pyShadowMaster.cpp
@@ -20,8 +20,6 @@
 #include "PRP/Object/pyObjInterface.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ShadowMaster, plShadowMaster)
 
 PY_PROPERTY(float, ShadowMaster, attenDist, getAttenDist, setAttenDist)
@@ -59,5 +57,3 @@ PY_PLASMA_TYPE_INIT(ShadowMaster) {
 }
 
 PY_PLASMA_IFC_METHODS(ShadowMaster, plShadowMaster)
-
-}

--- a/Python/PRP/Light/pySpotLightInfo.cpp
+++ b/Python/PRP/Light/pySpotLightInfo.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Light/plOmniLightInfo.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(SpotLightInfo, plSpotLightInfo)
 
 PY_PROPERTY(float, SpotLightInfo, falloff, getFalloff, setFalloff)
@@ -48,5 +46,3 @@ PY_PLASMA_TYPE_INIT(SpotLightInfo) {
 }
 
 PY_PLASMA_IFC_METHODS(SpotLightInfo, plSpotLightInfo)
-
-}

--- a/Python/PRP/Message/pyActivateEventData.cpp
+++ b/Python/PRP/Message/pyActivateEventData.cpp
@@ -18,8 +18,6 @@
 
 #include <PRP/Message/proEventData.h>
 
-extern "C" {
-
 PY_PLASMA_NEW(ActivateEventData, proActivateEventData)
 
 PY_PROPERTY(bool, ActivateEventData, active, isActive, setActive)
@@ -45,5 +43,3 @@ PY_PLASMA_TYPE_INIT(ActivateEventData) {
 }
 
 PY_PLASMA_IFC_METHODS(ActivateEventData, proActivateEventData)
-
-}

--- a/Python/PRP/Message/pyAnimCmdMsg.cpp
+++ b/Python/PRP/Message/pyAnimCmdMsg.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Message/plAnimCmdMsg.h>
 #include "pyMessageWithCallbacks.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(AnimCmdMsg, plAnimCmdMsg)
 
 PY_PROPERTY(ST::string, AnimCmdMsg, animName, getAnimName, setAnimName)
@@ -116,5 +114,3 @@ PY_PLASMA_TYPE_INIT(AnimCmdMsg) {
 }
 
 PY_PLASMA_IFC_METHODS(AnimCmdMsg, plAnimCmdMsg)
-
-};

--- a/Python/PRP/Message/pyArmatureEffectMsg.cpp
+++ b/Python/PRP/Message/pyArmatureEffectMsg.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Message/plArmatureEffectMsg.h>
 #include "pyMessage.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ArmatureEffectStateMsg, plArmatureEffectStateMsg)
 
 PY_PROPERTY(int8_t, ArmatureEffectStateMsg, surface, getSurface, setSurface)
@@ -47,5 +45,3 @@ PY_PLASMA_TYPE_INIT(ArmatureEffectStateMsg) {
 }
 
 PY_PLASMA_IFC_METHODS(ArmatureEffectStateMsg, plArmatureEffectStateMsg)
-
-}

--- a/Python/PRP/Message/pyBookEventData.cpp
+++ b/Python/PRP/Message/pyBookEventData.cpp
@@ -18,8 +18,6 @@
 
 #include <PRP/Message/proEventData.h>
 
-extern "C" {
-
 PY_PLASMA_NEW(BookEventData, proBookEventData)
 
 PY_PROPERTY(unsigned int, BookEventData, event, getEvent, setEvent)
@@ -45,5 +43,3 @@ PY_PLASMA_TYPE_INIT(BookEventData) {
 }
 
 PY_PLASMA_IFC_METHODS(BookEventData, proBookEventData)
-
-}

--- a/Python/PRP/Message/pyCallbackEventData.cpp
+++ b/Python/PRP/Message/pyCallbackEventData.cpp
@@ -18,8 +18,6 @@
 
 #include <PRP/Message/proEventData.h>
 
-extern "C" {
-
 PY_PLASMA_NEW(CallbackEventData, proCallbackEventData)
 
 PY_PROPERTY(int, CallbackEventData, callbackEventType, getCallbackEventType,
@@ -44,5 +42,3 @@ PY_PLASMA_TYPE_INIT(CallbackEventData) {
 }
 
 PY_PLASMA_IFC_METHODS(CallbackEventData, proCallbackEventData)
-
-}

--- a/Python/PRP/Message/pyClickDragEventData.cpp
+++ b/Python/PRP/Message/pyClickDragEventData.cpp
@@ -18,8 +18,6 @@
 
 #include <PRP/Message/proEventData.h>
 
-extern "C" {
-
 PY_PLASMA_NEW(ClickDragEventData, proClickDragEventData)
 
 PY_PLASMA_TYPE(ClickDragEventData, proClickDragEventData,
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(ClickDragEventData) {
 }
 
 PY_PLASMA_IFC_METHODS(ClickDragEventData, proClickDragEventData)
-
-}

--- a/Python/PRP/Message/pyClimbingBlockerHitEventData.cpp
+++ b/Python/PRP/Message/pyClimbingBlockerHitEventData.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Message/proEventData.h>
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ClimbingBlockerHitEventData, proClimbingBlockerHitEventData)
 
 PY_PROPERTY(plKey, ClimbingBlockerHitEventData, blocker, getBlocker, setBlocker)
@@ -45,5 +43,3 @@ PY_PLASMA_TYPE_INIT(ClimbingBlockerHitEventData) {
 }
 
 PY_PLASMA_IFC_METHODS(ClimbingBlockerHitEventData, proClimbingBlockerHitEventData)
-
-}

--- a/Python/PRP/Message/pyCollisionEventData.cpp
+++ b/Python/PRP/Message/pyCollisionEventData.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Message/proEventData.h>
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(CollisionEventData, proCollisionEventData)
 
 PY_PROPERTY(bool, CollisionEventData, enter, isEnter, setEnter)
@@ -49,5 +47,3 @@ PY_PLASMA_TYPE_INIT(CollisionEventData) {
 }
 
 PY_PLASMA_IFC_METHODS(CollisionEventData, proCollisionEventData)
-
-}

--- a/Python/PRP/Message/pyContainedEventData.cpp
+++ b/Python/PRP/Message/pyContainedEventData.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Message/proEventData.h>
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ContainedEventData, proContainedEventData)
 
 PY_PROPERTY(plKey, ContainedEventData, contained, getContained, setContained)
@@ -49,5 +47,3 @@ PY_PLASMA_TYPE_INIT(ContainedEventData) {
 }
 
 PY_PLASMA_IFC_METHODS(ContainedEventData, proContainedEventData)
-
-}

--- a/Python/PRP/Message/pyControlKeyEventData.cpp
+++ b/Python/PRP/Message/pyControlKeyEventData.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Message/proEventData.h>
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ControlKeyEventData, proControlKeyEventData)
 
 PY_PROPERTY(int, ControlKeyEventData, controlKey, getControlKey, setControlKey)
@@ -47,5 +45,3 @@ PY_PLASMA_TYPE_INIT(ControlKeyEventData) {
 }
 
 PY_PLASMA_IFC_METHODS(ControlKeyEventData, proControlKeyEventData)
-
-}

--- a/Python/PRP/Message/pyCoopEventData.cpp
+++ b/Python/PRP/Message/pyCoopEventData.cpp
@@ -18,8 +18,6 @@
 
 #include <PRP/Message/proEventData.h>
 
-extern "C" {
-
 PY_PLASMA_NEW(CoopEventData, proCoopEventData)
 
 PY_PROPERTY(unsigned int, CoopEventData, id, getID, setID)
@@ -45,5 +43,3 @@ PY_PLASMA_TYPE_INIT(CoopEventData) {
 }
 
 PY_PLASMA_IFC_METHODS(CoopEventData, proCoopEventData)
-
-}

--- a/Python/PRP/Message/pyCursorChangeMsg.cpp
+++ b/Python/PRP/Message/pyCursorChangeMsg.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Message/plCursorChangeMsg.h>
 #include "pyMessage.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(CursorChangeMsg, plCursorChangeMsg)
 
 PY_PROPERTY(int, CursorChangeMsg, type, getType, setType)
@@ -60,5 +58,3 @@ PY_PLASMA_TYPE_INIT(CursorChangeMsg) {
 }
 
 PY_PLASMA_IFC_METHODS(CursorChangeMsg, plCursorChangeMsg)
-
-}

--- a/Python/PRP/Message/pyEnableMsg.cpp
+++ b/Python/PRP/Message/pyEnableMsg.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Message/plEnableMsg.h>
 #include "pyMessage.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(EnableMsg, plEnableMsg)
 
 PY_METHOD_VA(EnableMsg, getCmd, "Params: cmd") {
@@ -91,5 +89,3 @@ PY_PLASMA_TYPE_INIT(EnableMsg) {
 }
 
 PY_PLASMA_IFC_METHODS(EnableMsg, plEnableMsg)
-
-};

--- a/Python/PRP/Message/pyEventCallbackMsg.cpp
+++ b/Python/PRP/Message/pyEventCallbackMsg.cpp
@@ -20,8 +20,6 @@
 #include "pyMessage.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(EventCallbackMsg, plEventCallbackMsg)
 
 PY_PROPERTY(float, EventCallbackMsg, eventTime, getEventTime, setEventTime)
@@ -53,5 +51,3 @@ PY_PLASMA_TYPE_INIT(EventCallbackMsg) {
 }
 
 PY_PLASMA_IFC_METHODS(EventCallbackMsg, plEventCallbackMsg)
-
-}

--- a/Python/PRP/Message/pyEventData.cpp
+++ b/Python/PRP/Message/pyEventData.cpp
@@ -20,8 +20,6 @@
 #include "Stream/pyStream.h"
 #include "ResManager/pyResManager.h"
 
-extern "C" {
-
 PY_PLASMA_DEALLOC(EventData)
 PY_PLASMA_EMPTY_INIT(EventData)
 PY_PLASMA_NEW_MSG(EventData, "proEventData is abstract")
@@ -120,5 +118,3 @@ PY_PLASMA_TYPE_INIT(EventData) {
 }
 
 PY_PLASMA_IFC_METHODS(EventData, proEventData)
-
-}

--- a/Python/PRP/Message/pyExcludeRegionMsg.cpp
+++ b/Python/PRP/Message/pyExcludeRegionMsg.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Message/plExcludeRegionMsg.h>
 #include "pyMessage.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ExcludeRegionMsg, plExcludeRegionMsg)
 
 PY_PROPERTY(unsigned char, ExcludeRegionMsg, cmd, getCmd, setCmd)
@@ -49,5 +47,3 @@ PY_PLASMA_TYPE_INIT(ExcludeRegionMsg) {
 }
 
 PY_PLASMA_IFC_METHODS(ExcludeRegionMsg, plExcludeRegionMsg)
-
-}

--- a/Python/PRP/Message/pyFacingEventData.cpp
+++ b/Python/PRP/Message/pyFacingEventData.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Message/proEventData.h>
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(FacingEventData, proFacingEventData)
 
 PY_PROPERTY(plKey, FacingEventData, facer, getFacer, setFacer)
@@ -50,5 +48,3 @@ PY_PLASMA_TYPE_INIT(FacingEventData) {
 }
 
 PY_PLASMA_IFC_METHODS(FacingEventData, proFacingEventData)
-
-}

--- a/Python/PRP/Message/pyLinkToAgeMsg.cpp
+++ b/Python/PRP/Message/pyLinkToAgeMsg.cpp
@@ -22,8 +22,6 @@
 #include "PRP/Misc/pyAgeLinkInfo.h"
 #include <PRP/Modifier/pyPythonFileMod.h>
 
-extern "C" {
-
 PY_PLASMA_NEW(LinkToAgeMsg, plLinkToAgeMsg)
 
 PY_GETSET_GETTER_DECL(LinkToAgeMsg, ageLink) {
@@ -65,5 +63,3 @@ PY_PLASMA_TYPE_INIT(LinkToAgeMsg) {
 }
 
 PY_PLASMA_IFC_METHODS(LinkToAgeMsg, plLinkToAgeMsg)
-
-}

--- a/Python/PRP/Message/pyMessage.cpp
+++ b/Python/PRP/Message/pyMessage.cpp
@@ -20,8 +20,6 @@
 #include "PRP/KeyedObject/pyKey.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(Message, plMessage)
 
 PY_METHOD_VA(Message, addReceiver,
@@ -123,5 +121,3 @@ PY_PLASMA_TYPE_INIT(Message) {
 }
 
 PY_PLASMA_IFC_METHODS(Message, plMessage)
-
-}

--- a/Python/PRP/Message/pyMessageWithCallbacks.cpp
+++ b/Python/PRP/Message/pyMessageWithCallbacks.cpp
@@ -20,8 +20,6 @@
 #include "pyMessage.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(MessageWithCallbacks, plMessageWithCallbacks)
 
 PY_METHOD_VA(MessageWithCallbacks, addCallback,
@@ -101,5 +99,3 @@ PY_PLASMA_TYPE_INIT(MessageWithCallbacks) {
 }
 
 PY_PLASMA_IFC_METHODS(MessageWithCallbacks, plMessageWithCallbacks)
-
-};

--- a/Python/PRP/Message/pyMsgForwarder.cpp
+++ b/Python/PRP/Message/pyMsgForwarder.cpp
@@ -21,8 +21,6 @@
 #include "PRP/KeyedObject/pyKey.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(MsgForwarder, plMsgForwarder)
 
 PY_METHOD_NOARGS(MsgForwarder, clearForwardKeys,
@@ -99,5 +97,3 @@ PY_PLASMA_TYPE_INIT(MsgForwarder) {
 }
 
 PY_PLASMA_IFC_METHODS(MsgForwarder, plMsgForwarder)
-
-}

--- a/Python/PRP/Message/pyMultiStageEventData.cpp
+++ b/Python/PRP/Message/pyMultiStageEventData.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Message/proEventData.h>
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(MultiStageEventData, proMultiStageEventData)
 
 PY_PROPERTY(int, MultiStageEventData, stage, getStage, setStage)
@@ -49,5 +47,3 @@ PY_PLASMA_TYPE_INIT(MultiStageEventData) {
 }
 
 PY_PLASMA_IFC_METHODS(MultiStageEventData, proMultiStageEventData)
-
-}

--- a/Python/PRP/Message/pyNotifyMsg.cpp
+++ b/Python/PRP/Message/pyNotifyMsg.cpp
@@ -21,8 +21,6 @@
 #include "pyEventData.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(NotifyMsg, plNotifyMsg)
 
 PY_METHOD_NOARGS(NotifyMsg, clearEvents, "Remove all event objects") {
@@ -111,5 +109,3 @@ PY_PLASMA_TYPE_INIT(NotifyMsg) {
 }
 
 PY_PLASMA_IFC_METHODS(NotifyMsg, plNotifyMsg)
-
-}

--- a/Python/PRP/Message/pyOfferLinkBookEventData.cpp
+++ b/Python/PRP/Message/pyOfferLinkBookEventData.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Message/proEventData.h>
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(OfferLinkBookEventData, proOfferLinkBookEventData)
 
 PY_PROPERTY(plKey, OfferLinkBookEventData, offerer, getOfferer, setOfferer)
@@ -49,5 +47,3 @@ PY_PLASMA_TYPE_INIT(OfferLinkBookEventData) {
 }
 
 PY_PLASMA_IFC_METHODS(OfferLinkBookEventData, proOfferLinkBookEventData)
-
-}

--- a/Python/PRP/Message/pyOneShotMsg.cpp
+++ b/Python/PRP/Message/pyOneShotMsg.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Message/plResponderMsg.h>
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(OneShotMsg, plOneShotMsg)
 
 PY_METHOD_NOARGS(OneShotMsg, clearCallbacks, "Remove all callbacks") {
@@ -102,5 +100,3 @@ PY_PLASMA_TYPE_INIT(OneShotMsg) {
 }
 
 PY_PLASMA_IFC_METHODS(OneShotMsg, plOneShotMsg)
-
-}

--- a/Python/PRP/Message/pyPickedEventData.cpp
+++ b/Python/PRP/Message/pyPickedEventData.cpp
@@ -20,8 +20,6 @@
 #include "PRP/KeyedObject/pyKey.h"
 #include "Math/pyGeometry3.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(PickedEventData, proPickedEventData)
 
 PY_PROPERTY(plKey, PickedEventData, picker, getPicker, setPicker)
@@ -51,5 +49,3 @@ PY_PLASMA_TYPE_INIT(PickedEventData) {
 }
 
 PY_PLASMA_IFC_METHODS(PickedEventData, proPickedEventData)
-
-}

--- a/Python/PRP/Message/pyResponderMsg.cpp
+++ b/Python/PRP/Message/pyResponderMsg.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Message/plResponderMsg.h>
 #include "pyMessage.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ResponderMsg, plResponderMsg)
 
 PY_PLASMA_TYPE(ResponderMsg, plResponderMsg, "plResponderMsg wrapper")
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(ResponderMsg) {
 }
 
 PY_PLASMA_IFC_METHODS(ResponderMsg, plResponderMsg)
-
-}

--- a/Python/PRP/Message/pyResponderStateEventData.cpp
+++ b/Python/PRP/Message/pyResponderStateEventData.cpp
@@ -18,8 +18,6 @@
 
 #include <PRP/Message/proEventData.h>
 
-extern "C" {
-
 PY_PLASMA_NEW(ResponderStateEventData, proResponderStateEventData)
 
 PY_PROPERTY(int, ResponderStateEventData, state, getState, setState)
@@ -44,5 +42,3 @@ PY_PLASMA_TYPE_INIT(ResponderStateEventData) {
 }
 
 PY_PLASMA_IFC_METHODS(ResponderStateEventData, proResponderStateEventData)
-
-}

--- a/Python/PRP/Message/pySoundMsg.cpp
+++ b/Python/PRP/Message/pySoundMsg.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Message/plSoundMsg.h>
 #include "pyMessageWithCallbacks.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(SoundMsg, plSoundMsg)
 
 PY_METHOD_VA(SoundMsg, getCmd,
@@ -122,5 +120,3 @@ PY_PLASMA_TYPE_INIT(SoundMsg) {
 }
 
 PY_PLASMA_IFC_METHODS(SoundMsg, plSoundMsg)
-
-};

--- a/Python/PRP/Message/pySpawnedEventData.cpp
+++ b/Python/PRP/Message/pySpawnedEventData.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Message/proEventData.h>
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(SpawnedEventData, proSpawnedEventData)
 
 PY_PROPERTY(plKey, SpawnedEventData, spawner, getSpawner, setSpawner)
@@ -46,5 +44,3 @@ PY_PLASMA_TYPE_INIT(SpawnedEventData) {
 }
 
 PY_PLASMA_IFC_METHODS(SpawnedEventData, proSpawnedEventData)
-
-}

--- a/Python/PRP/Message/pySwimMsg.cpp
+++ b/Python/PRP/Message/pySwimMsg.cpp
@@ -20,8 +20,6 @@
 #include <PRP/Message/plSwimMsg.h>
 #include "pyMessage.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(SwimMsg, plSwimMsg)
 
 PY_PROPERTY(bool, SwimMsg, isEntering, getIsEntering, setIsEntering)
@@ -47,5 +45,3 @@ PY_PLASMA_TYPE_INIT(SwimMsg) {
 }
 
 PY_PLASMA_IFC_METHODS(SwimMsg, plSwimMsg)
-
-}

--- a/Python/PRP/Message/pyTimerCallbackMsg.cpp
+++ b/Python/PRP/Message/pyTimerCallbackMsg.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Message/plTimerCallbackMsg.h>
 #include "pyMessage.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(TimerCallbackMsg, plTimerCallbackMsg)
 
 PY_PROPERTY(unsigned int, TimerCallbackMsg, ID, getID, setID)
@@ -46,5 +44,3 @@ PY_PLASMA_TYPE_INIT(TimerCallbackMsg) {
 }
 
 PY_PLASMA_IFC_METHODS(TimerCallbackMsg, plTimerCallbackMsg)
-
-}

--- a/Python/PRP/Message/pyVariableEventData.cpp
+++ b/Python/PRP/Message/pyVariableEventData.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Message/proEventData.h>
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(VariableEventData, proVariableEventData)
 
 PY_PROPERTY(ST::string, VariableEventData, name, getName, setName)
@@ -51,5 +49,3 @@ PY_PLASMA_TYPE_INIT(VariableEventData) {
 }
 
 PY_PLASMA_IFC_METHODS(VariableEventData, proVariableEventData)
-
-}

--- a/Python/PRP/Misc/pyAgeInfoStruct.cpp
+++ b/Python/PRP/Misc/pyAgeInfoStruct.cpp
@@ -20,8 +20,6 @@
 #include <Sys/plUuid.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(AgeInfoStruct, plAgeInfoStruct)
 
 PY_PROPERTY(ST::string, AgeInfoStruct, ageFilename, getAgeFilename, setAgeFilename)
@@ -70,5 +68,3 @@ PY_PLASMA_TYPE_INIT(AgeInfoStruct) {
 }
 
 PY_PLASMA_IFC_METHODS(AgeInfoStruct, plAgeInfoStruct)
-
-}

--- a/Python/PRP/Misc/pyAgeLinkStruct.cpp
+++ b/Python/PRP/Misc/pyAgeLinkStruct.cpp
@@ -20,8 +20,6 @@
 #include "pySpawnPointInfo.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(AgeLinkStruct, plAgeLinkStruct)
 
 PY_GETSET_GETTER_DECL(AgeLinkStruct, ageInfo) {
@@ -122,5 +120,3 @@ PY_PLASMA_TYPE_INIT(AgeLinkStruct) {
 }
 
 PY_PLASMA_IFC_METHODS(AgeLinkStruct, plAgeLinkStruct)
-
-}

--- a/Python/PRP/Misc/pyRenderLevel.cpp
+++ b/Python/PRP/Misc/pyRenderLevel.cpp
@@ -18,8 +18,6 @@
 
 #include <PRP/Misc/plRenderLevel.h>
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(RenderLevel, "Cannot construct plRenderLevel objects")
 
 typedef PyObject pyRenderLevel;
@@ -43,6 +41,4 @@ PY_PLASMA_TYPE_INIT(RenderLevel) {
 
     Py_INCREF(&pyRenderLevel_Type);
     return (PyObject*)&pyRenderLevel_Type;
-}
-
 }

--- a/Python/PRP/Misc/pyRenderLevel.h
+++ b/Python/PRP/Misc/pyRenderLevel.h
@@ -19,11 +19,7 @@
 
 #include "PyPlasma.h"
 
-extern "C" {
-
 extern PyTypeObject pyRenderLevel_Type;
 PyObject* Init_pyRenderLevel_Type();
-
-}
 
 #endif

--- a/Python/PRP/Misc/pySpawnPointInfo.cpp
+++ b/Python/PRP/Misc/pySpawnPointInfo.cpp
@@ -18,8 +18,6 @@
 
 #include <PRP/Misc/plSpawnPointInfo.h>
 
-extern "C" {
-
 PY_PLASMA_NEW(SpawnPointInfo, plSpawnPointInfo)
 
 PY_PROPERTY(ST::string, SpawnPointInfo, title, getTitle, setTitle)
@@ -46,5 +44,3 @@ PY_PLASMA_TYPE_INIT(SpawnPointInfo) {
 }
 
 PY_PLASMA_IFC_METHODS(SpawnPointInfo, plSpawnPointInfo)
-
-}

--- a/Python/PRP/Modifier/pyExcludeRegionModifier.cpp
+++ b/Python/PRP/Modifier/pyExcludeRegionModifier.cpp
@@ -20,8 +20,6 @@
 #include "pyModifier.h"
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ExcludeRegionModifier, plExcludeRegionModifier)
 
 PY_METHOD_VA(ExcludeRegionModifier, addSafePoint,
@@ -108,5 +106,3 @@ PY_PLASMA_TYPE_INIT(ExcludeRegionModifier) {
 }
 
 PY_PLASMA_IFC_METHODS(ExcludeRegionModifier, plExcludeRegionModifier)
-
-};

--- a/Python/PRP/Modifier/pyFollowMod.cpp
+++ b/Python/PRP/Modifier/pyFollowMod.cpp
@@ -20,8 +20,6 @@
 #include "PRP/Modifier/pyModifier.h"
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(FollowMod, plFollowMod)
 
 PY_PROPERTY(plFollowMod::FollowLeaderType, FollowMod, leaderType, getLeaderType,
@@ -62,5 +60,3 @@ PY_PLASMA_TYPE_INIT(FollowMod) {
 }
 
 PY_PLASMA_IFC_METHODS(FollowMod, plFollowMod)
-
-}

--- a/Python/PRP/Modifier/pyInterfaceInfoModifier.cpp
+++ b/Python/PRP/Modifier/pyInterfaceInfoModifier.cpp
@@ -21,8 +21,6 @@
 #include "PRP/KeyedObject/pyKey.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(InterfaceInfoModifier, plInterfaceInfoModifier)
 
 PY_METHOD_NOARGS(InterfaceInfoModifier, clearIntfKeys, "Remove all interface keys") {
@@ -98,5 +96,3 @@ PY_PLASMA_TYPE_INIT(InterfaceInfoModifier) {
 }
 
 PY_PLASMA_IFC_METHODS(InterfaceInfoModifier, plInterfaceInfoModifier)
-
-}

--- a/Python/PRP/Modifier/pyLogicModBase.cpp
+++ b/Python/PRP/Modifier/pyLogicModBase.cpp
@@ -23,8 +23,6 @@
 #include "PRP/pyCreatable.h"
 #include "Util/pyBitVector.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(LogicModBase, "plLogicModBase is abstract")
 
 PY_METHOD_NOARGS(LogicModBase, clearCommands, "Remove all commands") {
@@ -141,5 +139,3 @@ PY_PLASMA_TYPE_INIT(LogicModBase) {
 }
 
 PY_PLASMA_IFC_METHODS(LogicModBase, plLogicModBase)
-
-}

--- a/Python/PRP/Modifier/pyLogicModifier.cpp
+++ b/Python/PRP/Modifier/pyLogicModifier.cpp
@@ -20,8 +20,6 @@
 #include "PRP/KeyedObject/pyKey.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(LogicModifier, plLogicModifier)
 
 PY_METHOD_NOARGS(LogicModifier, clearConditions, "Remove all condition keys") {
@@ -101,5 +99,3 @@ PY_PLASMA_TYPE_INIT(LogicModifier) {
 }
 
 PY_PLASMA_IFC_METHODS(LogicModifier, plLogicModifier)
-
-}

--- a/Python/PRP/Modifier/pyMaintainersMarkerModifier.cpp
+++ b/Python/PRP/Modifier/pyMaintainersMarkerModifier.cpp
@@ -20,8 +20,6 @@
 #include "pyModifier.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(MaintainersMarkerModifier, plMaintainersMarkerModifier)
 
 PY_PROPERTY(unsigned int, MaintainersMarkerModifier, calibration,
@@ -54,5 +52,3 @@ PY_PLASMA_TYPE_INIT(MaintainersMarkerModifier) {
 }
 
 PY_PLASMA_IFC_METHODS(MaintainersMarkerModifier, plMaintainersMarkerModifier)
-
-}

--- a/Python/PRP/Modifier/pyModifier.cpp
+++ b/Python/PRP/Modifier/pyModifier.cpp
@@ -20,8 +20,6 @@
 #include "PRP/Object/pySynchedObject.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(Modifier, "plModifier is abstract")
 
 PY_PLASMA_TYPE(Modifier, plModifier, "plModifier wrapper")
@@ -37,5 +35,3 @@ PY_PLASMA_TYPE_INIT(Modifier) {
 }
 
 PY_PLASMA_IFC_METHODS(Modifier, plModifier)
-
-}

--- a/Python/PRP/Modifier/pyMultiModifier.cpp
+++ b/Python/PRP/Modifier/pyMultiModifier.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Modifier/plModifier.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(MultiModifier, "plMultiModifier is abstract")
 
 PY_METHOD_VA(MultiModifier, getFlag,
@@ -68,5 +66,3 @@ PY_PLASMA_TYPE_INIT(MultiModifier) {
 }
 
 PY_PLASMA_IFC_METHODS(MultiModifier, plMultiModifier)
-
-}

--- a/Python/PRP/Modifier/pyOneShotMod.cpp
+++ b/Python/PRP/Modifier/pyOneShotMod.cpp
@@ -20,8 +20,6 @@
 #include "pyModifier.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(OneShotMod, plOneShotMod)
 
 PY_PROPERTY(ST::string, OneShotMod, animName, getAnimName, setAnimName)
@@ -55,5 +53,3 @@ PY_PLASMA_TYPE_INIT(OneShotMod) {
 }
 
 PY_PLASMA_IFC_METHODS(OneShotMod, plOneShotMod)
-
-}

--- a/Python/PRP/Modifier/pyPostEffectMod.cpp
+++ b/Python/PRP/Modifier/pyPostEffectMod.cpp
@@ -20,8 +20,6 @@
 #include "PRP/KeyedObject/pyKey.h"
 #include "Math/pyMatrix.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(PostEffectMod, plPostEffectMod)
 
 PY_PROPERTY(float, PostEffectMod, hither, getHither, setHither)
@@ -43,7 +41,7 @@ static PyGetSetDef pyPostEffectMod_GetSet[] = {
     PY_GETSET_TERMINATOR
 };
 
-PY_PLASMA_TYPE(PostEffectMod, plPostEffectMod, "plPostEffectMod wrapper");
+PY_PLASMA_TYPE(PostEffectMod, plPostEffectMod, "plPostEffectMod wrapper")
 
 PY_PLASMA_TYPE_INIT(PostEffectMod) {
     pyPostEffectMod_Type.tp_new = pyPostEffectMod_new;
@@ -57,5 +55,3 @@ PY_PLASMA_TYPE_INIT(PostEffectMod) {
 }
 
 PY_PLASMA_IFC_METHODS(PostEffectMod, plPostEffectMod)
-
-}

--- a/Python/PRP/Modifier/pyPythonFileMod.cpp
+++ b/Python/PRP/Modifier/pyPythonFileMod.cpp
@@ -21,8 +21,6 @@
 #include "PRP/KeyedObject/pyKey.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(PythonFileMod, plPythonFileMod)
 
 PY_METHOD_NOARGS(PythonFileMod, clearReceivers,
@@ -125,5 +123,3 @@ PY_PLASMA_TYPE_INIT(PythonFileMod) {
 }
 
 PY_PLASMA_IFC_METHODS(PythonFileMod, plPythonFileMod)
-
-}

--- a/Python/PRP/Modifier/pyPythonParameter.cpp
+++ b/Python/PRP/Modifier/pyPythonParameter.cpp
@@ -21,8 +21,6 @@
 #include "Stream/pyStream.h"
 #include "ResManager/pyResManager.h"
 
-extern "C" {
-
 PY_PLASMA_VALUE_DEALLOC(PythonParameter)
 
 PY_PLASMA_INIT_DECL(PythonParameter) {
@@ -212,5 +210,3 @@ PY_PLASMA_TYPE_INIT(PythonParameter) {
 }
 
 PY_PLASMA_VALUE_IFC_METHODS(PythonParameter, plPythonParameter)
-
-}

--- a/Python/PRP/Modifier/pyResponderEnableMsg.cpp
+++ b/Python/PRP/Modifier/pyResponderEnableMsg.cpp
@@ -20,8 +20,6 @@
 #include "PRP/Message/pyMessage.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ResponderEnableMsg, plResponderEnableMsg)
 
 PY_PROPERTY(bool, ResponderEnableMsg, enable, getEnable, setEnable)
@@ -45,5 +43,3 @@ PY_PLASMA_TYPE_INIT(ResponderEnableMsg) {
 }
 
 PY_PLASMA_IFC_METHODS(ResponderEnableMsg, plResponderEnableMsg)
-
-}

--- a/Python/PRP/Modifier/pyResponderModifier.cpp
+++ b/Python/PRP/Modifier/pyResponderModifier.cpp
@@ -20,8 +20,6 @@
 #include "pyModifier.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ResponderModifier, plResponderModifier)
 
 PY_METHOD_VA(ResponderModifier, addState,
@@ -111,5 +109,3 @@ PY_PLASMA_TYPE_INIT(ResponderModifier) {
 }
 
 PY_PLASMA_IFC_METHODS(ResponderModifier, plResponderModifier)
-
-}

--- a/Python/PRP/Modifier/pyResponderModifier_Cmd.cpp
+++ b/Python/PRP/Modifier/pyResponderModifier_Cmd.cpp
@@ -20,8 +20,6 @@
 #include "PRP/pyCreatable.h"
 #include "PRP/Message/pyMessage.h"
 
-extern "C" {
-
 PY_PLASMA_DEALLOC(ResponderModifier_Cmd)
 
 PY_PLASMA_INIT_DECL(ResponderModifier_Cmd) {
@@ -72,5 +70,3 @@ PY_PLASMA_TYPE_INIT(ResponderModifier_Cmd) {
 }
 
 PY_PLASMA_IFC_METHODS(ResponderModifier_Cmd, plResponderModifier::plResponderCmd)
-
-}

--- a/Python/PRP/Modifier/pyResponderModifier_State.cpp
+++ b/Python/PRP/Modifier/pyResponderModifier_State.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Modifier/plResponderModifier.h>
 #include "PRP/Message/pyMessage.h"
 
-extern "C" {
-
 PY_PLASMA_DEALLOC(ResponderModifier_State)
 PY_PLASMA_EMPTY_INIT(ResponderModifier_State)
 PY_PLASMA_NEW(ResponderModifier_State, plResponderModifier::plResponderState)
@@ -139,5 +137,3 @@ PY_PLASMA_TYPE_INIT(ResponderModifier_State) {
 }
 
 PY_PLASMA_IFC_METHODS(ResponderModifier_State, plResponderModifier::plResponderState)
-
-}

--- a/Python/PRP/Modifier/pySingleModifier.cpp
+++ b/Python/PRP/Modifier/pySingleModifier.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Modifier/plModifier.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(SingleModifier, "plSingleModifier is abstract")
 
 PY_METHOD_VA(SingleModifier, getFlag,
@@ -68,5 +66,3 @@ PY_PLASMA_TYPE_INIT(SingleModifier) {
 }
 
 PY_PLASMA_IFC_METHODS(SingleModifier, plSingleModifier)
-
-}

--- a/Python/PRP/Modifier/pySpawnModifier.cpp
+++ b/Python/PRP/Modifier/pySpawnModifier.cpp
@@ -20,8 +20,6 @@
 #include "pyModifier.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(SpawnModifier, plSpawnModifier)
 
 PY_PLASMA_TYPE(SpawnModifier, plSpawnModifier, "plSpawnModifier wrapper")
@@ -37,5 +35,3 @@ PY_PLASMA_TYPE_INIT(SpawnModifier) {
 }
 
 PY_PLASMA_IFC_METHODS(SpawnModifier, plSpawnModifier)
-
-}

--- a/Python/PRP/Object/pyAudioInterface.cpp
+++ b/Python/PRP/Object/pyAudioInterface.cpp
@@ -20,8 +20,6 @@
 #include "PRP/pyCreatable.h"
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(AudioInterface, plAudioInterface)
 
 PY_PROPERTY(plKey, AudioInterface, audible, getAudible, setAudible)
@@ -45,5 +43,3 @@ PY_PLASMA_TYPE_INIT(AudioInterface) {
 }
 
 PY_PLASMA_IFC_METHODS(AudioInterface, plAudioInterface)
-
-}

--- a/Python/PRP/Object/pyCoordinateInterface.cpp
+++ b/Python/PRP/Object/pyCoordinateInterface.cpp
@@ -21,8 +21,6 @@
 #include "PRP/KeyedObject/pyKey.h"
 #include "Math/pyMatrix.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(CoordinateInterface, plCoordinateInterface)
 
 PY_METHOD_NOARGS(CoordinateInterface, clearChildren,
@@ -114,5 +112,3 @@ PY_PLASMA_TYPE_INIT(CoordinateInterface) {
 }
 
 PY_PLASMA_IFC_METHODS(CoordinateInterface, plCoordinateInterface)
-
-}

--- a/Python/PRP/Object/pyDrawInterface.cpp
+++ b/Python/PRP/Object/pyDrawInterface.cpp
@@ -20,8 +20,6 @@
 #include "PRP/pyCreatable.h"
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(DrawInterface, plDrawInterface)
 
 PY_METHOD_NOARGS(DrawInterface, clearDrawables,
@@ -156,5 +154,3 @@ PY_PLASMA_TYPE_INIT(DrawInterface) {
 }
 
 PY_PLASMA_IFC_METHODS(DrawInterface, plDrawInterface)
-
-}

--- a/Python/PRP/Object/pyObjInterface.cpp
+++ b/Python/PRP/Object/pyObjInterface.cpp
@@ -22,8 +22,6 @@
 #include "PRP/KeyedObject/pyKey.h"
 #include "Util/pyBitVector.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(ObjInterface, "plObjInterface is abstract")
 
 PY_METHOD_VA(ObjInterface, getProperty,
@@ -81,5 +79,3 @@ PY_PLASMA_TYPE_INIT(ObjInterface) {
 }
 
 PY_PLASMA_IFC_METHODS(ObjInterface, plObjInterface)
-
-}

--- a/Python/PRP/Object/pySceneObject.cpp
+++ b/Python/PRP/Object/pySceneObject.cpp
@@ -21,8 +21,6 @@
 #include "PRP/pyCreatable.h"
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(SceneObject, plSceneObject)
 
 PY_METHOD_NOARGS(SceneObject, clearInterfaces,
@@ -161,5 +159,3 @@ PY_PLASMA_TYPE_INIT(SceneObject) {
 }
 
 PY_PLASMA_IFC_METHODS(SceneObject, plSceneObject)
-
-}

--- a/Python/PRP/Object/pySimulationInterface.cpp
+++ b/Python/PRP/Object/pySimulationInterface.cpp
@@ -20,8 +20,6 @@
 #include "PRP/pyCreatable.h"
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(SimulationInterface, plSimulationInterface)
 
 PY_PROPERTY(plKey, SimulationInterface, physical, getPhysical, setPhysical)
@@ -73,5 +71,3 @@ PY_PLASMA_TYPE_INIT(SimulationInterface) {
 }
 
 PY_PLASMA_IFC_METHODS(SimulationInterface, plSimulationInterface)
-
-}

--- a/Python/PRP/Object/pySynchedObject.cpp
+++ b/Python/PRP/Object/pySynchedObject.cpp
@@ -20,8 +20,6 @@
 #include "PRP/pyCreatable.h"
 #include "PRP/KeyedObject/pyKeyedObject.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(SynchedObject, "plSynchedObject is abstract")
 
 PY_METHOD_VA(SynchedObject, setExclude,
@@ -176,5 +174,3 @@ PY_PLASMA_TYPE_INIT(SynchedObject) {
 }
 
 PY_PLASMA_IFC_METHODS(SynchedObject, plSynchedObject)
-
-}

--- a/Python/PRP/Physics/pyCollisionDetector.cpp
+++ b/Python/PRP/Physics/pyCollisionDetector.cpp
@@ -20,8 +20,6 @@
 #include "pyDetectorModifier.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(CollisionDetector, "plCollisionDetector is abstract")
 
 PY_PROPERTY(unsigned char, CollisionDetector, type, getType, setType)
@@ -52,5 +50,3 @@ PY_PLASMA_TYPE_INIT(CollisionDetector) {
 }
 
 PY_PLASMA_IFC_METHODS(CollisionDetector, plCollisionDetector)
-
-};

--- a/Python/PRP/Physics/pyDetectorModifier.cpp
+++ b/Python/PRP/Physics/pyDetectorModifier.cpp
@@ -21,8 +21,6 @@
 #include "PRP/KeyedObject/pyKey.h"
 #include "PRP/Modifier/pyModifier.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(DetectorModifier, "plDetectorModifier is abstract")
 
 PY_METHOD_VA(DetectorModifier, addReceiver,
@@ -103,5 +101,3 @@ PY_PLASMA_TYPE_INIT(DetectorModifier) {
 }
 
 PY_PLASMA_IFC_METHODS(DetectorModifier, plDetectorModifier)
-
-};

--- a/Python/PRP/Physics/pyGenericPhysical.cpp
+++ b/Python/PRP/Physics/pyGenericPhysical.cpp
@@ -22,8 +22,6 @@
 #include "Math/pyGeometry3.h"
 #include "Util/pyBitVector.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(GenericPhysical, plGenericPhysical)
 
 PY_METHOD_VA(GenericPhysical, getProperty,
@@ -265,5 +263,3 @@ PY_PLASMA_TYPE_INIT(GenericPhysical) {
 }
 
 PY_PLASMA_IFC_METHODS(GenericPhysical, plGenericPhysical)
-
-}

--- a/Python/PRP/Physics/pyObjectInVolumeAndFacingDetector.cpp
+++ b/Python/PRP/Physics/pyObjectInVolumeAndFacingDetector.cpp
@@ -18,8 +18,6 @@
 
 #include <PRP/Physics/plObjectInVolumeDetector.h>
 
-extern "C" {
-
 PY_PLASMA_NEW(ObjectInVolumeAndFacingDetector, plObjectInVolumeAndFacingDetector)
 
 PY_PROPERTY(float, ObjectInVolumeAndFacingDetector, facingTolerance,
@@ -48,5 +46,3 @@ PY_PLASMA_TYPE_INIT(ObjectInVolumeAndFacingDetector) {
 }
 
 PY_PLASMA_IFC_METHODS(ObjectInVolumeAndFacingDetector, plObjectInVolumeAndFacingDetector)
-
-};

--- a/Python/PRP/Physics/pyObjectInVolumeDetector.cpp
+++ b/Python/PRP/Physics/pyObjectInVolumeDetector.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Physics/plObjectInVolumeDetector.h>
 #include "pyCollisionDetector.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ObjectInVolumeDetector, plObjectInVolumeDetector)
 
 PY_PLASMA_TYPE(ObjectInVolumeDetector, plObjectInVolumeDetector,
@@ -37,5 +35,3 @@ PY_PLASMA_TYPE_INIT(ObjectInVolumeDetector) {
 }
 
 PY_PLASMA_IFC_METHODS(ObjectInVolumeDetector, plObjectInVolumeDetector)
-
-};

--- a/Python/PRP/Physics/pyPanicLinkRegion.cpp
+++ b/Python/PRP/Physics/pyPanicLinkRegion.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Physics/plCollisionDetector.h>
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(PanicLinkRegion, plPanicLinkRegion)
 
 PY_PROPERTY(bool, PanicLinkRegion, playLinkOutAnim, getPlayLinkOutAnim, setPlayLinkOutAnim)
@@ -44,5 +42,3 @@ PY_PLASMA_TYPE_INIT(PanicLinkRegion) {
 }
 
 PY_PLASMA_IFC_METHODS(PanicLinkRegion, plPanicLinkRegion)
-
-};

--- a/Python/PRP/Physics/pyPhysical.cpp
+++ b/Python/PRP/Physics/pyPhysical.cpp
@@ -20,8 +20,6 @@
 #include "PRP/Object/pySynchedObject.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(Physical, "plPhysical is abstract")
 
 PY_PLASMA_TYPE(Physical, plPhysical, "plPhysical wrapper")
@@ -37,5 +35,3 @@ PY_PLASMA_TYPE_INIT(Physical) {
 }
 
 PY_PLASMA_IFC_METHODS(Physical, plPhysical)
-
-}

--- a/Python/PRP/Physics/pyPhysical.h
+++ b/Python/PRP/Physics/pyPhysical.h
@@ -23,12 +23,8 @@
 PY_WRAP_PLASMA(Physical, class plPhysical);
 PY_WRAP_PLASMA(GenericPhysical, class plGenericPhysical);
 
-extern "C" {
-
 extern PyTypeObject pySimDefs_Type;
 PyObject* Init_pySimDefs_Type();
-
-}
 
 /* Python property helpers */
 inline PyObject* pyPlasma_convert(plSimDefs::Bounds value) {

--- a/Python/PRP/Physics/pyPickingDetector.cpp
+++ b/Python/PRP/Physics/pyPickingDetector.cpp
@@ -18,8 +18,6 @@
 
 #include <PRP/Physics/plDetectorModifier.h>
 
-extern "C" {
-
 PY_PLASMA_NEW(PickingDetector, plPickingDetector)
 
 PY_PLASMA_TYPE(PickingDetector, plPickingDetector, "plPickingDetector wrapper")
@@ -35,5 +33,3 @@ PY_PLASMA_TYPE_INIT(PickingDetector) {
 }
 
 PY_PLASMA_IFC_METHODS(PickingDetector, plPickingDetector)
-
-};

--- a/Python/PRP/Physics/pySimDefs.cpp
+++ b/Python/PRP/Physics/pySimDefs.cpp
@@ -18,8 +18,6 @@
 
 #include <PRP/Physics/plPhysical.h>
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(SimDefs, "Cannot construct plSimDefs objects")
 
 typedef PyObject pySimDefs;
@@ -58,6 +56,4 @@ PY_PLASMA_TYPE_INIT(SimDefs) {
 
     Py_INCREF(&pySimDefs_Type);
     return (PyObject*)&pySimDefs_Type;
-}
-
 }

--- a/Python/PRP/Physics/pySubworldRegionDetector.cpp
+++ b/Python/PRP/Physics/pySubworldRegionDetector.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Physics/plCollisionDetector.h>
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(SubworldRegionDetector, plSubworldRegionDetector)
 
 PY_PROPERTY(plKey, SubworldRegionDetector, subworld, getSubworld, setSubworld)
@@ -47,5 +45,3 @@ PY_PLASMA_TYPE_INIT(SubworldRegionDetector) {
 }
 
 PY_PLASMA_IFC_METHODS(SubworldRegionDetector, plSubworldRegionDetector)
-
-};

--- a/Python/PRP/Region/pyBounds.cpp
+++ b/Python/PRP/Region/pyBounds.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Region/hsBounds.h>
 #include "Stream/pyStream.h"
 
-extern "C" {
-
 PY_PLASMA_VALUE_DEALLOC(Bounds)
 PY_PLASMA_EMPTY_INIT(Bounds)
 PY_PLASMA_VALUE_NEW(Bounds, hsBounds)
@@ -95,5 +93,3 @@ PY_PLASMA_TYPE_INIT(Bounds) {
 }
 
 PY_PLASMA_VALUE_IFC_METHODS(Bounds, hsBounds)
-
-}

--- a/Python/PRP/Region/pyBounds3.cpp
+++ b/Python/PRP/Region/pyBounds3.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Region/hsBounds.h>
 #include "Math/pyGeometry3.h"
 
-extern "C" {
-
 PY_PLASMA_VALUE_NEW(Bounds3, hsBounds3)
 
 PY_PROPERTY(hsVector3, Bounds3, mins, getMins, setMins)
@@ -51,5 +49,3 @@ PY_PLASMA_TYPE_INIT(Bounds3) {
 }
 
 PY_PLASMA_VALUE_IFC_METHODS(Bounds3, hsBounds3)
-
-}

--- a/Python/PRP/Region/pyBounds3Ext.cpp
+++ b/Python/PRP/Region/pyBounds3Ext.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Region/hsBounds.h>
 #include "Math/pyGeometry3.h"
 
-extern "C" {
-
 PY_PLASMA_VALUE_NEW(Bounds3Ext, hsBounds3Ext)
 
 PY_METHOD_VA(Bounds3Ext, getAxis,
@@ -176,5 +174,3 @@ PY_PLASMA_TYPE_INIT(Bounds3Ext) {
 }
 
 PY_PLASMA_VALUE_IFC_METHODS(Bounds3Ext, hsBounds3Ext)
-
-}

--- a/Python/PRP/Region/pyBoundsOriented.cpp
+++ b/Python/PRP/Region/pyBoundsOriented.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Region/hsBounds.h>
 #include "Math/pyGeometry3.h"
 
-extern "C" {
-
 PY_PLASMA_VALUE_NEW(BoundsOriented, hsBoundsOriented)
 
 PY_GETSET_GETTER_DECL(BoundsOriented, planes) {
@@ -77,5 +75,3 @@ PY_PLASMA_TYPE_INIT(BoundsOriented) {
 }
 
 PY_PLASMA_VALUE_IFC_METHODS(BoundsOriented, hsBoundsOriented)
-
-}

--- a/Python/PRP/Region/pyConvexIsect.cpp
+++ b/Python/PRP/Region/pyConvexIsect.cpp
@@ -20,8 +20,6 @@
 #include "Math/pyGeometry3.h"
 #include "Math/pyMatrix.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(ConvexIsect, plConvexIsect)
 
 PY_METHOD_VA(ConvexIsect, addPlane,
@@ -73,5 +71,3 @@ PY_PLASMA_TYPE_INIT(ConvexIsect) {
 }
 
 PY_PLASMA_IFC_METHODS(ConvexIsect, plConvexIsect)
-
-}

--- a/Python/PRP/Region/pySimpleRegionSensor.cpp
+++ b/Python/PRP/Region/pySimpleRegionSensor.cpp
@@ -21,8 +21,6 @@
 #include "PRP/Modifier/pyModifier.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(SimpleRegionSensor, plSimpleRegionSensor)
 
 PY_PROPERTY_CREATABLE(plMessage, Message, SimpleRegionSensor, enterMsg,
@@ -51,5 +49,3 @@ PY_PLASMA_TYPE_INIT(SimpleRegionSensor) {
 }
 
 PY_PLASMA_IFC_METHODS(SimpleRegionSensor, plSimpleRegionSensor);
-
-}

--- a/Python/PRP/Region/pySoftVolume.cpp
+++ b/Python/PRP/Region/pySoftVolume.cpp
@@ -20,8 +20,6 @@
 #include "PRP/Object/pyObjInterface.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(SoftVolume, "plSoftVolume is abstract")
 
 PY_PROPERTY(unsigned int, SoftVolume, listenState, getListenState, setListenState)
@@ -55,5 +53,3 @@ PY_PLASMA_TYPE_INIT(SoftVolume) {
 }
 
 PY_PLASMA_IFC_METHODS(SoftVolume, plSoftVolume)
-
-}

--- a/Python/PRP/Region/pySoftVolumeComplex.cpp
+++ b/Python/PRP/Region/pySoftVolumeComplex.cpp
@@ -20,8 +20,6 @@
 #include "PRP/pyCreatable.h"
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(SoftVolumeComplex, "plSoftVolumeComplex is abstract")
 
 PY_METHOD_VA(SoftVolumeComplex, addSubVolume,
@@ -99,5 +97,3 @@ PY_PLASMA_TYPE_INIT(SoftVolumeComplex) {
 }
 
 PY_PLASMA_IFC_METHODS(SoftVolumeComplex, plSoftVolumeComplex)
-
-}

--- a/Python/PRP/Region/pySoftVolumeIntersect.cpp
+++ b/Python/PRP/Region/pySoftVolumeIntersect.cpp
@@ -18,8 +18,6 @@
 
 #include <PRP/Region/plSoftVolume.h>
 
-extern "C" {
-
 PY_PLASMA_NEW(SoftVolumeIntersect, plSoftVolumeIntersect)
 
 PY_PLASMA_TYPE(SoftVolumeIntersect, plSoftVolumeIntersect,
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(SoftVolumeIntersect) {
 }
 
 PY_PLASMA_IFC_METHODS(SoftVolumeIntersect, plSoftVolumeIntersect)
-
-}

--- a/Python/PRP/Region/pySoftVolumeInvert.cpp
+++ b/Python/PRP/Region/pySoftVolumeInvert.cpp
@@ -18,8 +18,6 @@
 
 #include <PRP/Region/plSoftVolume.h>
 
-extern "C" {
-
 PY_PLASMA_NEW(SoftVolumeInvert, plSoftVolumeInvert)
 
 PY_PLASMA_TYPE(SoftVolumeInvert, plSoftVolumeInvert, "plSoftVolumeInvert wrapper")
@@ -35,5 +33,3 @@ PY_PLASMA_TYPE_INIT(SoftVolumeInvert) {
 }
 
 PY_PLASMA_IFC_METHODS(SoftVolumeInvert, plSoftVolumeInvert)
-
-}

--- a/Python/PRP/Region/pySoftVolumeSimple.cpp
+++ b/Python/PRP/Region/pySoftVolumeSimple.cpp
@@ -20,8 +20,6 @@
 #include "pyVolumeIsect.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(SoftVolumeSimple, plSoftVolumeSimple)
 
 PY_PROPERTY_CREATABLE(plVolumeIsect, VolumeIsect, SoftVolumeSimple, volume,
@@ -48,5 +46,3 @@ PY_PLASMA_TYPE_INIT(SoftVolumeSimple) {
 }
 
 PY_PLASMA_IFC_METHODS(SoftVolumeSimple, plSoftVolumeSimple)
-
-}

--- a/Python/PRP/Region/pySoftVolumeUnion.cpp
+++ b/Python/PRP/Region/pySoftVolumeUnion.cpp
@@ -18,8 +18,6 @@
 
 #include <PRP/Region/plSoftVolume.h>
 
-extern "C" {
-
 PY_PLASMA_NEW(SoftVolumeUnion, plSoftVolumeUnion)
 
 PY_PLASMA_TYPE(SoftVolumeUnion, plSoftVolumeUnion, "plSoftVolumeUnion wrapper")
@@ -35,5 +33,3 @@ PY_PLASMA_TYPE_INIT(SoftVolumeUnion) {
 }
 
 PY_PLASMA_IFC_METHODS(SoftVolumeUnion, plSoftVolumeUnion)
-
-}

--- a/Python/PRP/Region/pySwimCircularCurrentRegion.cpp
+++ b/Python/PRP/Region/pySwimCircularCurrentRegion.cpp
@@ -19,8 +19,6 @@
 #include "PRP/KeyedObject/pyKey.h"
 #include <PRP/Region/plSwimRegion.h>
 
-extern "C" {
-
 PY_PLASMA_NEW(SwimCircularCurrentRegion, plSwimCircularCurrentRegion)
 
 PY_PROPERTY(float, SwimCircularCurrentRegion, rotation, getRotation, setRotation)
@@ -55,5 +53,3 @@ PY_PLASMA_TYPE_INIT(SwimCircularCurrentRegion) {
 }
 
 PY_PLASMA_IFC_METHODS(SwimCircularCurrentRegion, plSwimCircularCurrentRegion);
-
-}

--- a/Python/PRP/Region/pySwimDetector.cpp
+++ b/Python/PRP/Region/pySwimDetector.cpp
@@ -17,8 +17,6 @@
 #include "pySimpleRegionSensor.h"
 #include <PRP/Region/plSimpleRegionSensor.h>
 
-extern "C" {
-
 PY_PLASMA_NEW(SwimDetector, plSwimDetector)
 
 PY_PLASMA_TYPE(SwimDetector, plSwimDetector, "plSwimDetector wrapper")
@@ -34,5 +32,3 @@ PY_PLASMA_TYPE_INIT(SwimDetector) {
 }
 
 PY_PLASMA_IFC_METHODS(SwimDetector, plSwimDetector);
-
-}

--- a/Python/PRP/Region/pySwimRegionInterface.cpp
+++ b/Python/PRP/Region/pySwimRegionInterface.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Region/plSwimRegion.h>
 #include "PRP/Object/pyObjInterface.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(SwimRegionInterface, plSwimRegionInterface)
 
 PY_PROPERTY(float, SwimRegionInterface, downBuoyancy, getDownBuoyancy, setDownBuoyancy)
@@ -51,5 +49,3 @@ PY_PLASMA_TYPE_INIT(SwimRegionInterface) {
 }
 
 PY_PLASMA_IFC_METHODS(SwimRegionInterface, plSwimRegionInterface);
-
-}

--- a/Python/PRP/Region/pySwimStraightCurrentRegion.cpp
+++ b/Python/PRP/Region/pySwimStraightCurrentRegion.cpp
@@ -19,8 +19,6 @@
 #include "PRP/KeyedObject/pyKey.h"
 #include <PRP/Region/plSwimRegion.h>
 
-extern "C" {
-
 PY_PLASMA_NEW(SwimStraightCurrentRegion, plSwimStraightCurrentRegion)
 
 PY_PROPERTY(float, SwimStraightCurrentRegion, nearDist, getNearDist, setNearDist)
@@ -53,5 +51,3 @@ PY_PLASMA_TYPE_INIT(SwimStraightCurrentRegion) {
 }
 
 PY_PLASMA_IFC_METHODS(SwimStraightCurrentRegion, plSwimStraightCurrentRegion);
-
-}

--- a/Python/PRP/Region/pyVisRegion.cpp
+++ b/Python/PRP/Region/pyVisRegion.cpp
@@ -20,8 +20,6 @@
 #include "PRP/Object/pyObjInterface.h"
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(VisRegion, plVisRegion)
 
 PY_PROPERTY(plKey, VisRegion, region, getRegion, setRegion)
@@ -52,5 +50,3 @@ PY_PLASMA_TYPE_INIT(VisRegion) {
 }
 
 PY_PLASMA_IFC_METHODS(VisRegion, plVisRegion)
-
-}

--- a/Python/PRP/Region/pyVolumeIsect.cpp
+++ b/Python/PRP/Region/pyVolumeIsect.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Region/plVolumeIsect.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(VolumeIsect, "plVolumeIsect is abstract")
 
 PY_PLASMA_TYPE(VolumeIsect, plVolumeIsect, "plVolumeIsect wrapper")
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(VolumeIsect) {
 }
 
 PY_PLASMA_IFC_METHODS(VolumeIsect, plVolumeIsect)
-
-}

--- a/Python/PRP/Surface/pyBitmap.cpp
+++ b/Python/PRP/Surface/pyBitmap.cpp
@@ -20,8 +20,6 @@
 #include "PRP/KeyedObject/pyKeyedObject.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(Bitmap, "plBitmap is abstract")
 
 PY_METHOD_VA(Bitmap, setConfig,
@@ -145,5 +143,3 @@ PY_PLASMA_TYPE_INIT(Bitmap) {
 }
 
 PY_PLASMA_IFC_METHODS(Bitmap, plBitmap)
-
-}

--- a/Python/PRP/Surface/pyCubicEnvironmap.cpp
+++ b/Python/PRP/Surface/pyCubicEnvironmap.cpp
@@ -20,8 +20,6 @@
 #include "PRP/pyCreatable.h"
 #include "pyBitmap.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(CubicEnvironmap, plCubicEnvironmap)
 
 #define CEM_FACE(propName, faceName)                                    \
@@ -71,5 +69,3 @@ PY_PLASMA_TYPE_INIT(CubicEnvironmap) {
 }
 
 PY_PLASMA_IFC_METHODS(CubicEnvironmap, plCubicEnvironmap)
-
-}

--- a/Python/PRP/Surface/pyCubicRenderTarget.cpp
+++ b/Python/PRP/Surface/pyCubicRenderTarget.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Surface/plRenderTarget.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(CubicRenderTarget, plCubicRenderTarget)
 
 /* These are proxies to render target objects in the CRT, so they cannot be set */
@@ -80,5 +78,3 @@ PY_PLASMA_TYPE_INIT(CubicRenderTarget) {
 }
 
 PY_PLASMA_IFC_METHODS(CubicRenderTarget, plCubicRenderTarget)
-
-}

--- a/Python/PRP/Surface/pyDistOpacityMod.cpp
+++ b/Python/PRP/Surface/pyDistOpacityMod.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Surface/plDistOpacityMod.h>
 #include "pyDistOpacityMod.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(DistOpacityMod, plDistOpacityMod)
 
 #define DOM_DISTANCE(propName, distEnum)                                \
@@ -65,5 +63,3 @@ PY_PLASMA_TYPE_INIT(DistOpacityMod) {
 }
 
 PY_PLASMA_IFC_METHODS(DistOpacityMod, plDistOpacityMod)
-
-}

--- a/Python/PRP/Surface/pyDynamicCamMap.cpp
+++ b/Python/PRP/Surface/pyDynamicCamMap.cpp
@@ -22,8 +22,6 @@
 #include "Math/pyGeometry3.h"
 #include "Sys/pyColor.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(DynamicCamMap, plDynamicCamMap)
 
 PY_METHOD_VA(DynamicCamMap, addMatLayer,
@@ -343,5 +341,3 @@ PY_PLASMA_TYPE_INIT(DynamicCamMap) {
 }
 
 PY_PLASMA_IFC_METHODS(DynamicCamMap, plDynamicCamMap)
-
-}

--- a/Python/PRP/Surface/pyDynamicEnvMap.cpp
+++ b/Python/PRP/Surface/pyDynamicEnvMap.cpp
@@ -25,8 +25,6 @@
 #include "Math/pyGeometry3.h"
 #include "Sys/pyColor.h"
 
-extern "C" {
-
 // DynamicEnvMap
 
 PY_PLASMA_NEW(DynamicEnvMap, plDynamicEnvMap)
@@ -131,5 +129,3 @@ PY_PLASMA_TYPE_INIT(DynamicEnvMap) {
 }
 
 PY_PLASMA_IFC_METHODS(DynamicEnvMap, plDynamicEnvMap)
-
-}

--- a/Python/PRP/Surface/pyDynamicTextMap.cpp
+++ b/Python/PRP/Surface/pyDynamicTextMap.cpp
@@ -20,8 +20,6 @@
 #include "pyBitmap.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(DynamicTextMap, plDynamicTextMap)
 
 PY_GETSET_GETTER_DECL(DynamicTextMap, initBuffer) {
@@ -84,5 +82,3 @@ PY_PLASMA_TYPE_INIT(DynamicTextMap) {
 }
 
 PY_PLASMA_IFC_METHODS(DynamicTextMap, plDynamicTextMap)
-
-}

--- a/Python/PRP/Surface/pyFadeOpacityMod.cpp
+++ b/Python/PRP/Surface/pyFadeOpacityMod.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Surface/plFadeOpacityMod.h>
 #include "PRP/Modifier/pyModifier.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(FadeOpacityMod, plFadeOpacityMod)
 
 PY_PROPERTY(float, FadeOpacityMod, fadeUp, getFadeUp, setFadeUp)
@@ -64,5 +62,3 @@ PY_PLASMA_TYPE_INIT(FadeOpacityMod) {
 }
 
 PY_PLASMA_IFC_METHODS(FadeOpacityMod, plFadeOpacityMod)
-
-}

--- a/Python/PRP/Surface/pyFixedWaterState7.cpp
+++ b/Python/PRP/Surface/pyFixedWaterState7.cpp
@@ -20,8 +20,6 @@
 #include "Math/pyGeometry3.h"
 #include "Sys/pyColor.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(FixedWaterState7, plFixedWaterState7)
 
 PY_PROPERTY_PROXY(plFixedWaterState7::WaveState, FixedWaterState7, geoState, getGeoState)
@@ -90,5 +88,3 @@ PY_PLASMA_TYPE_INIT(FixedWaterState7) {
 }
 
 PY_PLASMA_IFC_METHODS(FixedWaterState7, plFixedWaterState7)
-
-}

--- a/Python/PRP/Surface/pyGMatState.cpp
+++ b/Python/PRP/Surface/pyGMatState.cpp
@@ -18,8 +18,6 @@
 
 #include <PRP/Surface/hsGMatState.h>
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(GMatState, "Cannot construct hsGMatState objects")
 
 PY_PROPERTY_MEMBER(unsigned int, GMatState, blendFlags, fBlendFlags)
@@ -141,5 +139,3 @@ PY_PLASMA_TYPE_INIT(GMatState) {
 }
 
 PY_PLASMA_IFC_METHODS(GMatState, hsGMatState)
-
-}

--- a/Python/PRP/Surface/pyGMaterial.cpp
+++ b/Python/PRP/Surface/pyGMaterial.cpp
@@ -21,8 +21,6 @@
 #include "PRP/Object/pySynchedObject.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(GMaterial, hsGMaterial)
 
 PY_METHOD_NOARGS(GMaterial, clearLayers, "Remove all layer keys from the material") {
@@ -168,5 +166,3 @@ PY_PLASMA_TYPE_INIT(GMaterial) {
 }
 
 PY_PLASMA_IFC_METHODS(GMaterial, hsGMaterial)
-
-}

--- a/Python/PRP/Surface/pyLayer.cpp
+++ b/Python/PRP/Surface/pyLayer.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Surface/plLayer.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(Layer, plLayer)
 
 PY_PLASMA_TYPE(Layer, plLayer, "plLayer wrapper")
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(Layer) {
 }
 
 PY_PLASMA_IFC_METHODS(Layer, plLayer)
-
-}

--- a/Python/PRP/Surface/pyLayerAVI.cpp
+++ b/Python/PRP/Surface/pyLayerAVI.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Surface/plLayerMovie.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(LayerAVI, plLayerAVI)
 
 PY_PLASMA_TYPE(LayerAVI, plLayerAVI, "plLayerAVI wrapper")
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(LayerAVI) {
 }
 
 PY_PLASMA_IFC_METHODS(LayerAVI, plLayerAVI)
-
-}

--- a/Python/PRP/Surface/pyLayerAnimation.cpp
+++ b/Python/PRP/Surface/pyLayerAnimation.cpp
@@ -20,8 +20,6 @@
 #include "PRP/Animation/pyAnimTimeConvert.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(LayerAnimation, plLayerAnimation)
 
 PY_PROPERTY_PROXY_RO(plAnimTimeConvert, LayerAnimation, timeConvert, getTimeConvert)
@@ -45,5 +43,3 @@ PY_PLASMA_TYPE_INIT(LayerAnimation) {
 }
 
 PY_PLASMA_IFC_METHODS(LayerAnimation, plLayerAnimation)
-
-}

--- a/Python/PRP/Surface/pyLayerAnimationBase.cpp
+++ b/Python/PRP/Surface/pyLayerAnimationBase.cpp
@@ -21,8 +21,6 @@
 #include "PRP/Animation/pyController.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(LayerAnimationBase, "plLayerAnimationBase is abstract")
 
 PY_PROPERTY_CREATABLE(plController, Controller, LayerAnimationBase,
@@ -63,5 +61,3 @@ PY_PLASMA_TYPE_INIT(LayerAnimationBase) {
 }
 
 PY_PLASMA_IFC_METHODS(LayerAnimationBase, plLayerAnimationBase)
-
-}

--- a/Python/PRP/Surface/pyLayerBink.cpp
+++ b/Python/PRP/Surface/pyLayerBink.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Surface/plLayerMovie.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(LayerBink, plLayerBink)
 
 PY_PLASMA_TYPE(LayerBink, plLayerBink, "plLayerBink wrapper")
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(LayerBink) {
 }
 
 PY_PLASMA_IFC_METHODS(LayerBink, plLayerBink)
-
-}

--- a/Python/PRP/Surface/pyLayerDepth.cpp
+++ b/Python/PRP/Surface/pyLayerDepth.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Surface/plLayer.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(LayerDepth, plLayerDepth)
 
 PY_PLASMA_TYPE(LayerDepth, plLayerDepth, "plLayerDepth wrapper")
@@ -36,5 +34,3 @@ PY_PLASMA_TYPE_INIT(LayerDepth) {
 }
 
 PY_PLASMA_IFC_METHODS(LayerDepth, plLayerDepth)
-
-}

--- a/Python/PRP/Surface/pyLayerInterface.cpp
+++ b/Python/PRP/Surface/pyLayerInterface.cpp
@@ -24,8 +24,6 @@
 #include "Math/pyMatrix.h"
 #include "Sys/pyColor.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(LayerInterface, "plLayerInterface is abstract")
 
 PY_PROPERTY(plKey, LayerInterface, underLay, getUnderLay, setUnderLay)
@@ -102,5 +100,3 @@ PY_PLASMA_TYPE_INIT(LayerInterface) {
 }
 
 PY_PLASMA_IFC_METHODS(LayerInterface, plLayerInterface)
-
-}

--- a/Python/PRP/Surface/pyLayerLinkAnimation.cpp
+++ b/Python/PRP/Surface/pyLayerLinkAnimation.cpp
@@ -20,8 +20,6 @@
 #include "PRP/KeyedObject/pyKey.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(LayerLinkAnimation, plLayerLinkAnimation)
 
 PY_PROPERTY(plKey, LayerLinkAnimation, linkKey, getLinkKey, setLinkKey)
@@ -48,5 +46,3 @@ PY_PLASMA_TYPE_INIT(LayerLinkAnimation) {
 }
 
 PY_PLASMA_IFC_METHODS(LayerLinkAnimation, plLayerLinkAnimation)
-
-}

--- a/Python/PRP/Surface/pyLayerMovie.cpp
+++ b/Python/PRP/Surface/pyLayerMovie.cpp
@@ -20,8 +20,6 @@
 #include "pyLayerAnimation.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(LayerMovie, plLayerMovie)
 
 PY_PROPERTY(ST::string, LayerMovie, movieName, getMovieName, setMovieName)
@@ -45,5 +43,3 @@ PY_PLASMA_TYPE_INIT(LayerMovie) {
 }
 
 PY_PLASMA_IFC_METHODS(LayerMovie, plLayerMovie)
-
-}

--- a/Python/PRP/Surface/pyLayerSDLAnimation.cpp
+++ b/Python/PRP/Surface/pyLayerSDLAnimation.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Surface/plLayerAnimation.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(LayerSDLAnimation, plLayerSDLAnimation)
 
 PY_PROPERTY(ST::string, LayerSDLAnimation, varName, getVarName, setVarName)
@@ -44,5 +42,3 @@ PY_PLASMA_TYPE_INIT(LayerSDLAnimation) {
 }
 
 PY_PLASMA_IFC_METHODS(LayerSDLAnimation, plLayerSDLAnimation)
-
-}

--- a/Python/PRP/Surface/pyMipmap.cpp
+++ b/Python/PRP/Surface/pyMipmap.cpp
@@ -20,8 +20,6 @@
 #include "PRP/pyCreatable.h"
 #include "Stream/pyStream.h"
 
-extern "C" {
-
 PY_PLASMA_INIT_DECL(Mipmap) {
     const char* name = "";
     int width, height, numLevels, compType, format;
@@ -352,5 +350,3 @@ PY_PLASMA_TYPE_INIT(Mipmap) {
 }
 
 PY_PLASMA_IFC_METHODS(Mipmap, plMipmap)
-
-}

--- a/Python/PRP/Surface/pyRenderTarget.cpp
+++ b/Python/PRP/Surface/pyRenderTarget.cpp
@@ -20,8 +20,6 @@
 #include "pyBitmap.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(RenderTarget, plRenderTarget)
 
 PY_PROPERTY(unsigned short, RenderTarget, width, getWidth, setWidth)
@@ -94,5 +92,3 @@ PY_PLASMA_TYPE_INIT(RenderTarget) {
 }
 
 PY_PLASMA_IFC_METHODS(RenderTarget, plRenderTarget)
-
-}

--- a/Python/PRP/Surface/pyShader.cpp
+++ b/Python/PRP/Surface/pyShader.cpp
@@ -20,8 +20,6 @@
 #include "PRP/KeyedObject/pyKeyedObject.h"
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(Shader, plShader)
 
 PY_GETSET_GETTER_DECL(Shader, constants) {
@@ -126,5 +124,3 @@ PY_PLASMA_TYPE_INIT(Shader) {
 }
 
 PY_PLASMA_IFC_METHODS(Shader, plShader)
-
-}

--- a/Python/PRP/Surface/pyShaderConst.cpp
+++ b/Python/PRP/Surface/pyShaderConst.cpp
@@ -19,8 +19,6 @@
 #include <PRP/Surface/plShader.h>
 #include "Stream/pyStream.h"
 
-extern "C" {
-
 PY_PLASMA_VALUE_DEALLOC(ShaderConst)
 
 PY_PLASMA_INIT_DECL(ShaderConst) {
@@ -161,5 +159,3 @@ PY_PLASMA_TYPE_INIT(ShaderConst) {
 }
 
 PY_PLASMA_VALUE_IFC_METHODS(ShaderConst, plShaderConst)
-
-}

--- a/Python/PRP/Surface/pyWaveSet7.cpp
+++ b/Python/PRP/Surface/pyWaveSet7.cpp
@@ -20,8 +20,6 @@
 #include "pyFixedWaterState7.h"
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(WaveSet7, plWaveSet7)
 
 PY_METHOD_VA(WaveSet7, addShore,
@@ -158,5 +156,3 @@ PY_PLASMA_TYPE_INIT(WaveSet7) {
 }
 
 PY_PLASMA_IFC_METHODS(WaveSet7, plWaveSet7)
-
-}

--- a/Python/PRP/Surface/pyWaveSetBase.cpp
+++ b/Python/PRP/Surface/pyWaveSetBase.cpp
@@ -18,8 +18,6 @@
 
 #include "PRP/Modifier/pyModifier.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(WaveSetBase, "plWaveSetBase is abstract")
 
 PY_PLASMA_TYPE(WaveSetBase, plWaveSetBase, "plWaveSetBase wrapper")
@@ -35,5 +33,3 @@ PY_PLASMA_TYPE_INIT(WaveSetBase) {
 }
 
 PY_PLASMA_IFC_METHODS(WaveSetBase, plWaveSetBase)
-
-}

--- a/Python/PRP/Surface/pyWaveState7.cpp
+++ b/Python/PRP/Surface/pyWaveState7.cpp
@@ -18,8 +18,6 @@
 
 #include <PRP/Surface/plFixedWaterState7.h>
 
-extern "C" {
-
 PY_PLASMA_EMPTY_INIT(WaveState7)
 PY_PLASMA_NEW(WaveState7, plFixedWaterState7::WaveState)
 
@@ -53,5 +51,3 @@ PY_PLASMA_TYPE_INIT(WaveState7) {
 }
 
 PY_PLASMA_IFC_METHODS(WaveState7, plFixedWaterState7::WaveState)
-
-}

--- a/Python/PRP/pyCreatable.cpp
+++ b/Python/PRP/pyCreatable.cpp
@@ -20,8 +20,6 @@
 #include "Stream/pyStream.h"
 #include "ResManager/pyResManager.h"
 
-extern "C" {
-
 PY_PLASMA_DEALLOC(Creatable)
 PY_PLASMA_EMPTY_INIT(Creatable)
 PY_PLASMA_NEW_MSG(Creatable, "plCreatable is abstract")
@@ -132,5 +130,3 @@ PY_PLASMA_TYPE_INIT(Creatable) {
 }
 
 PY_PLASMA_IFC_METHODS(Creatable, plCreatable)
-
-}

--- a/Python/PRP/pyCreatableStub.cpp
+++ b/Python/PRP/pyCreatableStub.cpp
@@ -18,8 +18,6 @@
 
 #include <PRP/plCreatable.h>
 
-extern "C" {
-
 PY_PLASMA_INIT_DECL(CreatableStub) {
     int classId, length;
     if (!PyArg_ParseTuple(args, "ii", &classId, &length)) {
@@ -71,5 +69,3 @@ PY_PLASMA_TYPE_INIT(CreatableStub) {
 }
 
 PY_PLASMA_IFC_METHODS(CreatableStub, const plCreatableStub)
-
-}

--- a/Python/PRP/pySceneNode.cpp
+++ b/Python/PRP/pySceneNode.cpp
@@ -20,8 +20,6 @@
 #include "KeyedObject/pyKey.h"
 #include "KeyedObject/pyKeyedObject.h"
 
-extern "C" {
-
 PY_PLASMA_NEW(SceneNode, plSceneNode)
 
 PY_METHOD_NOARGS(SceneNode, clear, "Removes all objects from the Scene Node") {
@@ -170,5 +168,3 @@ PY_PLASMA_TYPE_INIT(SceneNode) {
 }
 
 PY_PLASMA_IFC_METHODS(SceneNode, plSceneNode)
-
-}

--- a/Python/PyPlasma.h
+++ b/Python/PyPlasma.h
@@ -93,7 +93,6 @@ struct pySequenceFastRef
 
 /* Use this macro to ensure the layouts of subclass types are consistent */
 #define PY_WRAP_PLASMA(pyType, plType)                          \
-    extern "C" {                                                \
     struct py##pyType {                                         \
         PyObject_HEAD                                           \
         plType* fThis;                                          \
@@ -102,13 +101,11 @@ struct pySequenceFastRef
     extern PyTypeObject py##pyType##_Type;                      \
     PyObject* Init_py##pyType##_Type();                         \
     int py##pyType##_Check(PyObject* obj);                      \
-    PyObject* py##pyType##_From##pyType(plType*);               \
-    }
+    PyObject* py##pyType##_From##pyType(plType*);
 
 /* Defines a value-type wrapped class (i.e. those which are copied instead of
  * sharing references) */
 #define PY_WRAP_PLASMA_VALUE(pyType, plType)                    \
-    extern "C" {                                                \
     struct py##pyType {                                         \
         PyObject_HEAD                                           \
         plType* fThis;                                          \
@@ -116,8 +113,7 @@ struct pySequenceFastRef
     extern PyTypeObject py##pyType##_Type;                      \
     PyObject* Init_py##pyType##_Type();                         \
     int py##pyType##_Check(PyObject* obj);                      \
-    PyObject* py##pyType##_From##pyType(const plType&);         \
-    }
+    PyObject* py##pyType##_From##pyType(const plType&);
 
 #define PY_PLASMA_CHECK_TYPE(pyType)                                    \
     int py##pyType##_Check(PyObject* obj) {                             \

--- a/Python/ResManager/pyAgeInfo.cpp
+++ b/Python/ResManager/pyAgeInfo.cpp
@@ -20,8 +20,6 @@
 #include "Stream/pyStream.h"
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_DEALLOC(AgeInfo)
 PY_PLASMA_EMPTY_INIT(AgeInfo)
 PY_PLASMA_NEW(AgeInfo, plAgeInfo)
@@ -271,5 +269,3 @@ PY_PLASMA_TYPE_INIT(AgeInfo) {
 }
 
 PY_PLASMA_IFC_METHODS(AgeInfo, plAgeInfo)
-
-}

--- a/Python/ResManager/pyFactory.cpp
+++ b/Python/ResManager/pyFactory.cpp
@@ -19,8 +19,6 @@
 #include <ResManager/plFactory.h>
 #include "PRP/pyCreatable.h"
 
-extern "C" {
-
 PY_PLASMA_NEW_MSG(Factory, "plFactory cannot be constructed")
 
 PY_METHOD_STATIC_VA(Factory, ClassName,
@@ -1141,6 +1139,4 @@ PY_PLASMA_TYPE_INIT(Factory) {
 
     Py_INCREF(&pyFactory_Type);
     return (PyObject*)&pyFactory_Type;
-}
-
 }

--- a/Python/ResManager/pyPageInfo.cpp
+++ b/Python/ResManager/pyPageInfo.cpp
@@ -20,8 +20,6 @@
 #include "Stream/pyStream.h"
 #include "PRP/KeyedObject/pyKey.h"
 
-extern "C" {
-
 PY_PLASMA_DEALLOC(PageInfo)
 PY_PLASMA_EMPTY_INIT(PageInfo)
 PY_PLASMA_NEW(PageInfo, plPageInfo)
@@ -143,5 +141,3 @@ PY_PLASMA_TYPE_INIT(PageInfo) {
 }
 
 PY_PLASMA_IFC_METHODS(PageInfo, plPageInfo)
-
-}

--- a/Python/ResManager/pyResManager.cpp
+++ b/Python/ResManager/pyResManager.cpp
@@ -24,8 +24,6 @@
 #include "PRP/KeyedObject/pyKey.h"
 #include "PRP/KeyedObject/pyKeyedObject.h"
 
-extern "C" {
-
 PY_PLASMA_DEALLOC(ResManager)
 
 PY_PLASMA_INIT_DECL(ResManager) {
@@ -626,5 +624,3 @@ PY_PLASMA_TYPE_INIT(ResManager) {
 }
 
 PY_PLASMA_IFC_METHODS(ResManager, plResManager)
-
-}

--- a/Python/ResManager/pyResManager.h
+++ b/Python/ResManager/pyResManager.h
@@ -23,11 +23,7 @@ PY_WRAP_PLASMA(ResManager, class plResManager);
 PY_WRAP_PLASMA(PageInfo, class plPageInfo);
 PY_WRAP_PLASMA(AgeInfo, class plAgeInfo);
 
-extern "C" {
-
 extern PyTypeObject pyFactory_Type;
 PyObject* Init_pyFactory_Type();
-
-}
 
 #endif

--- a/Python/Stream/pyEncryptedStream.cpp
+++ b/Python/Stream/pyEncryptedStream.cpp
@@ -18,8 +18,6 @@
 
 #include <Stream/plEncryptedStream.h>
 
-extern "C" {
-
 PY_PLASMA_NEW(EncryptedStream, plEncryptedStream)
 
 PY_METHOD_VA(EncryptedStream, open,
@@ -138,5 +136,3 @@ PY_PLASMA_TYPE_INIT(EncryptedStream) {
 }
 
 PY_PLASMA_IFC_METHODS(EncryptedStream, plEncryptedStream)
-
-}

--- a/Python/Stream/pyFileStream.cpp
+++ b/Python/Stream/pyFileStream.cpp
@@ -18,8 +18,6 @@
 
 #include <Stream/hsStream.h>
 
-extern "C" {
-
 PY_PLASMA_NEW(FileStream, hsFileStream)
 
 PY_METHOD_VA(FileStream, open,
@@ -78,5 +76,3 @@ PY_PLASMA_TYPE_INIT(FileStream) {
 }
 
 PY_PLASMA_IFC_METHODS(FileStream, hsFileStream)
-
-}

--- a/Python/Stream/pyRAMStream.cpp
+++ b/Python/Stream/pyRAMStream.cpp
@@ -18,8 +18,6 @@
 
 #include <Stream/hsRAMStream.h>
 
-extern "C" {
-
 PY_PLASMA_NEW(RAMStream, hsRAMStream)
 
 PY_METHOD_VA(RAMStream, resize,
@@ -85,5 +83,3 @@ PY_PLASMA_TYPE_INIT(RAMStream) {
 }
 
 PY_PLASMA_IFC_METHODS(RAMStream, hsRAMStream)
-
-}

--- a/Python/Stream/pyStream.cpp
+++ b/Python/Stream/pyStream.cpp
@@ -18,8 +18,6 @@
 
 #include <Stream/hsStream.h>
 
-extern "C" {
-
 PY_PLASMA_DEALLOC(Stream)
 
 PY_PLASMA_INIT_DECL(Stream) {
@@ -426,5 +424,3 @@ PY_PLASMA_TYPE_INIT(Stream) {
 }
 
 PY_PLASMA_IFC_METHODS(Stream, hsStream)
-
-}

--- a/Python/Sys/pyColor32.cpp
+++ b/Python/Sys/pyColor32.cpp
@@ -20,8 +20,6 @@
 #include "Stream/pyStream.h"
 #include <string_theory/format>
 
-extern "C" {
-
 PY_PLASMA_VALUE_DEALLOC(Color32)
 
 PY_METHOD_KWARGS(Color32, set,
@@ -212,5 +210,3 @@ PY_PLASMA_TYPE_INIT(Color32) {
 }
 
 PY_PLASMA_VALUE_IFC_METHODS(Color32, hsColor32)
-
-}

--- a/Python/Sys/pyColorRGBA.cpp
+++ b/Python/Sys/pyColorRGBA.cpp
@@ -20,8 +20,6 @@
 #include "Stream/pyStream.h"
 #include <string_theory/format>
 
-extern "C" {
-
 PY_PLASMA_VALUE_DEALLOC(ColorRGBA)
 
 PY_PLASMA_INIT_DECL(ColorRGBA) {
@@ -210,5 +208,3 @@ PY_PLASMA_TYPE_INIT(ColorRGBA) {
 }
 
 PY_PLASMA_VALUE_IFC_METHODS(ColorRGBA, hsColorRGBA)
-
-}

--- a/Python/Util/pyBitVector.cpp
+++ b/Python/Util/pyBitVector.cpp
@@ -19,8 +19,6 @@
 #include <Util/hsBitVector.h>
 #include "Stream/pyStream.h"
 
-extern "C" {
-
 PY_PLASMA_DEALLOC(BitVector)
 PY_PLASMA_EMPTY_INIT(BitVector)
 PY_PLASMA_NEW(BitVector, hsBitVector)
@@ -181,5 +179,3 @@ PY_PLASMA_TYPE_INIT(BitVector) {
 }
 
 PY_PLASMA_IFC_METHODS(BitVector, hsBitVector)
-
-}

--- a/Python/Util/pyDDSurface.cpp
+++ b/Python/Util/pyDDSurface.cpp
@@ -22,8 +22,6 @@
 #include "PRP/pyCreatable.h"
 #include "PRP/Surface/pyBitmap.h"
 
-extern "C" {
-
 PY_PLASMA_DEALLOC(DDSurface)
 PY_PLASMA_EMPTY_INIT(DDSurface)
 PY_PLASMA_NEW(DDSurface, plDDSurface)
@@ -493,5 +491,3 @@ PY_PLASMA_TYPE_INIT(DDSurface) {
 }
 
 PY_PLASMA_IFC_METHODS(DDSurface, plDDSurface)
-
-}

--- a/core/Sys/plUnifiedTime.cpp
+++ b/core/Sys/plUnifiedTime.cpp
@@ -18,12 +18,11 @@
 #include "plUnifiedTime.h"
 
 #ifdef _MSC_VER
-extern "C" {
-
 int gettimeofday(struct timeval* tv, void* tz) {
     FILETIME ft;
 
-    if (!tv) return -1;
+    if (!tv)
+        return -1;
     GetSystemTimeAsFileTime(&ft);
 
     unsigned __int64 tim = ft.dwHighDateTime;
@@ -36,8 +35,6 @@ int gettimeofday(struct timeval* tv, void* tz) {
     tv->tv_usec = (long)(tim % 1000000L);
 
     return 0;
-}
-
 }
 #endif
 

--- a/core/Sys/plUnifiedTime.h
+++ b/core/Sys/plUnifiedTime.h
@@ -26,9 +26,7 @@
 
 // FIX: MSVC doesn't have the <sys/time.h> stuff, so let's add it
 #ifdef _MSC_VER
-extern "C" {
-    int gettimeofday(struct timeval* tv, void* tz);
-}
+int gettimeofday(struct timeval* tv, void* tz);
 #endif
 
 #include "Stream/pfPrcHelper.h"

--- a/core/Sys/plUuid.cpp
+++ b/core/Sys/plUuid.cpp
@@ -19,7 +19,7 @@
 #include <cstring>
 
 static const unsigned char nullDat4[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
-const plUuid NullUuid(0, 0, 0, nullDat4);
+const plUuid plUuid::Null(0, 0, 0, nullDat4);
 
 plUuid::plUuid() : fData1(0), fData2(0), fData3(0) {
     memset(fData4, 0, sizeof(fData4));
@@ -98,10 +98,6 @@ void plUuid::clear() {
     fData2 = 0;
     fData3 = 0;
     memset(fData4, 0, sizeof(fData4));
-}
-
-bool plUuid::isNull() const {
-    return operator==(NullUuid);
 }
 
 ST::string plUuid::toString() const {

--- a/core/Sys/plUuid.h
+++ b/core/Sys/plUuid.h
@@ -31,6 +31,8 @@ private:
     unsigned char fData4[8];
 
 public:
+    static const plUuid Null;
+
     /** Constructs a null UUID, i.e. 00000000-0000-0000-0000-000000000000. */
     plUuid();
 
@@ -78,7 +80,7 @@ public:
     void clear();
 
     /** Returns true if the UUID is 00000000-0000-0000-0000-000000000000. */
-    bool isNull() const;
+    bool isNull() const { return operator==(Null); }
 
     /**
      * Returns a string representation of this UUID in the form of
@@ -95,7 +97,5 @@ public:
      */
     void fromString(const ST::string& str);
 };
-
-extern const plUuid NullUuid;
 
 #endif


### PR DESCRIPTION
"C" linkage is only needed for symbols directly exported to or imported from a C API.  Symbols which are only accessible through C++ code and/or pointers don't need the "C" linkage, so this cleans up everything else.