### PR TITLE
Dynamically detect available SHA algorithms and port to EVP APIs

### DIFF
--- a/net/CMakeLists.txt
+++ b/net/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(OpenSSL)
+find_package(OpenSSL REQUIRED)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../core)


### PR DESCRIPTION
Dynamically detect available SHA algorithms and throw an exception when one isn't available (fixes compilation but not functionality with current OpenSSL versions that removed SHA0).  This also ports to the more standard/supported (albeit more verbose) EVP APIs instead of direct calls to the low-level SHA algorithms.