### PR TITLE
Remove more temporary heap buffers from PyHSPlasma

### DIFF
--- a/Python/Stream/pyRAMStream.cpp
+++ b/Python/Stream/pyRAMStream.cpp
@@ -42,10 +42,9 @@ static PyMethodDef pyRAMStream_Methods[] = {
 };
 
 PY_GETSET_GETTER_DECL(RAMStream, buffer) {
-    char* buf = new char[self->fThis->size()];
-    self->fThis->copyTo(buf, self->fThis->size());
-    PyObject* bufObj = PyBytes_FromStringAndSize(buf, self->fThis->size());
-    delete[] buf;
+    PyObject* bufObj = PyBytes_FromStringAndSize(NULL, self->fThis->size());
+    char* data = PyBytes_AS_STRING(bufObj);
+    self->fThis->copyTo(data, self->fThis->size());
     return bufObj;
 }
 

--- a/Python/Stream/pyStream.cpp
+++ b/Python/Stream/pyStream.cpp
@@ -94,14 +94,13 @@ PY_METHOD_VA(Stream, read,
         PyErr_SetString(PyExc_TypeError, "read expects an int");
         return NULL;
     }
-    char* buf = new char[size];
+    PyObject* bufObj = PyBytes_FromStringAndSize(NULL, size);
     try {
+        char* buf = PyBytes_AS_STRING(bufObj);
         self->fThis->read((size_t)size, buf);
-        PyObject* data = PyBytes_FromStringAndSize(buf, size);
-        delete[] buf;
-        return data;
+        return bufObj;
     } catch (...) {
-        delete[] buf;
+        Py_DECREF(bufObj);
         PyErr_SetString(PyExc_IOError, "Error reading from stream");
         return NULL;
     }


### PR DESCRIPTION
This removes a few more temporary heap-allocated buffers from PyHSPlasma's hsStream bindings. The buffers are replaced with using the final PyBytes objects' backing buffers.