### PR TITLE
Read and write the DisplayToWorld transform rotation quat symmetrically.

### DIFF
--- a/core/PRP/Physics/plGenericPhysical.cpp
+++ b/core/PRP/Physics/plGenericPhysical.cpp
@@ -408,10 +408,10 @@ void plGenericPhysical::IPrcParse(const pfPrcTag* tag, plResManager* mgr) {
 
 void plGenericPhysical::IReadHKPhysical(hsStream* S, plResManager* mgr) {
     fPos.read(S);
-    float rad = S->readFloat();
-    hsVector3 axis;
-    axis.read(S);
-    fRot = hsQuat(rad, axis);
+    fRot.W = S->readFloat();
+    fRot.X = S->readFloat();
+    fRot.Y = S->readFloat();
+    fRot.Z = S->readFloat();
 
     unsigned int hMemberGroup, hReportGroup, hCollideGroup;
     fMass = S->readFloat();


### PR DESCRIPTION
plClient writes a computed DisplayToWorld transform, but does some additional computation during the read in preparation for setting up the Havok physical.  We may want this computed transform at some point, but for now it's easier (and better for preserving PRP identity) to just read and write the same bits avoiding all additional computation.