### PR TITLE
pyMipmap improvements

### DIFF
--- a/Python/PRP/Surface/pyMipmap.cpp
+++ b/Python/PRP/Surface/pyMipmap.cpp
@@ -231,10 +231,9 @@ PY_METHOD_NOARGS(Mipmap, extractColorData,
     "Extract an RGB color buffer from a JPEG mipmap")
 {
     size_t dataSize = self->fThis->getWidth() * self->fThis->getHeight() * 3;
-    char* data = new char[dataSize];
+    PyObject* buf = PyBytes_FromStringAndSize(NULL, dataSize);
+    char* data = PyBytes_AS_STRING(buf);
     self->fThis->extractColorData(data, dataSize);
-    PyObject* buf = PyBytes_FromStringAndSize(data, dataSize);
-    delete[] data;
     return buf;
 }
 
@@ -242,10 +241,9 @@ PY_METHOD_NOARGS(Mipmap, extractAlphaData,
     "Extract an alpha intensity buffer from a JPEG mipmap")
 {
     size_t dataSize = self->fThis->getWidth() * self->fThis->getHeight() * 1;
-    char* data = new char[dataSize];
+    PyObject* buf = PyBytes_FromStringAndSize(NULL, dataSize);
+    char* data = PyBytes_AS_STRING(buf);
     self->fThis->extractAlphaData(data, dataSize);
-    PyObject* buf = PyBytes_FromStringAndSize(data, dataSize);
-    delete[] data;
     return buf;
 }
 
@@ -271,16 +269,15 @@ PY_METHOD_VA(Mipmap, DecompressImage,
         return NULL;
     }
     size_t size = self->fThis->GetUncompressedSize(level);
-    unsigned char* buf = new unsigned char[size];
+    PyObject* img = PyBytes_FromStringAndSize(NULL, size);
+    char* buf = PyBytes_AS_STRING(img);
     try {
         self->fThis->DecompressImage(level, buf, size);
     } catch (const hsBadParamException& ex) {
         PyErr_SetString(PyExc_RuntimeError, ex.what());
-        delete[] buf;
+        Py_DECREF(img);
         return NULL;
     }
-    PyObject* img = PyBytes_FromStringAndSize((char*)buf, size);
-    delete[] buf;
     return img;
 }
 

--- a/Python/PRP/Surface/pyMipmap.cpp
+++ b/Python/PRP/Surface/pyMipmap.cpp
@@ -142,7 +142,12 @@ PY_METHOD_VA(Mipmap, setLevel,
         PyErr_SetString(PyExc_TypeError, "setLevel expects int, binary string");
         return NULL;
     }
-    self->fThis->setLevelData(level, (const void*)data, dataSize);
+    try {
+        self->fThis->setLevelData(level, (const void*)data, dataSize);
+    } catch (const hsBadParamException& ex) {
+        PyErr_SetString(PyExc_RuntimeError, ex.what());
+        return NULL;
+    }
     Py_RETURN_NONE;
 }
 
@@ -156,7 +161,12 @@ PY_METHOD_VA(Mipmap, setImageJPEG,
         PyErr_SetString(PyExc_TypeError, "setImageJPEG expects a binary string");
         return NULL;
     }
-    self->fThis->setImageJPEG((const void*)data, dataSize);
+    try {
+        self->fThis->setImageJPEG((const void*)data, dataSize);
+    } catch (const hsBadParamException& ex) {
+        PyErr_SetString(PyExc_RuntimeError, ex.what());
+        return NULL;
+    }
     Py_RETURN_NONE;
 }
 
@@ -170,7 +180,12 @@ PY_METHOD_VA(Mipmap, setAlphaJPEG,
         PyErr_SetString(PyExc_TypeError, "setAlphaJPEG expects a binary string");
         return NULL;
     }
-    self->fThis->setAlphaJPEG((const void*)data, dataSize);
+    try {
+        self->fThis->setAlphaJPEG((const void*)data, dataSize);
+    } catch (const hsBadParamException& ex) {
+        PyErr_SetString(PyExc_RuntimeError, ex.what());
+        return NULL;
+    }
     Py_RETURN_NONE;
 }
 
@@ -186,7 +201,7 @@ PY_METHOD_VA(Mipmap, setColorData,
     }
     try {
         self->fThis->setColorData((const void*)data, dataSize);
-    } catch (hsBadParamException& ex) {
+    } catch (const hsBadParamException& ex) {
         PyErr_SetString(PyExc_RuntimeError, ex.what());
         return NULL;
     }
@@ -205,7 +220,7 @@ PY_METHOD_VA(Mipmap, setAlphaData,
     }
     try {
         self->fThis->setAlphaData((const void*)data, dataSize);
-    } catch (hsBadParamException& ex) {
+    } catch (const hsBadParamException& ex) {
         PyErr_SetString(PyExc_RuntimeError, ex.what());
         return NULL;
     }
@@ -257,7 +272,13 @@ PY_METHOD_VA(Mipmap, DecompressImage,
     }
     size_t size = self->fThis->GetUncompressedSize(level);
     unsigned char* buf = new unsigned char[size];
-    self->fThis->DecompressImage(level, buf, size);
+    try {
+        self->fThis->DecompressImage(level, buf, size);
+    } catch (const hsBadParamException& ex) {
+        PyErr_SetString(PyExc_RuntimeError, ex.what());
+        delete[] buf;
+        return NULL;
+    }
     PyObject* img = PyBytes_FromStringAndSize((char*)buf, size);
     delete[] buf;
     return img;
@@ -278,7 +299,7 @@ PY_METHOD_VA(Mipmap, CompressImage,
     } catch (hsBadParamException& ex) {
         PyErr_SetString(PyExc_RuntimeError, ex.what());
         return NULL;
-    } catch (hsNotImplementedException& ex) {
+    } catch (const hsNotImplementedException& ex) {
         PyErr_SetString(PyExc_NotImplementedError, ex.what());
         return NULL;
     }

--- a/Python/PyPlasma.h
+++ b/Python/PyPlasma.h
@@ -73,12 +73,14 @@ struct pySequenceFastRef
     #undef PyBytes_FromStringAndSize
     #undef PyBytes_AsStringAndSize
     #undef PyBytes_AsString
+    #undef PyBytes_AS_STRING
 
     #define PyAnyString_FromSTString PyString_FromSTString
     #define PyBytes_Check(ob) PyString_Check(ob)
     #define PyBytes_FromStringAndSize(v, len) PyString_FromStringAndSize(v, len)
     #define PyBytes_AsStringAndSize(obj, buf, len) PyString_AsStringAndSize(obj, buf, len)
     #define PyBytes_AsString PyString_AsString
+    #define PyBytes_AS_STRING PyString_AS_STRING
 #else
     #error Your Python version is too old.  Only 2.6 and later are supported
 #endif


### PR DESCRIPTION
This changeset adds more exception translators to the `pyMipmap` member functions and removes some redundant buffer copying.