### PR TITLE
Latin-1 PRP support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,8 +43,7 @@ configure_file(${PROJECT_SOURCE_DIR}/cmake/PlasmaConfig.h.in
                ${PROJECT_BINARY_DIR}/PlasmaConfig.h)
 include_directories(${PROJECT_BINARY_DIR})
 
-find_package(string_theory REQUIRED)
-include_directories(${STRING_THEORY_INCLUDE_DIRS})
+find_package(string_theory 1.5 REQUIRED)
 
 add_subdirectory(core)
 

--- a/core/Stream/hsStream.cpp
+++ b/core/Stream/hsStream.cpp
@@ -16,6 +16,7 @@
 
 #include <string.h>
 #include <sys/stat.h>
+#include <string_theory/exceptions>
 #include "hsStream.h"
 #include "Sys/Platform.h"
 #include "Debug/plDebug.h"
@@ -96,7 +97,15 @@ ST::string hsStream::readStr(size_t len) {
     char* buf = result.create_writable_buffer(len);
     read(len * sizeof(char), buf);
     buf[len] = 0;
-    return result;
+
+    try {
+        return result;
+    } catch (ST::unicode_error&) {
+        fprintf(stderr, "WARNING: String \"%s\" contained invalid unicode characters.\n"
+                "Treating as Latin-1 instead.  If you save this file, the string will be\n"
+                "converted to UTF-8!\n", buf);
+        return ST::string::from_latin_1(result);
+    }
 }
 
 ST::string hsStream::readSafeStr() {
@@ -132,7 +141,15 @@ ST::string hsStream::readSafeStr() {
         }
         buf[size] = 0;
     }
-    return result;
+
+    try {
+        return result;
+    } catch (ST::unicode_error&) {
+        fprintf(stderr, "WARNING: String \"%s\" contained invalid unicode characters.\n"
+                "Treating as Latin-1 instead.  If you save this file, the string will be \n"
+                "converted to UTF-8!\n", buf);
+        return ST::string::from_latin_1(result);
+    }
 }
 
 ST::string hsStream::readSafeWStr() {


### PR DESCRIPTION
This allows libhsplasma to load PRPs with Latin-1 encoded strings (see #97).

Note that doing so and then re-saving the PRP will cause the string to get converted to UTF-8, which **may break external references** if they are not also updated to UTF-8.