### PR TITLE
Minor cleanup and optimizations

### DIFF
--- a/Python/PyPlasma.cpp
+++ b/Python/PyPlasma.cpp
@@ -27,13 +27,17 @@ PyObject* PyUnicode_FromSTString(const ST::string& str) {
 }
 
 ST::string PyAnyString_AsSTString(PyObject* str) {
+    char *buffer;
+    Py_ssize_t size;
     if (PyUnicode_Check(str)) {
         PyObject* utfStr = PyUnicode_AsUTF8String(str);
-        ST::string plstr = PyBytes_AsString(utfStr);
+        PyBytes_AsStringAndSize(utfStr, &buffer, &size);
+        ST::string plstr(buffer, size, ST::assume_valid);
         Py_XDECREF(utfStr);
         return plstr;
     } else {
-        return PyBytes_AsString(str);
+        PyBytes_AsStringAndSize(str, &buffer, &size);
+        return ST::string(buffer, size);
     }
 }
 

--- a/core/PRP/KeyedObject/hsKeyedObject.h
+++ b/core/PRP/KeyedObject/hsKeyedObject.h
@@ -91,15 +91,15 @@ public:
     hsKeyedObjectStub() : fStub(NULL) { }
     virtual ~hsKeyedObjectStub();
 
-    short ClassIndex() const HS_FINAL { return fStub->ClassIndex(); }
-    const char* ClassName() const HS_FINAL { return "hsKeyedObjectStub"; }
-    bool isStub() const HS_FINAL { return true; }
+    short ClassIndex() const HS_FINAL_OVERRIDE { return fStub->ClassIndex(); }
+    const char* ClassName() const HS_FINAL_OVERRIDE { return "hsKeyedObjectStub"; }
+    bool isStub() const HS_FINAL_OVERRIDE { return true; }
 
-    void write(hsStream* S, plResManager* mgr) HS_FINAL;
+    void write(hsStream* S, plResManager* mgr) HS_FINAL_OVERRIDE;
 
 protected:
-    void IPrcWrite(pfPrcHelper* prc) HS_FINAL;
-    void IPrcParse(const pfPrcTag* tag, plResManager* mgr) HS_FINAL;
+    void IPrcWrite(pfPrcHelper* prc) HS_FINAL_OVERRIDE;
+    void IPrcParse(const pfPrcTag* tag, plResManager* mgr) HS_FINAL_OVERRIDE;
 
 public:
     /** Returns the underlying plCreatableStub object of this stub */

--- a/core/PRP/KeyedObject/plKey.h
+++ b/core/PRP/KeyedObject/plKey.h
@@ -254,7 +254,7 @@ public:
  * plKey's members, with the addition of Exists() and isLoaded(), which
  * are direct members of the plKey container.
  */
-class PLASMA_DLL plKey HS_FINAL_CLASS {
+class PLASMA_DLL plKey HS_FINAL {
 private:
     plKeyData* fKeyData;
 

--- a/core/PRP/KeyedObject/plKey.h
+++ b/core/PRP/KeyedObject/plKey.h
@@ -254,7 +254,7 @@ public:
  * plKey's members, with the addition of Exists() and isLoaded(), which
  * are direct members of the plKey container.
  */
-class PLASMA_DLL plKey {
+class PLASMA_DLL plKey HS_FINAL_CLASS {
 private:
     plKeyData* fKeyData;
 
@@ -280,7 +280,7 @@ public:
      * the object yourself.  However, if the object is registered with the
      * plResManager, you should not delete the object.
      */
-    virtual ~plKey();
+    ~plKey();
 
     /** Allows for *(plKey) usage as a pointer. */
     plKeyData& operator*() const { return *fKeyData; }
@@ -292,10 +292,10 @@ public:
     operator plKeyData*() const { return fKeyData; }
 
     /** Copies and refs the key data in other */
-    virtual plKey& operator=(const plKey& other);
+    plKey& operator=(const plKey& other);
 
     /** Refs the key data and stores it in this key */
-    virtual plKey& operator=(plKeyData* other);
+    plKey& operator=(plKeyData* other);
 
     /** Returns true if the keys point to the same plKeyData */
     bool operator==(const plKey& other) const { return fKeyData == other.fKeyData; }

--- a/core/PRP/plCreatable.h
+++ b/core/PRP/plCreatable.h
@@ -155,8 +155,8 @@ public:
 
     virtual ~plCreatableStub();
 
-    short ClassIndex() const HS_FINAL { return fClassIdx; }
-    bool isStub() const HS_FINAL { return true; }
+    short ClassIndex() const HS_FINAL_OVERRIDE { return fClassIdx; }
+    bool isStub() const HS_FINAL_OVERRIDE { return true; }
 
     void read(hsStream* S, plResManager* mgr) HS_OVERRIDE;
     void write(hsStream* S, plResManager* mgr) HS_OVERRIDE;

--- a/core/PlasmaDefs.h
+++ b/core/PlasmaDefs.h
@@ -50,13 +50,13 @@
 #endif
 
 #ifdef HAVE_OVERRIDE
-  #define HS_OVERRIDE     override
-  #define HS_FINAL        override final    // Add both to satisfy -Wsuggest-override
-  #define HS_FINAL_CLASS  final
+  #define HS_OVERRIDE       override
+  #define HS_FINAL          final
+  #define HS_FINAL_OVERRIDE override final  // Prefer both to satisfy -Wsuggest-override
 #else
   #define HS_OVERRIDE
   #define HS_FINAL
-  #define HS_FINAL_CLASS
+  #define HS_FINAL_OVERRIDE
 #endif
 
 #ifdef HAVE_NOEXCEPT

--- a/core/PlasmaDefs.h
+++ b/core/PlasmaDefs.h
@@ -50,11 +50,13 @@
 #endif
 
 #ifdef HAVE_OVERRIDE
-  #define HS_OVERRIDE override
-  #define HS_FINAL    override final    // Add both to satisfy -Wsuggest-override
+  #define HS_OVERRIDE     override
+  #define HS_FINAL        override final    // Add both to satisfy -Wsuggest-override
+  #define HS_FINAL_CLASS  final
 #else
   #define HS_OVERRIDE
   #define HS_FINAL
+  #define HS_FINAL_CLASS
 #endif
 
 #ifdef HAVE_NOEXCEPT


### PR DESCRIPTION
* Make `plKey` non-virtual and final
* Optimize conversion of Python strings to `ST::string`
* Rename some macros for clarity