### PR TITLE
Allow PRPs to be read/written from any stream

### DIFF
--- a/Python/ResManager/pyResManager.cpp
+++ b/Python/ResManager/pyResManager.cpp
@@ -185,22 +185,38 @@ PY_METHOD_VA(ResManager, WritePage,
     "Writes an entire page to a PRP file")
 {
     const char* filename;
+    pyStream* stream;
     pyPageInfo* page;
-    if (!PyArg_ParseTuple(args, "sO", &filename, &page)) {
-        PyErr_SetString(PyExc_TypeError, "WritePage expects string, plPageInfo");
+    if (PyArg_ParseTuple(args, "sO", &filename, &page)) {
+        if (!pyPageInfo_Check((PyObject*)page)) {
+            PyErr_SetString(PyExc_TypeError, "WritePage expects string or hsStream, plPageInfo");
+            return NULL;
+        }
+
+        try {
+            self->fThis->WritePage(filename, page->fThis);
+            Py_RETURN_NONE;
+        } catch (...) {
+            PyErr_SetString(PyExc_IOError, "Error writing page");
+            return NULL;
+        }
+    } else if (PyErr_Clear(), PyArg_ParseTuple(args, "OO", &stream, &page)) {
+        if (!pyPageInfo_Check((PyObject*)page) || !pyStream_Check((PyObject*)stream)) {
+            PyErr_SetString(PyExc_TypeError, "WritePage expects string or hsStream, plPageInfo");
+            return NULL;
+        }
+
+        try {
+            self->fThis->WritePage(stream->fThis, page->fThis);
+            Py_RETURN_NONE;
+        } catch (...) {
+            PyErr_SetString(PyExc_IOError, "Error writing page");
+            return NULL;
+        }
+    } else {
+        PyErr_SetString(PyExc_TypeError, "WritePage expects string or hsStream, plPageInfo");
         return NULL;
     }
-    if (!pyPageInfo_Check((PyObject*)page)) {
-        PyErr_SetString(PyExc_TypeError, "WritePage expects string, plPageInfo");
-        return NULL;
-    }
-    try {
-        self->fThis->WritePage(filename, page->fThis);
-    } catch (...) {
-        PyErr_SetString(PyExc_IOError, "Error writing page");
-        return NULL;
-    }
-    Py_RETURN_NONE;
 }
 
 PY_METHOD_VA(ResManager, FindPage,

--- a/core/ResManager/plResManager.cpp
+++ b/core/ResManager/plResManager.cpp
@@ -204,8 +204,13 @@ plPageInfo* plResManager::ReadPagePrc(const pfPrcTag* root) {
 }
 
 void plResManager::WritePage(const ST::string& filename, plPageInfo* page) {
-    hsFileStream* S = new hsFileStream();
-    S->open(filename, fmWrite);
+    hsFileStream S;
+    S.open(filename, fmWrite);
+    WritePage(&S, page);
+    S.close();
+}
+
+void plResManager::WritePage(hsStream* S, plPageInfo* page) {
     S->setVer(getVer());
     std::vector<short> types = keys.getTypes(page->getLocation());
     page->setClassList(types);
@@ -220,8 +225,6 @@ void plResManager::WritePage(const ST::string& filename, plPageInfo* page) {
     else
         page->setChecksum(S->pos() - page->getDataStart());
     page->writeSums(S);
-    S->close();
-    delete S;
 }
 
 void plResManager::WritePagePrc(pfPrcHelper* prc, plPageInfo* page) {

--- a/core/ResManager/plResManager.h
+++ b/core/ResManager/plResManager.h
@@ -180,6 +180,12 @@ public:
     void WritePage(const ST::string& filename, plPageInfo* page);
 
     /**
+     * Write the specified page to an arbitrary stream
+     * \sa WritePagePrc(), WriteAge(), WriteAgePrc()
+     */
+    void WritePage(hsStream* S, plPageInfo* page);
+
+    /**
      * Write the specified page to a PRC document
      * \sa WritePage(), WriteAge(), WriteAgePrc()
      */

--- a/core/ResManager/plResManager.h
+++ b/core/ResManager/plResManager.h
@@ -167,6 +167,15 @@ public:
     plPageInfo* ReadPage(const ST::string& filename, bool stub = false);
 
     /**
+     * Read a Page from an arbitrary stream and register it with the ResManager.
+     * \param prxS stream containing the page header and keyring.
+     * \param prmS stream containing the keyed object data.
+     * \return a pointer to the plPageInfo describing the page.
+     * \sa ReadPageRaw(), ReadPagePrc(), ReadAge(), ReadAgePrc()
+     */
+    plPageInfo* ReadPage(hsStream* prxS, hsStream* prmS = NULL, bool stub = false);
+
+    /**
      * Parse a page from a PRC data source, and register it with the ResManager.
      * \return a pointer to the plPageInfo describing the page.
      * \sa ReadPage(), ReadPageRaw(), ReadAge(), ReadAgePrc()


### PR DESCRIPTION
This enables PRPs to be read in from or written out to any arbitrary stream. The most readily apparent use case is writing a PRP to an `hsRAMStream` (or some custom derivative of `hsStream`, if you're feeling really fancy). As a bonus, some temporary heap allocations were removed.