### PR TITLE
Inline exception classes to silence "class derived from non-dllexport base" warnings in MSVC 2017

### DIFF
--- a/core/Debug/hsExceptions.hpp
+++ b/core/Debug/hsExceptions.hpp
@@ -20,72 +20,71 @@
 #include <string_theory/string>
 #include <exception>
 
-class PLASMA_DLL hsException : public std::exception {
+class hsException : public std::exception {
 protected:
     ST::string fWhat;
     const char* fFile;
     unsigned long fLine;
 
 public:
-    hsException(const char* file, unsigned long line) HS_NOEXCEPT
+    inline hsException(const char* file, unsigned long line) HS_NOEXCEPT
         : fWhat("Undefined Plasma Exception"), fFile(file), fLine(line) { }
-    virtual ~hsException() HS_NOEXCEPT { }
+    inline virtual ~hsException() HS_NOEXCEPT { }
 
-    hsException& operator=(const hsException& other) HS_NOEXCEPT {
+    inline hsException& operator=(const hsException& other) HS_NOEXCEPT {
         fWhat = other.fWhat;
         return *this;
     }
 
-    const char* what() const HS_NOEXCEPT HS_OVERRIDE { return fWhat.c_str(); }
-    const char* File() const HS_NOEXCEPT { return fFile; }
-    unsigned long Line() const HS_NOEXCEPT { return fLine; }
+    inline const char* what() const HS_NOEXCEPT HS_OVERRIDE { return fWhat.c_str(); }
+    inline const char* File() const HS_NOEXCEPT { return fFile; }
+    inline unsigned long Line() const HS_NOEXCEPT { return fLine; }
 
 protected:
-    hsException(const ST::string& w, const char* file, unsigned long line) HS_NOEXCEPT
+    inline hsException(const ST::string& w, const char* file, unsigned long line) HS_NOEXCEPT
         : fWhat(w), fFile(file), fLine(line) { }
 };
 
-class PLASMA_DLL hsNotImplementedException : public hsException {
+class hsNotImplementedException : public hsException {
 public:
-    hsNotImplementedException(const char* file, unsigned long line,
-                              const ST::string& feature = ST::null) HS_NOEXCEPT
+    inline hsNotImplementedException(const char* file, unsigned long line,
+                                     const ST::string& feature = ST::null) HS_NOEXCEPT
         : hsException(file, line)
     {
         if (feature.is_empty())
-            fWhat = "Not implemented";
+            fWhat = ST_LITERAL("Not implemented");
         else
-            fWhat = ST::string("`") + feature + "' not implemented";
+            fWhat = ST_LITERAL("`") + feature + ST_LITERAL("' not implemented");
     }
 };
 
-class PLASMA_DLL hsBadParamException : public hsException {
+class hsBadParamException : public hsException {
 public:
-    hsBadParamException(const char* file, unsigned long line,
-                        const ST::string& details = ST::null) HS_NOEXCEPT
-        : hsException(file, line)
+    inline hsBadParamException(const char* file, unsigned long line,
+                               const ST::string& details = ST::null) HS_NOEXCEPT
+        : hsException(ST_LITERAL("Bad parameter"), file, line)
     {
-        fWhat = "Bad parameter";
         if (!details.is_empty())
-            fWhat += ST::string(": ") + details;
+            fWhat += ST_LITERAL(": ") + details;
     }
 };
 
-class PLASMA_DLL hsOutOfBoundsException : public hsException {
+class hsOutOfBoundsException : public hsException {
 public:
-    hsOutOfBoundsException(const char* file, unsigned long line) HS_NOEXCEPT
-        : hsException(file, line) { fWhat = "Out of bounds"; }
+    inline hsOutOfBoundsException(const char* file, unsigned long line) HS_NOEXCEPT
+        : hsException(ST_LITERAL("Out of bounds"), file, line) { }
 };
 
-class PLASMA_DLL hsBadVersionException : public hsException {
+class hsBadVersionException : public hsException {
 public:
-    hsBadVersionException(const char* file, unsigned long line) HS_NOEXCEPT
-        : hsException(file, line) { fWhat = "Unknown Plasma version"; }
+    inline hsBadVersionException(const char* file, unsigned long line) HS_NOEXCEPT
+        : hsException(ST_LITERAL("Unknown Plasma version"), file, line) { }
 };
 
-class PLASMA_DLL hsVersionMismatchException : public hsException {
+class hsVersionMismatchException : public hsException {
 public:
-    hsVersionMismatchException(const char* file, unsigned long line) HS_NOEXCEPT
-        : hsException(file, line) { fWhat = "Plasma Versions don't match"; }
+    inline hsVersionMismatchException(const char* file, unsigned long line) HS_NOEXCEPT
+        : hsException(ST_LITERAL("Plasma Versions don't match"), file, line) { }
 };
 
 #endif

--- a/core/SDL/plSDLMgr.cpp
+++ b/core/SDL/plSDLMgr.cpp
@@ -311,14 +311,3 @@ void plSDLMgr::write(hsStream* S) {
     for (size_t i=0; i<fDescriptors.size(); i++)
         fDescriptors[i]->write(S);
 }
-
-
-/* plSDLParseException */
-plSDLParseException::plSDLParseException(const char* file, unsigned long line,
-                                         const char* msg) HS_NOEXCEPT
-                   : hsException(file, line) {
-    if (msg == NULL)
-        fWhat = "Unknown SDL Parse Error";
-    else
-        fWhat = ST::string("SDL Error: ") + msg;
-}

--- a/core/SDL/plSDLMgr.h
+++ b/core/SDL/plSDLMgr.h
@@ -43,10 +43,17 @@ public:
     void write(hsStream* S);
 };
 
-class PLASMA_DLL plSDLParseException : public hsException {
+class plSDLParseException : public hsException {
 public:
-    plSDLParseException(const char* file, unsigned long line,
-                        const char* msg) HS_NOEXCEPT;
+    inline plSDLParseException(const char* file, unsigned long line,
+                               const char* msg) HS_NOEXCEPT
+        : hsException(file, line)
+    {
+        if (msg == nullptr)
+            fWhat = ST_LITERAL("Unknown SDL Parse Error");
+        else
+            fWhat = ST_LITERAL("SDL Error: ") + msg;
+    }
 };
 
 #endif

--- a/core/Stream/hsStream.cpp
+++ b/core/Stream/hsStream.cpp
@@ -441,23 +441,3 @@ time_t hsFileStream::getModTime() const {
     fstat(fileno(F), &stbuf);
     return stbuf.st_mtime;
 }
-
-
-/* hsFileReadException */
-hsFileReadException::hsFileReadException(const char* file,
-                     unsigned long line, const char* filename) HS_NOEXCEPT
-                   : hsException(file, line) {
-    fWhat = "Error reading file";
-    if (filename != NULL)
-        fWhat += ST::string(": ") + filename;
-}
-
-
-/* hsFileWriteException */
-hsFileWriteException::hsFileWriteException(const char* file,
-                      unsigned long line, const char* filename) HS_NOEXCEPT
-                    : hsException(file, line) {
-    fWhat = "Error writing to file";
-    if (filename != NULL)
-        fWhat += ST::string(": ") + filename;
-}

--- a/core/Stream/hsStream.h
+++ b/core/Stream/hsStream.h
@@ -114,16 +114,26 @@ public:
     time_t getModTime() const;
 };
 
-class PLASMA_DLL hsFileReadException : public hsException {
+class hsFileReadException : public hsException {
 public:
-    hsFileReadException(const char* file, unsigned long line,
-                        const char* filename = NULL) HS_NOEXCEPT;
+    inline hsFileReadException(const char* file, unsigned long line,
+                               const char* filename = nullptr) HS_NOEXCEPT
+        : hsException(ST_LITERAL("Error reading file"), file, line)
+    {
+        if (filename != nullptr)
+            fWhat += ST_LITERAL(": ") + filename;
+    }
 };
 
-class PLASMA_DLL hsFileWriteException : public hsException {
+class hsFileWriteException : public hsException {
 public:
-    hsFileWriteException(const char* file, unsigned long line,
-                         const char* filename = NULL) HS_NOEXCEPT;
+    inline hsFileWriteException(const char* file, unsigned long line,
+                                const char* filename = nullptr) HS_NOEXCEPT
+        : hsException(ST_LITERAL("Error writing to file"), file, line)
+    {
+        if (filename != nullptr)
+            fWhat += ST_LITERAL(": ") + filename;
+    }
 };
 
 #endif

--- a/core/Stream/pfPrcParser.cpp
+++ b/core/Stream/pfPrcParser.cpp
@@ -171,24 +171,3 @@ pfPrcTag* pfPrcParser::readTag(hsTokenStream* tok) {
     delete childPtr;
     return tag;
 }
-
-
-/* pfPrcParseException */
-pfPrcParseException::pfPrcParseException(const char* file, unsigned long line,
-                                         const char* msg) HS_NOEXCEPT
-                   : hsException(file, line) {
-    if (msg == NULL) {
-        fWhat = "Unknown Parse Error";
-    } else {
-        fWhat = ST::string("Parse Error: ") + msg;
-    }
-}
-
-/* pfPrcTagException */
-pfPrcTagException::pfPrcTagException(const char* file, unsigned long line,
-                                     const ST::string& tag) HS_NOEXCEPT
-                 : pfPrcParseException(file, line, NULL) {
-    fWhat = "Unexpected tag";
-    if (!tag.is_empty())
-        fWhat += ": " + tag;
-}

--- a/core/Stream/pfPrcParser.h
+++ b/core/Stream/pfPrcParser.h
@@ -70,17 +70,30 @@ private:
 };
 
 
-class PLASMA_DLL pfPrcParseException : public hsException {
+class pfPrcParseException : public hsException {
 public:
-    pfPrcParseException(const char* file, unsigned long line,
-                        const char* msg) HS_NOEXCEPT;
+    inline pfPrcParseException(const char* file, unsigned long line,
+                               const char* msg) HS_NOEXCEPT
+        : hsException(file, line)
+    {
+        if (msg == nullptr)
+            fWhat = ST_LITERAL("Unknown Parse Error");
+        else
+            fWhat = ST_LITERAL("Parse Error: ") + msg;
+    }
 };
 
 
-class PLASMA_DLL pfPrcTagException : public pfPrcParseException {
+class pfPrcTagException : public pfPrcParseException {
 public:
-    pfPrcTagException(const char* file, unsigned long line,
-                      const ST::string& tag) HS_NOEXCEPT;
+    inline pfPrcTagException(const char* file, unsigned long line,
+                             const ST::string& tag) HS_NOEXCEPT
+        : pfPrcParseException(file, line, nullptr)
+    {
+        fWhat = ST_LITERAL("Unexpected tag");
+        if (!tag.is_empty())
+            fWhat += ST_LITERAL(": ") + tag;
+    }
 };
 
 #endif

--- a/core/Util/plJPEG.cpp
+++ b/core/Util/plJPEG.cpp
@@ -22,16 +22,6 @@ extern "C" {
 #include <jerror.h>
 }
 
-/* hsJPEGException */
-hsJPEGException::hsJPEGException(const char* file, unsigned long line,
-                                 const char* message) HS_NOEXCEPT
-               : hsException(file, line) {
-    fWhat = "libJPEG error";
-    if (message != NULL)
-        fWhat += ST::string(": ") + message;
-}
-
-
 #define INPUT_BUF_SIZE  4096
 
 /* hsStream JPEG source -- modelled after IJG's stdio src */

--- a/core/Util/plJPEG.h
+++ b/core/Util/plJPEG.h
@@ -23,10 +23,15 @@ extern "C" {
 #include <jpeglib.h>
 }
 
-class PLASMA_DLL hsJPEGException : public hsException {
+class hsJPEGException : public hsException {
 public:
-    hsJPEGException(const char* file, unsigned long line,
-                    const char* message = NULL) HS_NOEXCEPT;
+    inline hsJPEGException(const char* file, unsigned long line,
+                           const char* message = nullptr) HS_NOEXCEPT
+        : hsException(ST_LITERAL("libJPEG error"), file, line)
+    {
+        if (message != nullptr)
+            fWhat += ST_LITERAL(": ") + message;
+    }
 };
 
 

--- a/core/Util/plPNG.cpp
+++ b/core/Util/plPNG.cpp
@@ -22,16 +22,6 @@
 /* Don't know why this isn't provided by libpng itself... */
 #define PNG_SIG_LENGTH (8)
 
-/* hsPNGException */
-hsPNGException::hsPNGException(const char* file, unsigned long line,
-                               const char* message) throw()
-              : hsException(file, line) {
-    fWhat = ST_LITERAL("libPNG error");
-    if (message != NULL)
-        fWhat += ST_LITERAL(": ") + message;
-}
-
-
 /* libpng helpers */
 static void pl_png_read(png_structp png, png_bytep data, png_size_t size) {
     hsStream* S = reinterpret_cast<hsStream*>(png_get_io_ptr(png));

--- a/core/Util/plPNG.h
+++ b/core/Util/plPNG.h
@@ -21,10 +21,15 @@
 
 #include <png.h>
 
-class PLASMA_DLL hsPNGException : public hsException {
+class hsPNGException : public hsException {
 public:
-    hsPNGException(const char* file, unsigned long line,
-                   const char* message = NULL) throw();
+    inline hsPNGException(const char* file, unsigned long line,
+                          const char* message = nullptr) HS_NOEXCEPT
+        : hsException(ST_LITERAL("libPNG error"), file, line)
+    {
+        if (message != nullptr)
+            fWhat += ST_LITERAL(": ") + message;
+    }
 };
 
 


### PR DESCRIPTION
Also makes better use of ST literals in exception messages.