### PR TITLE
Fix 64-bit build

### DIFF
--- a/core/Stream/pfPrcHelper.cpp
+++ b/core/Stream/pfPrcHelper.cpp
@@ -65,6 +65,12 @@ void pfPrcHelper::writeParam(const char* name, long value) {
     file->writeStr(buf);
 }
 
+void pfPrcHelper::writeParam(const char* name, long long value) {
+    char buf[256];
+    snprintf(buf, 256, " %s=\"%lld\"", name, value);
+    file->writeStr(buf);
+}
+
 void pfPrcHelper::writeParam(const char* name, unsigned int value) {
     char buf[256];
     snprintf(buf, 256, " %s=\"%u\"", name, value);
@@ -74,6 +80,12 @@ void pfPrcHelper::writeParam(const char* name, unsigned int value) {
 void pfPrcHelper::writeParam(const char* name, unsigned long value) {
     char buf[256];
     snprintf(buf, 256, " %s=\"%lu\"", name, value);
+    file->writeStr(buf);
+}
+
+void pfPrcHelper::writeParam(const char* name, unsigned long long value) {
+    char buf[256];
+    snprintf(buf, 256, " %s=\"%llu\"", name, value);
     file->writeStr(buf);
 }
 

--- a/core/Stream/pfPrcHelper.h
+++ b/core/Stream/pfPrcHelper.h
@@ -52,8 +52,10 @@ public:
     void writeParam(const char* name, const char* value);
     void writeParam(const char* name, int value);
     void writeParam(const char* name, long value);
+    void writeParam(const char* name, long long value);
     void writeParam(const char* name, unsigned int value);
     void writeParam(const char* name, unsigned long value);
+    void writeParam(const char* name, unsigned long long value);
     void writeParam(const char* name, float value);
     void writeParam(const char* name, double value);
     void writeParam(const char* name, bool value);


### PR DESCRIPTION
#107 changed the way the maximum number of emitters was stored such that it now has a type of size_t. On x64, this is a 64-bit integer for which there was no 64-bit PRC overload. This adds a 64-bit overload in the style of the already existing ones such that libHSPlasma will compile again.