### PR TITLE
Use newer CMake with built-in compiler flag settings for C++ standard,

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: cpp
 matrix:
   include:
     - os: linux
-      dist: trusty
+      dist: xenial
       compiler: gcc
       env: PYTHON_VER=2.7
       addons:
@@ -15,9 +15,9 @@ matrix:
             - libjpeg-turbo8-dev
             - python2.7-dev
     - os: linux
-      dist: trusty
+      dist: xenial
       compiler: gcc
-      env: PYTHON_VER=3.4
+      env: PYTHON_VER=3.5
       addons:
         apt:
           packages:
@@ -25,7 +25,7 @@ matrix:
             - libpng12-dev
             - zlib1g-dev
             - libjpeg-turbo8-dev
-            - python3.4-dev
+            - python3.5-dev
     - os: osx
       osx_image: xcode8.3
       compiler: clang

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,10 @@
 project(libhsplasma)
-cmake_minimum_required(VERSION 2.8.9)   # For Python module features
+cmake_minimum_required(VERSION 3.1)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake")
 
 option(ENABLE_SSE2 "Build with SSE2 CPU instructions" ON)
@@ -9,7 +14,7 @@ set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG ${CMAKE_CXX_FLAGS_DEBUG}")
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR
         CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
     set(WARNING_FLAGS "-Wall -Wextra -Wno-unused-parameter")
-    set(CMAKE_CXX_FLAGS "-std=c++0x ${WARNING_FLAGS} ${CMAKE_CXX_FLAGS}")
+    set(CMAKE_CXX_FLAGS "${WARNING_FLAGS} ${CMAKE_CXX_FLAGS}")
     set(CMAKE_C_FLAGS "${WARNING_FLAGS} ${CMAKE_C_FLAGS}")
     if(ENABLE_SSE2)
         set(CMAKE_CXX_FLAGS "-msse2 ${CMAKE_CXX_FLAGS}")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,14 +5,14 @@ environment:
     PREFIX_VERSION: 20180708
 
   matrix:
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
-      VisualStudioVersion: 12.0
-      CMAKE_GENERATOR: Visual Studio 12 2013
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      VisualStudioVersion: 14.0
+      CMAKE_GENERATOR: Visual Studio 14 2015
       PYTHON_PREFIX: C:\Python27
       CMAKE_PARAMS: -DPYTHON_INCLUDE_DIR=C:/Python27/include
         -DPYTHON_LIBRARY=C:/Python27/libs/python27.lib
         -DPYTHON_EXECUTABLE=C:/Python27/python.exe
-      PREFIX_TARGET: vc2013-x86-static
+      PREFIX_TARGET: vc2015-x86-static
       DIST_SUFFIX: '%PREFIX_TARGET%-py27'
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015

--- a/core/PlasmaDefs.h
+++ b/core/PlasmaDefs.h
@@ -36,18 +36,7 @@
   #define PLASMANET_DLL
 #endif
 
-#ifdef _MSC_VER
-  typedef signed __int8     int8_t;
-  typedef unsigned __int8   uint8_t;
-  typedef signed __int16    int16_t;
-  typedef unsigned __int16  uint16_t;
-  typedef signed __int32    int32_t;
-  typedef unsigned __int32  uint32_t;
-  typedef signed __int64    int64_t;
-  typedef unsigned __int64  uint64_t;
-#else
-  #include <stdint.h>
-#endif
+#include <cstdint>
 
 #ifdef HAVE_OVERRIDE
   #define HS_OVERRIDE       override


### PR DESCRIPTION
and remove MSVC stdint.h hack that hasn't been needed since VS2010.