### PR TITLE
Add missing camera constant to PyHSPlasma

### DIFF
--- a/Python/PRP/Message/pyCameraMsg.cpp
+++ b/Python/PRP/Message/pyCameraMsg.cpp
@@ -155,6 +155,8 @@ PY_PLASMA_TYPE_INIT(CameraMsg) {
     PY_TYPE_ADD_CONST(CameraMsg, "kUpdateCameras", plCameraMsg::kUpdateCameras);
     PY_TYPE_ADD_CONST(CameraMsg, "kResponderSetThirdPerson",
                      plCameraMsg::kResponderSetThirdPerson);
+    PY_TYPE_ADD_CONST(CameraMsg, "kResponderUndoThirdPerson",
+                     plCameraMsg::kResponderUndoThirdPerson);
     PY_TYPE_ADD_CONST(CameraMsg, "kNonPhysOn", plCameraMsg::kNonPhysOn);
     PY_TYPE_ADD_CONST(CameraMsg, "kNonPhysOff", plCameraMsg::kNonPhysOff);
     PY_TYPE_ADD_CONST(CameraMsg, "kResetPanning", plCameraMsg::kResetPanning);


### PR DESCRIPTION
One of the very few konstants in this message that is actually used was missing 😿 