### PR TITLE
Remove smart pointers from pyGeometrySpan

### DIFF
--- a/Python/PRP/Geometry/pyDrawableSpans.cpp
+++ b/Python/PRP/Geometry/pyDrawableSpans.cpp
@@ -348,7 +348,7 @@ PY_METHOD_VA(DrawableSpans, buildDIIndex,
         return NULL;
     }
 
-    std::vector<std::shared_ptr<plGeometrySpan> > spans(seq.size());
+    std::vector<plGeometrySpan*> spans(seq.size());
     for (size_t i = 0; i < spans.size(); ++i) {
         PyObject* o = seq.get(i);
         if (pyGeometrySpan_Check(o))
@@ -374,6 +374,7 @@ PY_METHOD_VA(DrawableSpans, addSourceSpan,
         PyErr_SetString(PyExc_TypeError, "addSourceSpan expects a plGeometrySpan");
         return NULL;
     }
+    span->fPyOwned = false;
     return pyPlasma_convert(self->fThis->addSourceSpan(span->fThis));
 }
 

--- a/Python/PRP/Geometry/pyGeometrySpan.cpp
+++ b/Python/PRP/Geometry/pyGeometrySpan.cpp
@@ -21,16 +21,7 @@
 #include "PRP/KeyedObject/pyKey.h"
 #include "PRP/Region/pyBounds.h"
 
-PY_PLASMA_DEALLOC_DECL(GeometrySpan) {
-    Py_TYPE(self)->tp_free(self);
-}
-
-PY_PLASMA_NEW_DECL(GeometrySpan) {
-    pyGeometrySpan* self = (pyGeometrySpan*)type->tp_alloc(type, 0);
-    if (self != NULL)
-        self->fThis.reset(new plGeometrySpan);
-    return (PyObject*)self;
-}
+PY_PLASMA_NEW(GeometrySpan, plGeometrySpan)
 
 PY_METHOD_VA(GeometrySpan, addPermaLight,
     "Params: light\n"
@@ -235,7 +226,6 @@ static PyGetSetDef pyGeometrySpan_GetSet[] = {
 PY_PLASMA_TYPE(GeometrySpan, plGeometrySpan, "plGeometrySpan wrapper")
 
 PY_PLASMA_TYPE_INIT(GeometrySpan) {
-    pyGeometrySpan_Type.tp_dealloc = pyGeometrySpan_dealloc;
     pyGeometrySpan_Type.tp_new = pyGeometrySpan_new;
     pyGeometrySpan_Type.tp_methods = pyGeometrySpan_Methods;
     pyGeometrySpan_Type.tp_getset = pyGeometrySpan_GetSet;
@@ -279,17 +269,4 @@ PY_PLASMA_TYPE_INIT(GeometrySpan) {
     return (PyObject*)&pyGeometrySpan_Type;
 }
 
-int pyGeometrySpan_Check(PyObject* obj) {
-    if (obj->ob_type == &pyGeometrySpan_Type
-        || PyType_IsSubtype(obj->ob_type, &pyGeometrySpan_Type))
-        return 1;
-    return 0;
-}
-
-PyObject* pyGeometrySpan_FromGeometrySpan(const std::shared_ptr<plGeometrySpan>& span) {
-    if (span == NULL)
-        Py_RETURN_NONE;
-    pyGeometrySpan* pspan = PyObject_New(pyGeometrySpan, &pyGeometrySpan_Type);
-    pspan->fThis = span;
-    return (PyObject*)pspan;
-}
+PY_PLASMA_IFC_METHODS(GeometrySpan, plGeometrySpan)

--- a/Python/PRP/Geometry/pyGeometrySpan.h
+++ b/Python/PRP/Geometry/pyGeometrySpan.h
@@ -18,16 +18,7 @@
 #define _PYGEOMETRYSPAN_H
 
 #include "PyPlasma.h"
-#include <memory>
 
-typedef struct {
-    PyObject_HEAD
-    std::shared_ptr<class plGeometrySpan> fThis;
-} pyGeometrySpan;
-
-extern PyTypeObject pyGeometrySpan_Type;
-PyObject* Init_pyGeometrySpan_Type();
-int pyGeometrySpan_Check(PyObject* obj);
-PyObject* pyGeometrySpan_FromGeometrySpan(const std::shared_ptr<class plGeometrySpan>& span);
+PY_WRAP_PLASMA(GeometrySpan, class plGeometrySpan);
 
 #endif

--- a/core/PRP/Geometry/plDrawableSpans.cpp
+++ b/core/PRP/Geometry/plDrawableSpans.cpp
@@ -101,7 +101,7 @@ void plDrawableSpans::read(hsStream* S, plResManager* mgr) {
     if (fSourceSpans.size() > 0 && !S->getVer().isUniversal())
         plDebug::Debug("Reading deprecated SourceSpans");
     for (size_t i=0; i<fSourceSpans.size(); i++) {
-        fSourceSpans[i].reset(new plGeometrySpan());
+        fSourceSpans[i] = new plGeometrySpan();
         fSourceSpans[i]->read(S);
         if (fSpans[i]->getMaterialIdx() == 0xFFFFFFFF)
             fSourceSpans[i]->setMaterial(NULL);
@@ -437,7 +437,7 @@ void plDrawableSpans::IPrcParse(const pfPrcTag* tag, plResManager* mgr) {
         fSourceSpans.resize(tag->countChildren());
         const pfPrcTag* child = tag->getFirstChild();
         for (size_t i=0; i<fSourceSpans.size(); i++) {
-            fSourceSpans[i].reset(new plGeometrySpan());
+            fSourceSpans[i] = new plGeometrySpan();
             fSourceSpans[i]->prcParse(tag);
             if (fSpans[i]->getMaterialIdx() == 0xFFFFFFFF)
                 fSourceSpans[i]->setMaterial(NULL);
@@ -728,7 +728,7 @@ void plDrawableSpans::composeGeometry(bool clearspans, bool calcbounds) {
         delete *span;
 
     for (size_t i=0; i<fSourceSpans.size(); i++) {
-        plGeometrySpan* span = fSourceSpans[i].get();
+        plGeometrySpan* span = fSourceSpans[i];
         unsigned int format = span->getFormat();
         plGBufferGroup* group = groups[format].first;
         if (!group) {
@@ -823,7 +823,7 @@ void plDrawableSpans::composeGeometry(bool clearspans, bool calcbounds) {
 void plDrawableSpans::decomposeGeometry(bool clearcolors) {
     for (size_t i=0; i<fIcicles.size(); i++) {
         plIcicle* icicle = fIcicles[i];
-        std::shared_ptr<plGeometrySpan> span(new plGeometrySpan());
+        plGeometrySpan* span = new plGeometrySpan();
         plGBufferGroup* group = fGroups[icicle->getGroupIdx()];
 
         span->setLocalToWorld(icicle->getLocalToWorld());
@@ -887,7 +887,7 @@ void plDrawableSpans::decomposeGeometry(bool clearcolors) {
     }
 }
 
-size_t plDrawableSpans::buildDIIndex(const std::vector<std::shared_ptr<plGeometrySpan> >& spans) {
+size_t plDrawableSpans::buildDIIndex(const std::vector<plGeometrySpan*>& spans) {
     plDISpanIndex di_idx;
     for (size_t i=0; i<spans.size(); ++i) {
         auto span_f = std::find(fSourceSpans.begin(), fSourceSpans.end(), spans[i]);
@@ -901,7 +901,7 @@ size_t plDrawableSpans::buildDIIndex(const std::vector<std::shared_ptr<plGeometr
     return result;
 }
 
-size_t plDrawableSpans::addSourceSpan(const std::shared_ptr<plGeometrySpan>& span)
+size_t plDrawableSpans::addSourceSpan(plGeometrySpan* span)
 {
     fSourceSpans.push_back(span);
     return fSourceSpans.size() - 1;

--- a/core/PRP/Geometry/plDrawableSpans.h
+++ b/core/PRP/Geometry/plDrawableSpans.h
@@ -25,7 +25,6 @@
 #include "plSpaceTree.h"
 #include "plIcicle.h"
 #include "plGeometrySpan.h"
-#include <memory>
 #include <vector>
 #include <list>
 
@@ -121,7 +120,7 @@ protected:
     unsigned int fProps, fCriteria;
     unsigned int fRenderLevel;
     plKey fSceneNode;
-    std::vector< std::shared_ptr<plGeometrySpan> > fSourceSpans;
+    std::vector<plGeometrySpan*> fSourceSpans;
 
 public:
     plDrawableSpans() : fSpaceTree(NULL), fProps(0), fCriteria(0), fRenderLevel(0) { }
@@ -205,11 +204,11 @@ public:
 
     void composeGeometry(bool clearspans=true, bool calcbounds=false);
     void decomposeGeometry(bool clearcolors=false);
-    size_t buildDIIndex(const std::vector<std::shared_ptr<plGeometrySpan> >& spans);
+    size_t buildDIIndex(const std::vector<plGeometrySpan*>& spans);
 
-    const std::vector<std::shared_ptr<plGeometrySpan> > getSourceSpans() const { return fSourceSpans; }
-    std::vector<std::shared_ptr<plGeometrySpan> > getSourceSpans() { return fSourceSpans; }
-    size_t addSourceSpan(const std::shared_ptr<plGeometrySpan>& span);
+    const std::vector<plGeometrySpan*> getSourceSpans() const { return fSourceSpans; }
+    std::vector<plGeometrySpan*> getSourceSpans() { return fSourceSpans; }
+    size_t addSourceSpan(plGeometrySpan* span);
 };
 
 #endif


### PR DESCRIPTION
This did not match the rest of PyHSPlasma and caused some odd crashes when trying to access a DrawableSpan's sourceSpans from Python.