### PR TITLE
Fix plJPEG image channels order

### DIFF
--- a/core/PRP/Surface/plMipmap.h
+++ b/core/PRP/Surface/plMipmap.h
@@ -82,6 +82,7 @@ public:
     unsigned int getWidth() const { return fWidth; }
     unsigned int getHeight() const { return fHeight; }
     const void* getImageData() const { return fImageData; }
+    void* getImageData() { return fImageData; }
     size_t getTotalSize() const { return fTotalSize; }
     size_t getNumLevels() const { return fLevelData.size(); }
     unsigned int getLevelSize(size_t idx) const { return fLevelData[idx].fSize; }

--- a/core/Util/plJPEG.cpp
+++ b/core/Util/plJPEG.cpp
@@ -192,6 +192,15 @@ void plJPEG::DecompressJPEG(hsStream* S, void* buf, size_t size)
         offs += out_stride;
     }
 
+    // Data stored as RGB on disk but Plasma uses BGR
+    uint32_t* dp = reinterpret_cast<uint32_t*>(buf);
+    for (size_t i=0; i<size; i += 4) {
+        *dp = (*dp & 0xFF00FF00)
+            | (*dp & 0x00FF0000) >> 16
+            | (*dp & 0x000000FF) << 16;
+        dp++;
+    }
+
     jpeg_finish_decompress(&ji.dinfo);
 }
 

--- a/core/Util/plJPEG.cpp
+++ b/core/Util/plJPEG.cpp
@@ -193,6 +193,9 @@ void plJPEG::DecompressJPEG(hsStream* S, void* buf, size_t size)
     }
 
     // Data stored as RGB on disk but Plasma uses BGR
+    if (reinterpret_cast<uintptr_t>(buf) % sizeof(uint32_t) != 0)
+        throw hsBadParamException(__FILE__, __LINE__, "buf should be aligned on a 32-bit boundary");
+
     uint32_t* dp = reinterpret_cast<uint32_t*>(buf);
     for (size_t i=0; i<size; i += 4) {
         *dp = (*dp & 0xFF00FF00)

--- a/core/Util/plJPEG.cpp
+++ b/core/Util/plJPEG.cpp
@@ -193,7 +193,7 @@ void plJPEG::DecompressJPEG(hsStream* S, void* buf, size_t size)
     }
 
     // Data stored as RGB on disk but Plasma uses BGR
-    if (reinterpret_cast<uintptr_t>(buf) % sizeof(uint32_t) != 0)
+    if (reinterpret_cast<uintptr_t>(buf) % alignof(uint32_t) != 0)
         throw hsBadParamException(__FILE__, __LINE__, "buf should be aligned on a 32-bit boundary");
 
     uint32_t* dp = reinterpret_cast<uint32_t*>(buf);


### PR DESCRIPTION
Plasma's plMipmaps store image data in BGR(A) for all uncompressed image types. However, JPEGs are stored as RGB on disk, so we must flip the channels for images that we read in. RLE images are unaffected because they operate on the pixel level. Indeed, the previous behavior would be inconsistent in that Cyan's lossy JPEG mipmaps would appear in RGB while Cyan's RLE mipmaps would appear in BGR.