### PR TITLE
Add a safe variant of plResManager::ReadCreatable and prcParseCreatable

### DIFF
--- a/core/PRP/Animation/plAnimPath.cpp
+++ b/core/PRP/Animation/plAnimPath.cpp
@@ -39,7 +39,7 @@ void plAnimPath::read(hsStream* S, plResManager* mgr)
         fTMController->read(S, mgr);
         fController = nullptr;
     } else {
-        fController = plCompoundController::Convert(mgr->ReadCreatable(S));
+        fController = mgr->ReadCreatableC<plCompoundController>(S);
         fTMController = nullptr;
     }
 
@@ -124,7 +124,7 @@ void plAnimPath::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
                 fTMController->prcParse(tag->getFirstChild(), mgr);
                 fController = nullptr;
             } else {
-                fController = plCompoundController::Convert(mgr->prcParseCreatable(tag->getFirstChild()));
+                fController = mgr->prcParseCreatableC<plCompoundController>(tag->getFirstChild());
                 fTMController = nullptr;
             }
         }

--- a/core/PRP/Animation/plAnimTimeConvert.cpp
+++ b/core/PRP/Animation/plAnimTimeConvert.cpp
@@ -36,9 +36,9 @@ void plAnimTimeConvert::read(hsStream* S, plResManager* mgr)
     fLoopBegin = S->readFloat();
     fSpeed = S->readFloat();
 
-    setEaseInCurve(plATCEaseCurve::Convert(mgr->ReadCreatable(S)));
-    setEaseOutCurve(plATCEaseCurve::Convert(mgr->ReadCreatable(S)));
-    setSpeedEaseCurve(plATCEaseCurve::Convert(mgr->ReadCreatable(S)));
+    setEaseInCurve(mgr->ReadCreatableC<plATCEaseCurve>(S));
+    setEaseOutCurve(mgr->ReadCreatableC<plATCEaseCurve>(S));
+    setSpeedEaseCurve(mgr->ReadCreatableC<plATCEaseCurve>(S));
     fCurrentAnimTime = S->readFloat();
     fLastEvalWorldTime = S->readDouble();
 
@@ -46,7 +46,7 @@ void plAnimTimeConvert::read(hsStream* S, plResManager* mgr)
         delete *msg;
     fCallbackMsgs.resize(S->readInt());
     for (size_t i=0; i<fCallbackMsgs.size(); i++)
-        fCallbackMsgs[i] = plEventCallbackMsg::Convert(mgr->ReadCreatable(S));
+        fCallbackMsgs[i] = mgr->ReadCreatableC<plEventCallbackMsg>(S);
 
     fStopPoints.resize(S->readInt());
     for (size_t i=0; i<fStopPoints.size(); i++)
@@ -146,13 +146,13 @@ void plAnimTimeConvert::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
         fSpeed = tag->getParam("Speed", "0").to_float();
     } else if (tag->getName() == "EaseInCurve") {
         if (!tag->getParam("NULL", "false").to_bool() && tag->hasChildren())
-            setSpeedEaseCurve(plATCEaseCurve::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setSpeedEaseCurve(mgr->prcParseCreatableC<plATCEaseCurve>(tag->getFirstChild()));
     } else if (tag->getName() == "EaseOutCurve") {
         if (!tag->getParam("NULL", "false").to_bool() && tag->hasChildren())
-            setSpeedEaseCurve(plATCEaseCurve::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setSpeedEaseCurve(mgr->prcParseCreatableC<plATCEaseCurve>(tag->getFirstChild()));
     } else if (tag->getName() == "SpeedEaseCurve") {
         if (!tag->getParam("NULL", "false").to_bool() && tag->hasChildren())
-            setSpeedEaseCurve(plATCEaseCurve::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setSpeedEaseCurve(mgr->prcParseCreatableC<plATCEaseCurve>(tag->getFirstChild()));
     } else if (tag->getName() == "Times") {
         fCurrentAnimTime = tag->getParam("CurrentAnimTime", "0").to_float();
         fLastEvalWorldTime = tag->getParam("LastEvalWorldTime", "0").to_float();
@@ -162,7 +162,7 @@ void plAnimTimeConvert::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
         fCallbackMsgs.resize(tag->countChildren());
         const pfPrcTag* child = tag->getFirstChild();
         for (size_t i=0; i<fCallbackMsgs.size(); i++) {
-            fCallbackMsgs[i] = plEventCallbackMsg::Convert(mgr->prcParseCreatable(child));
+            fCallbackMsgs[i] = mgr->prcParseCreatableC<plEventCallbackMsg>(child);
             child = child->getNextSibling();
         }
     } else if (tag->getName() == "StopPoints") {

--- a/core/PRP/Animation/plAnimTimeConvert.h
+++ b/core/PRP/Animation/plAnimTimeConvert.h
@@ -17,7 +17,6 @@
 #ifndef _PLANIMTIMECONVERT_H
 #define _PLANIMTIMECONVERT_H
 
-#include "PRP/plCreatable.h"
 #include "PRP/Message/plEventCallbackMsg.h"
 #include "plATCEaseCurves.h"
 

--- a/core/PRP/Animation/plController.cpp
+++ b/core/PRP/Animation/plController.cpp
@@ -84,9 +84,9 @@ plCompoundController::~plCompoundController()
 
 void plCompoundController::read(hsStream* S, plResManager* mgr)
 {
-    setXController(plController::Convert(mgr->ReadCreatable(S)));
-    setYController(plController::Convert(mgr->ReadCreatable(S)));
-    setZController(plController::Convert(mgr->ReadCreatable(S)));
+    setXController(mgr->ReadCreatableC<plController>(S));
+    setYController(mgr->ReadCreatableC<plController>(S));
+    setZController(mgr->ReadCreatableC<plController>(S));
 }
 
 void plCompoundController::write(hsStream* S, plResManager* mgr)
@@ -131,13 +131,13 @@ void plCompoundController::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
 {
     if (tag->getName() == "X") {
         if (tag->hasChildren() && !tag->getFirstChild()->getParam("NULL", "false").to_bool())
-            setXController(plController::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setXController(mgr->prcParseCreatableC<plController>(tag->getFirstChild()));
     } else if (tag->getName() == "Y") {
         if (tag->hasChildren() && !tag->getFirstChild()->getParam("NULL", "false").to_bool())
-            setYController(plController::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setYController(mgr->prcParseCreatableC<plController>(tag->getFirstChild()));
     } else if (tag->getName() == "Z") {
         if (tag->hasChildren() && !tag->getFirstChild()->getParam("NULL", "false").to_bool())
-            setZController(plController::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setZController(mgr->prcParseCreatableC<plController>(tag->getFirstChild()));
     } else {
         plCreatable::IPrcParse(tag, mgr);
     }

--- a/core/PRP/Animation/plController.h
+++ b/core/PRP/Animation/plController.h
@@ -18,6 +18,7 @@
 #define _PLCONTROLLER_H
 
 #include "PRP/plCreatable.h"
+#include "ResManager/plResManager.h"
 #include "hsKeys.h"
 
 class PLASMA_DLL plController : public plCreatable

--- a/core/PRP/Animation/plLineFollowMod.cpp
+++ b/core/PRP/Animation/plLineFollowMod.cpp
@@ -26,7 +26,7 @@ void plLineFollowMod::read(hsStream* S, plResManager* mgr)
 {
     plMultiModifier::read(S, mgr);
 
-    setPath(plAnimPath::Convert(mgr->ReadCreatable(S)));
+    setPath(mgr->ReadCreatableC<plAnimPath>(S));
     fPathParent = mgr->readKey(S);
     fRefObj = mgr->readKey(S);
 
@@ -101,7 +101,7 @@ void plLineFollowMod::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
 {
     if (tag->getName() == "Path") {
         if (tag->hasChildren())
-            setPath(plAnimPath::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setPath(mgr->prcParseCreatableC<plAnimPath>(tag->getFirstChild()));
     } else if (tag->getName() == "Parent") {
         if (tag->hasChildren())
             fPathParent = mgr->prcParseKey(tag->getFirstChild());

--- a/core/PRP/Avatar/plAGAnim.cpp
+++ b/core/PRP/Avatar/plAGAnim.cpp
@@ -34,8 +34,8 @@ void plAGAnim::read(hsStream* S, plResManager* mgr)
     clearApplicators();
     fApps.resize(S->readInt());
     for (size_t i=0; i<fApps.size(); i++) {
-        plAGApplicator* agApp = plAGApplicator::Convert(mgr->ReadCreatable(S));
-        plAGChannel* agChan = plAGChannel::Convert(mgr->ReadCreatable(S));
+        auto agApp = mgr->ReadCreatableC<plAGApplicator>(S);
+        auto agChan = mgr->ReadCreatableC<plAGChannel>(S);
         agApp->setChannel(agChan);
         fApps[i] = agApp;
     }
@@ -108,10 +108,10 @@ void plAGAnim::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
             while (subChild) {
                 if (subChild->getName() == "Applicator") {
                     if (subChild->hasChildren())
-                        agApp = plAGApplicator::Convert(mgr->prcParseCreatable(subChild->getFirstChild()));
+                        agApp = mgr->prcParseCreatableC<plAGApplicator>(subChild->getFirstChild());
                 } else if (subChild->getName() == "Channel") {
                     if (subChild->hasChildren())
-                        agChan = plAGChannel::Convert(mgr->prcParseCreatable(subChild->getFirstChild()));
+                        agChan = mgr->prcParseCreatableC<plAGChannel>(subChild->getFirstChild());
                 } else {
                     throw pfPrcTagException(__FILE__, __LINE__, subChild->getName());
                 }

--- a/core/PRP/Avatar/plArmatureMod.cpp
+++ b/core/PRP/Avatar/plArmatureMod.cpp
@@ -39,7 +39,7 @@ void plArmatureModBase::read(hsStream* S, plResManager* mgr)
     clearBrains();
     fBrains.resize(S->readInt());
     for (size_t i=0; i<fBrains.size(); i++)
-        fBrains[i] = plArmatureBrain::Convert(mgr->ReadCreatable(S));
+        fBrains[i] = mgr->ReadCreatableC<plArmatureBrain>(S);
 
     fDetector = mgr->readKey(S);
 }
@@ -122,7 +122,7 @@ void plArmatureModBase::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
         fBrains.resize(tag->countChildren());
         const pfPrcTag* child = tag->getFirstChild();
         for (size_t i=0; i<fBrains.size(); i++) {
-            fBrains[i] = plArmatureBrain::Convert(mgr->prcParseCreatable(child));
+            fBrains[i] = mgr->prcParseCreatableC<plArmatureBrain>(child);
             child = child->getNextSibling();
         }
     } else if (tag->getName() == "Detector") {
@@ -156,7 +156,7 @@ void plArmatureMod::read(hsStream* S, plResManager* mgr)
         clearBrains();
         fBrains.resize(S->readInt());
         for (size_t i=0; i<fBrains.size(); i++)
-            fBrains[i] = plArmatureBrain::Convert(mgr->ReadCreatable(S));
+            fBrains[i] = mgr->ReadCreatableC<plArmatureBrain>(S);
 
         if (S->readBool())
             fClothingOutfit = mgr->readKey(S);
@@ -308,7 +308,7 @@ void plArmatureMod::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
         fBrains.resize(tag->countChildren());
         const pfPrcTag* child = tag->getFirstChild();
         for (size_t i=0; i<fBrains.size(); i++) {
-            fBrains[i] = plArmatureBrain::Convert(mgr->prcParseCreatable(child));
+            fBrains[i] = mgr->prcParseCreatableC<plArmatureBrain>(child);
             child = child->getNextSibling();
         }
     } else if (tag->getName() == "ClothingOutfit") {

--- a/core/PRP/Avatar/plAvBrainGeneric.cpp
+++ b/core/PRP/Avatar/plAvBrainGeneric.cpp
@@ -31,7 +31,7 @@ void plAvBrainGeneric::read(hsStream* S, plResManager* mgr)
     clearStages();
     fStages.resize(S->readInt());
     for (size_t i=0; i<fStages.size(); i++) {
-        fStages[i] = plAnimStage::Convert(mgr->ReadCreatable(S));
+        fStages[i] = mgr->ReadCreatableC<plAnimStage>(S);
         fStages[i]->readAux(S);
     }
 
@@ -42,12 +42,12 @@ void plAvBrainGeneric::read(hsStream* S, plResManager* mgr)
     fForward = S->readBool();
 
     if (S->readBool())
-        setStartMessage(plMessage::Convert(mgr->ReadCreatable(S)));
+        setStartMessage(mgr->ReadCreatableC<plMessage>(S));
     else
         setStartMessage(nullptr);
 
     if (S->readBool())
-        setEndMessage(plMessage::Convert(mgr->ReadCreatable(S)));
+        setEndMessage(mgr->ReadCreatableC<plMessage>(S));
     else
         setEndMessage(nullptr);
 
@@ -177,13 +177,13 @@ void plAvBrainGeneric::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
         if (tag->getParam("NULL", "False").to_bool()) {
             setStartMessage(nullptr);
         } else if (tag->hasChildren()) {
-            setStartMessage(plMessage::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setStartMessage(mgr->prcParseCreatableC<plMessage>(tag->getFirstChild()));
         }
     } else if (tag->getName() == "EndMessage") {
         if (tag->getParam("NULL", "False").to_bool()) {
             setEndMessage(nullptr);
         } else if (tag->hasChildren()) {
-            setEndMessage(plMessage::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setEndMessage(mgr->prcParseCreatableC<plMessage>(tag->getFirstChild()));
         }
     } else if (tag->getName() == "Recipient") {
         if (tag->hasChildren())

--- a/core/PRP/Avatar/plAvTask.cpp
+++ b/core/PRP/Avatar/plAvTask.cpp
@@ -112,7 +112,7 @@ plAvTaskBrain::~plAvTaskBrain()
 
 void plAvTaskBrain::read(hsStream* S, plResManager* mgr)
 {
-    setBrain(plArmatureBrain::Convert(mgr->ReadCreatable(S)));
+    setBrain(mgr->ReadCreatableC<plArmatureBrain>(S));
 }
 
 void plAvTaskBrain::write(hsStream* S, plResManager* mgr)
@@ -139,7 +139,7 @@ void plAvTaskBrain::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
         if (tag->getParam("NULL", "false").to_bool())
             setBrain(nullptr);
         else if (tag->hasChildren())
-            setBrain(plArmatureBrain::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setBrain(mgr->prcParseCreatableC<plArmatureBrain>(tag->getFirstChild()));
     } else {
         plCreatable::IPrcParse(tag, mgr);
     }

--- a/core/PRP/Avatar/plAvTask.h
+++ b/core/PRP/Avatar/plAvTask.h
@@ -18,6 +18,7 @@
 #define _PLAVTASK_H
 
 #include "PRP/plCreatable.h"
+#include "ResManager/plResManager.h"
 #include "plArmatureBrain.h"
 
 class PLASMA_DLL plAvTask : public plCreatable

--- a/core/PRP/Avatar/plMatrixChannel.cpp
+++ b/core/PRP/Avatar/plMatrixChannel.cpp
@@ -64,7 +64,7 @@ plMatrixControllerChannel::~plMatrixControllerChannel()
 void plMatrixControllerChannel::read(hsStream* S, plResManager* mgr)
 {
     plAGChannel::read(S, mgr);
-    fController = plController::Convert(mgr->ReadCreatable(S));
+    fController = mgr->ReadCreatableC<plController>(S);
     fAP.read(S);
 }
 
@@ -93,7 +93,7 @@ void plMatrixControllerChannel::IPrcParse(const pfPrcTag* tag, plResManager* mgr
 {
     if (tag->getName() == "Controller") {
         if (tag->hasChildren())
-            fController = plController::Convert(mgr->prcParseCreatable(tag->getFirstChild()));
+            fController = mgr->prcParseCreatableC<plController>(tag->getFirstChild());
     } else if (tag->getName() == "AffineParts") {
         if (tag->hasChildren())
             fAP.prcParse(tag->getFirstChild());

--- a/core/PRP/Avatar/plNPCSpawnMod.cpp
+++ b/core/PRP/Avatar/plNPCSpawnMod.cpp
@@ -30,7 +30,7 @@ void plNPCSpawnMod::read(hsStream* S, plResManager* mgr)
     fAutoSpawn = S->readBool();
 
     if (S->readBool())
-        setNotify(plNotifyMsg::Convert(mgr->ReadCreatable(S)));
+        setNotify(mgr->ReadCreatableC<plNotifyMsg>(S));
 }
 
 void plNPCSpawnMod::write(hsStream* S, plResManager* mgr)
@@ -77,7 +77,7 @@ void plNPCSpawnMod::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
         if (tag->getParam("NULL", "false").to_bool()) {
             setNotify(nullptr);
         } else if (tag->hasChildren()) {
-            setNotify(plNotifyMsg::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setNotify(mgr->prcParseCreatableC<plNotifyMsg>(tag->getFirstChild()));
         }
     } else {
         plSingleModifier::IPrcParse(tag, mgr);

--- a/core/PRP/Avatar/plPointChannel.cpp
+++ b/core/PRP/Avatar/plPointChannel.cpp
@@ -58,7 +58,7 @@ plPointControllerChannel::~plPointControllerChannel()
 void plPointControllerChannel::read(hsStream* S, plResManager* mgr)
 {
     plAGChannel::read(S, mgr);
-    setController(plController::Convert(mgr->ReadCreatable(S)));
+    setController(mgr->ReadCreatableC<plController>(S));
 }
 
 void plPointControllerChannel::write(hsStream* S, plResManager* mgr)
@@ -81,7 +81,7 @@ void plPointControllerChannel::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
 {
     if (tag->getName() == "Controller") {
         if (tag->hasChildren())
-            setController(plController::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setController(mgr->prcParseCreatableC<plController>(tag->getFirstChild()));
     } else {
         plAGChannel::IPrcParse(tag, mgr);
     }

--- a/core/PRP/Avatar/plScalarChannel.cpp
+++ b/core/PRP/Avatar/plScalarChannel.cpp
@@ -57,7 +57,7 @@ plScalarControllerChannel::~plScalarControllerChannel()
 void plScalarControllerChannel::read(hsStream* S, plResManager* mgr)
 {
     plAGChannel::read(S, mgr);
-    setController(plController::Convert(mgr->ReadCreatable(S)));
+    setController(mgr->ReadCreatableC<plController>(S));
 }
 
 void plScalarControllerChannel::write(hsStream* S, plResManager* mgr)
@@ -80,7 +80,7 @@ void plScalarControllerChannel::IPrcParse(const pfPrcTag* tag, plResManager* mgr
 {
     if (tag->getName() == "Controller") {
         if (tag->hasChildren())
-            setController(plController::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setController(mgr->prcParseCreatableC<plController>(tag->getFirstChild()));
     } else {
         plAGChannel::IPrcParse(tag, mgr);
     }

--- a/core/PRP/Camera/plCameraModifier.cpp
+++ b/core/PRP/Camera/plCameraModifier.cpp
@@ -120,14 +120,14 @@ void plCameraModifier::read(hsStream* S, plResManager* mgr)
     fMessageQueue.resize(S->readInt());
     fSenderQueue.resize(fMessageQueue.size());
     for (size_t i=0; i<fMessageQueue.size(); i++)
-        fMessageQueue[i] = plMessage::Convert(mgr->ReadCreatable(S));
+        fMessageQueue[i] = mgr->ReadCreatableC<plMessage>(S);
     for (size_t i=0; i<fSenderQueue.size(); i++)
         fSenderQueue[i] = mgr->readKey(S);
 
     clearFOVInstructions();
     fFOVInstructions.resize(S->readInt());
     for (size_t i=0; i<fFOVInstructions.size(); i++)
-        fFOVInstructions[i] = plCameraMsg::Convert(mgr->ReadCreatable(S));
+        fFOVInstructions[i] = mgr->ReadCreatableC<plCameraMsg>(S);
 
     fAnimated = S->readBool();
     fStartAnimOnPush = S->readBool();
@@ -240,7 +240,7 @@ void plCameraModifier::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
         for (size_t i=0; i<fMessageQueue.size(); i++) {
             if (child->getName() != "Message")
                 throw pfPrcTagException(__FILE__, __LINE__, child->getName());
-            fMessageQueue[i] = plMessage::Convert(mgr->prcParseCreatable(child->getFirstChild()));
+            fMessageQueue[i] = mgr->prcParseCreatableC<plMessage>(child->getFirstChild());
             child = child->getNextSibling();
             if (child->getName() != "Sender")
                 throw pfPrcTagException(__FILE__, __LINE__, child->getName());
@@ -252,7 +252,7 @@ void plCameraModifier::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
         fFOVInstructions.resize(tag->countChildren());
         const pfPrcTag* child = tag->getFirstChild();
         for (size_t i=0; i<fFOVInstructions.size(); i++) {
-            fFOVInstructions[i] = plCameraMsg::Convert(mgr->prcParseCreatable(child));
+            fFOVInstructions[i] = mgr->prcParseCreatableC<plCameraMsg>(child);
             child = child->getNextSibling();
         }
     } else {

--- a/core/PRP/Geometry/plDrawableSpans.cpp
+++ b/core/PRP/Geometry/plDrawableSpans.cpp
@@ -140,7 +140,7 @@ void plDrawableSpans::read(hsStream* S, plResManager* mgr)
         fGroups[i]->read(S);
     }
 
-    setSpaceTree(plSpaceTree::Convert(mgr->ReadCreatable(S)));
+    setSpaceTree(mgr->ReadCreatableC<plSpaceTree>(S));
     fSceneNode = mgr->readKey(S);
 }
 
@@ -511,7 +511,7 @@ void plDrawableSpans::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
         }
     } else if (tag->getName() == "SpaceTree") {
         if (tag->hasChildren())
-            setSpaceTree(plSpaceTree::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setSpaceTree(mgr->prcParseCreatableC<plSpaceTree>(tag->getFirstChild()));
     } else if (tag->getName() == "SceneNode") {
         if (tag->hasChildren())
             fSceneNode = mgr->prcParseKey(tag->getFirstChild());

--- a/core/PRP/KeyedObject/hsKeyedObject.h
+++ b/core/PRP/KeyedObject/hsKeyedObject.h
@@ -18,6 +18,7 @@
 #define _HSKEYEDOBJECT_H
 
 #include "PRP/plCreatable.h"
+#include "ResManager/plResManager.h"
 #include "plKey.h"
 
 /**

--- a/core/PRP/Message/plAvTaskMsg.cpp
+++ b/core/PRP/Message/plAvTaskMsg.cpp
@@ -27,7 +27,7 @@ void plAvTaskMsg::read(hsStream* S, plResManager* mgr)
     plAvatarMsg::read(S, mgr);
 
     if (S->readBool())
-        setTask(plAvTask::Convert(mgr->ReadCreatable(S)));
+        setTask(mgr->ReadCreatableC<plAvTask>(S));
     else
         setTask(nullptr);
 }
@@ -65,7 +65,7 @@ void plAvTaskMsg::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
         if (tag->getParam("NULL", "false").to_bool())
             setTask(nullptr);
         else if (tag->hasChildren())
-            setTask(plAvTask::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setTask(mgr->prcParseCreatableC<plAvTask>(tag->getFirstChild()));
     } else {
         plAvatarMsg::IPrcParse(tag, mgr);
     }
@@ -87,7 +87,7 @@ plAvPushBrainMsg::~plAvPushBrainMsg()
 void plAvPushBrainMsg::read(hsStream* S, plResManager* mgr)
 {
     plAvTaskMsg::read(S, mgr);
-    setBrain(plArmatureBrain::Convert(mgr->ReadCreatable(S)));
+    setBrain(mgr->ReadCreatableC<plArmatureBrain>(S));
 }
 
 void plAvPushBrainMsg::write(hsStream* S, plResManager* mgr)
@@ -117,7 +117,7 @@ void plAvPushBrainMsg::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
         if (tag->getParam("NULL", "false").to_bool())
             setBrain(nullptr);
         else if (tag->hasChildren())
-            setBrain(plArmatureBrain::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setBrain(mgr->prcParseCreatableC<plArmatureBrain>(tag->getFirstChild()));
     } else {
         plAvTaskMsg::IPrcParse(tag, mgr);
     }

--- a/core/PRP/Message/plLoadAvatarMsg.cpp
+++ b/core/PRP/Message/plLoadAvatarMsg.cpp
@@ -28,7 +28,7 @@ void plLoadAvatarMsg::read(hsStream* S, plResManager* mgr)
     fIsPlayer = S->readBool();
     fSpawnPoint = mgr->readKey(S);
     if (S->readBool()) {
-        setInitialTask(plAvTask::Convert(mgr->ReadCreatable(S)));
+        setInitialTask(mgr->ReadCreatableC<plAvTask>(S));
     } else {
         setInitialTask(nullptr);
     }
@@ -86,7 +86,7 @@ void plLoadAvatarMsg::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
         fUserStr = tag->getParam("UserStr", "");
     } else if (tag->getName() == "InitialTask") {
         if (tag->hasChildren())
-            setInitialTask(plAvTask::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setInitialTask(mgr->prcParseCreatableC<plAvTask>(tag->getFirstChild()));
         else
             setInitialTask(nullptr);
     } else if (tag->getName() == "SpawnPoint") {

--- a/core/PRP/Message/plLoadCloneMsg.cpp
+++ b/core/PRP/Message/plLoadCloneMsg.cpp
@@ -31,7 +31,7 @@ void plLoadCloneMsg::read(hsStream* S, plResManager* mgr)
     fUserData = S->readInt();
     fValidMsg = S->readByte();
     fIsLoading = S->readByte();
-    setTriggerMsg(plMessage::Convert(mgr->ReadCreatable(S)));
+    setTriggerMsg(mgr->ReadCreatableC<plMessage>(S));
 }
 
 void plLoadCloneMsg::write(hsStream* S, plResManager* mgr)
@@ -94,7 +94,7 @@ void plLoadCloneMsg::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
         if (tag->getParam("NULL", "false").to_bool())
             setTriggerMsg(nullptr);
         else if (tag->hasChildren())
-            setTriggerMsg(plMessage::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setTriggerMsg(mgr->prcParseCreatableC<plMessage>(tag->getFirstChild()));
     } else {
         plMessage::IPrcParse(tag, mgr);
     }

--- a/core/PRP/Message/plMessage.h
+++ b/core/PRP/Message/plMessage.h
@@ -19,6 +19,7 @@
 
 #include "PRP/plCreatable.h"
 #include "PRP/KeyedObject/plKey.h"
+#include "ResManager/plResManager.h"
 
 class PLASMA_DLL plMessage : public plCreatable
 {

--- a/core/PRP/Message/plMessageWithCallbacks.cpp
+++ b/core/PRP/Message/plMessageWithCallbacks.cpp
@@ -29,7 +29,7 @@ void plMessageWithCallbacks::read(hsStream* S, plResManager* mgr)
     clearCallbacks();
     fCallbacks.resize(S->readInt());
     for (size_t i=0; i<fCallbacks.size(); i++) {
-        fCallbacks[i] = plMessage::Convert(mgr->ReadCreatable(S));
+        fCallbacks[i] = mgr->ReadCreatableC<plMessage>(S);
         if (fCallbacks[i] == nullptr)
             throw hsNotImplementedException(__FILE__, __LINE__, "Callback Message");
     }
@@ -61,7 +61,7 @@ void plMessageWithCallbacks::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
         fCallbacks.resize(tag->countChildren());
         const pfPrcTag* child = tag->getFirstChild();
         for (size_t i=0; i<fCallbacks.size(); i++) {
-            fCallbacks[i] = plMessage::Convert(mgr->prcParseCreatable(child));
+            fCallbacks[i] = mgr->prcParseCreatableC<plMessage>(child);
             child = child->getNextSibling();
         }
     } else {

--- a/core/PRP/Modifier/plAnimEventModifier.cpp
+++ b/core/PRP/Modifier/plAnimEventModifier.cpp
@@ -28,7 +28,7 @@ void plAnimEventModifier::read(hsStream* S, plResManager* mgr)
     fReceivers.resize(S->readInt());
     for (size_t i=0; i<fReceivers.size(); i++)
         fReceivers[i] = mgr->readKey(S);
-    setCallback(plMessage::Convert(mgr->ReadCreatable(S)));
+    setCallback(mgr->ReadCreatableC<plMessage>(S));
 }
 
 void plAnimEventModifier::write(hsStream* S, plResManager* mgr)
@@ -66,7 +66,7 @@ void plAnimEventModifier::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
         }
     } else if (tag->getName() == "Callback") {
         if (tag->hasChildren())
-            setCallback(plMessage::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setCallback(mgr->prcParseCreatableC<plMessage>(tag->getFirstChild()));
     } else {
         plSingleModifier::IPrcParse(tag, mgr);
     }

--- a/core/PRP/Modifier/plAxisAnimModifier.cpp
+++ b/core/PRP/Modifier/plAxisAnimModifier.cpp
@@ -35,7 +35,7 @@ void plAxisAnimModifier::read(hsStream* S, plResManager* mgr)
     fNotificationKey = mgr->readKey(S);
     fAllOrNothing = S->readBool();
 
-    setNotify(plNotifyMsg::Convert(mgr->ReadCreatable(S)));
+    setNotify(mgr->ReadCreatableC<plNotifyMsg>(S));
     size_t len = S->readShort();
     fAnimLabel = S->readStr(len);
 
@@ -194,7 +194,7 @@ void plAxisAnimModifier::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
             fNotificationKey = mgr->prcParseKey(tag->getFirstChild());
     } else if (tag->getName() == "Notify") {
         if (tag->hasChildren())
-            setNotify(plNotifyMsg::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setNotify(mgr->prcParseCreatableC<plNotifyMsg>(tag->getFirstChild()));
     } else if (tag->getName() == "EoaUnknowns") {
         // Blah, skip for now
     } else {

--- a/core/PRP/Modifier/plLogicModBase.cpp
+++ b/core/PRP/Modifier/plLogicModBase.cpp
@@ -42,9 +42,9 @@ void plLogicModBase::read(hsStream* S, plResManager* mgr)
     clearCommands();
     fCommandList.resize(S->readInt());
     for (size_t i=0; i<fCommandList.size(); i++)
-        fCommandList[i] = plMessage::Convert(mgr->ReadCreatable(S));
+        fCommandList[i] = mgr->ReadCreatableC<plMessage>(S);
 
-    setNotify(plNotifyMsg::Convert(mgr->ReadCreatable(S)));
+    setNotify(mgr->ReadCreatableC<plNotifyMsg>(S));
     fLogicFlags.read(S);
     fDisabled = S->readBool();
 }
@@ -93,12 +93,12 @@ void plLogicModBase::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
         fCommandList.resize(tag->countChildren());
         const pfPrcTag* child = tag->getFirstChild();
         for (size_t i=0; i<fCommandList.size(); i++) {
-            fCommandList[i] = plMessage::Convert(mgr->prcParseCreatable(child));
+            fCommandList[i] = mgr->prcParseCreatableC<plMessage>(child);
             child = child->getNextSibling();
         }
     } else if (tag->getName() == "Notify") {
         if (tag->hasChildren())
-            setNotify(plNotifyMsg::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setNotify(mgr->prcParseCreatableC<plNotifyMsg>(tag->getFirstChild()));
     } else if (tag->getName() == "LogicFlags") {
         if (tag->hasChildren())
             fLogicFlags.prcParse(tag->getFirstChild());

--- a/core/PRP/Modifier/plResponderModifier.cpp
+++ b/core/PRP/Modifier/plResponderModifier.cpp
@@ -62,7 +62,7 @@ void plResponderModifier::read(hsStream* S, plResManager* mgr)
         fStates[i]->fSwitchToState = S->readByte();
         fStates[i]->fCmds.resize(S->readByte());
         for (size_t j=0; j<fStates[i]->fCmds.size(); j++) {
-            plMessage* msg = plMessage::Convert(mgr->ReadCreatable(S));
+            auto msg = mgr->ReadCreatableC<plMessage>(S);
             int8_t waitOn = S->readByte();
             fStates[i]->fCmds[j] = new plResponderCmd(msg, waitOn);
             if (msg == nullptr)
@@ -187,7 +187,7 @@ void plResponderModifier::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
                             if (subChild->getName() == "WaitOn") {
                                 waitOn = subChild->getParam("value", "-1").to_int();
                             } else {
-                                msg = plMessage::Convert(mgr->prcParseCreatable(subChild));
+                                msg = mgr->prcParseCreatableC<plMessage>(subChild);
                             }
                             subChild = subChild->getNextSibling();
                         }

--- a/core/PRP/NetMessage/plNetMsgGameMessage.cpp
+++ b/core/PRP/NetMessage/plNetMsgGameMessage.cpp
@@ -28,7 +28,7 @@ void plNetMsgGameMessage::read(hsStream* S, plResManager* mgr)
 
     delete fMessage;
     hsRAMStream* msgStream = getStream();
-    fMessage = plMessage::Convert(mgr->ReadCreatable(msgStream));
+    fMessage = mgr->ReadCreatableC<plMessage>(msgStream);
 
     if (S->readBool())
         fDeliveryTime.read(S);
@@ -78,7 +78,7 @@ void plNetMsgGameMessage::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
         if (tag->getParam("NULL", "false").to_bool())
             fMessage = nullptr;
         else
-            fMessage = plMessage::Convert(mgr->prcParseCreatable(tag));
+            fMessage = mgr->prcParseCreatableC<plMessage>(tag);
     } else if (tag->getName() == "DeliveryTime") {
         if (tag->hasChildren())
             fDeliveryTime.prcParse(tag->getFirstChild());

--- a/core/PRP/NetMessage/plNetMsgRoomsList.h
+++ b/core/PRP/NetMessage/plNetMsgRoomsList.h
@@ -18,6 +18,7 @@
 #define _PLNETMSGROOMSLIST_H
 
 #include "plNetMessage.h"
+#include "PRP/KeyedObject/plLocation.h"
 
 class PLASMA_DLL plNetMsgRoomsList : public plNetMessage
 {

--- a/core/PRP/Particle/plBoundInterface.cpp
+++ b/core/PRP/Particle/plBoundInterface.cpp
@@ -24,7 +24,7 @@ plBoundInterface::~plBoundInterface()
 void plBoundInterface::read(hsStream* S, plResManager* mgr)
 {
     plObjInterface::read(S, mgr);
-    setBounds(plConvexVolume::Convert(mgr->ReadCreatable(S)));
+    setBounds(mgr->ReadCreatableC<plConvexVolume>(S));
 }
 
 void plBoundInterface::write(hsStream* S, plResManager* mgr)
@@ -46,7 +46,7 @@ void plBoundInterface::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
 {
     if (tag->getName() == "Bounds") {
         if (tag->hasChildren())
-            setBounds(plConvexVolume::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setBounds(mgr->prcParseCreatableC<plConvexVolume>(tag->getFirstChild()));
     } else {
         plObjInterface::IPrcParse(tag, mgr);
     }

--- a/core/PRP/Particle/plParticleEmitter.cpp
+++ b/core/PRP/Particle/plParticleEmitter.cpp
@@ -23,7 +23,7 @@ plParticleEmitter::~plParticleEmitter()
 
 void plParticleEmitter::read(hsStream* S, plResManager* mgr)
 {
-    setGenerator(plParticleGenerator::Convert(mgr->ReadCreatable(S)));
+    setGenerator(mgr->ReadCreatableC<plParticleGenerator>(S));
 
     fSpanIndex = S->readInt();
     fMaxParticles = S->readInt();
@@ -62,7 +62,7 @@ void plParticleEmitter::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
 {
     if (tag->getName() == "Generator") {
         if (tag->hasChildren())
-            setGenerator(plParticleGenerator::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setGenerator(mgr->prcParseCreatableC<plParticleGenerator>(tag->getFirstChild()));
     } else if (tag->getName() == "EmitterParams") {
         fSpanIndex = tag->getParam("SpanIndex", "0").to_uint();
         fMaxParticles = tag->getParam("MaxParticles", "0").to_uint();

--- a/core/PRP/Particle/plParticleEmitter.h
+++ b/core/PRP/Particle/plParticleEmitter.h
@@ -19,6 +19,7 @@
 
 #include "PRP/plCreatable.h"
 #include "PRP/Region/hsBounds.h"
+#include "ResManager/plResManager.h"
 #include "Sys/hsColor.h"
 #include "Math/hsMatrix44.h"
 #include "plParticleGenerator.h"

--- a/core/PRP/Particle/plParticleSystem.cpp
+++ b/core/PRP/Particle/plParticleSystem.cpp
@@ -32,11 +32,11 @@ void plParticleSystem::read(hsStream* S, plResManager* mgr)
     plModifier::read(S, mgr);
 
     fMaterial = mgr->readKey(S);
-    setAmbientCtl(plController::Convert(mgr->ReadCreatable(S)));
-    setDiffuseCtl(plController::Convert(mgr->ReadCreatable(S)));
-    setOpacityCtl(plController::Convert(mgr->ReadCreatable(S)));
-    setWidthCtl(plController::Convert(mgr->ReadCreatable(S)));
-    setHeightCtl(plController::Convert(mgr->ReadCreatable(S)));
+    setAmbientCtl(mgr->ReadCreatableC<plController>(S));
+    setDiffuseCtl(mgr->ReadCreatableC<plController>(S));
+    setOpacityCtl(mgr->ReadCreatableC<plController>(S));
+    setWidthCtl(mgr->ReadCreatableC<plController>(S));
+    setHeightCtl(mgr->ReadCreatableC<plController>(S));
 
     fXTiles = S->readInt();
     fYTiles = S->readInt();
@@ -54,7 +54,7 @@ void plParticleSystem::read(hsStream* S, plResManager* mgr)
     if (fNumValidEmitters > maxEmitters)
         throw hsBadParamException(__FILE__, __LINE__);
     for (size_t i=0; i<fNumValidEmitters; i++)
-        fEmitters[i] = plParticleEmitter::Convert(mgr->ReadCreatable(S));
+        fEmitters[i] = mgr->ReadCreatableC<plParticleEmitter>(S);
 
     fForces.resize(S->readInt());
     for (size_t i=0; i<fForces.size(); i++)
@@ -217,19 +217,19 @@ void plParticleSystem::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
             fMaterial = mgr->prcParseKey(tag->getFirstChild());
     } else if (tag->getName() == "AmbientCtl") {
         if (tag->hasChildren() && !tag->getParam("NULL", "false").to_bool())
-            setAmbientCtl(plController::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setAmbientCtl(mgr->prcParseCreatableC<plController>(tag->getFirstChild()));
     } else if (tag->getName() == "DiffuseCtl") {
         if (tag->hasChildren() && !tag->getParam("NULL", "false").to_bool())
-            setDiffuseCtl(plController::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setDiffuseCtl(mgr->prcParseCreatableC<plController>(tag->getFirstChild()));
     } else if (tag->getName() == "OpacityCtl") {
         if (tag->hasChildren() && !tag->getParam("NULL", "false").to_bool())
-            setOpacityCtl(plController::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setOpacityCtl(mgr->prcParseCreatableC<plController>(tag->getFirstChild()));
     } else if (tag->getName() == "WidthCtl") {
         if (tag->hasChildren() && !tag->getParam("NULL", "false").to_bool())
-            setWidthCtl(plController::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setWidthCtl(mgr->prcParseCreatableC<plController>(tag->getFirstChild()));
     } else if (tag->getName() == "HeightCtl") {
         if (tag->hasChildren() && !tag->getParam("NULL", "false").to_bool())
-            setHeightCtl(plController::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setHeightCtl(mgr->prcParseCreatableC<plController>(tag->getFirstChild()));
     } else if (tag->getName() == "ParticleParams") {
         fXTiles = tag->getParam("XTiles", "0").to_uint();
         fYTiles = tag->getParam("YTiles", "0").to_uint();
@@ -250,7 +250,7 @@ void plParticleSystem::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
             throw pfPrcParseException(__FILE__, __LINE__, "Too many particle emitters");
         const pfPrcTag* child = tag->getFirstChild();
         for (size_t i=0; i<fNumValidEmitters; i++) {
-            fEmitters[i] = plParticleEmitter::Convert(mgr->prcParseCreatable(child));
+            fEmitters[i] = mgr->prcParseCreatableC<plParticleEmitter>(child);
             child = child->getNextSibling();
         }
     } else if (tag->getName() == "Forces") {

--- a/core/PRP/Physics/plObjectInVolumeDetector.cpp
+++ b/core/PRP/Physics/plObjectInVolumeDetector.cpp
@@ -30,7 +30,7 @@ void plCameraRegionDetector::read(hsStream* S, plResManager* mgr)
     clearMessages();
     fMessages.resize(S->readInt());
     for (size_t i=0; i<fMessages.size(); i++)
-        fMessages[i] = plCameraMsg::Convert(mgr->ReadCreatable(S));
+        fMessages[i] = mgr->ReadCreatableC<plCameraMsg>(S);
 }
 
 void plCameraRegionDetector::write(hsStream* S, plResManager* mgr)
@@ -59,7 +59,7 @@ void plCameraRegionDetector::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
         fMessages.resize(tag->countChildren());
         const pfPrcTag* child = tag->getFirstChild();
         for (size_t i=0; i<fMessages.size(); i++) {
-            fMessages[i] = plCameraMsg::Convert(mgr->prcParseCreatable(child));
+            fMessages[i] = mgr->prcParseCreatableC<plCameraMsg>(child);
             child = child->getNextSibling();
         }
     } else {

--- a/core/PRP/Region/plSimpleRegionSensor.cpp
+++ b/core/PRP/Region/plSimpleRegionSensor.cpp
@@ -27,8 +27,8 @@ void plSimpleRegionSensor::read(hsStream* S, plResManager* mgr)
 {
     plSingleModifier::read(S, mgr);
 
-    setEnterMsg(S->readBool() ? plMessage::Convert(mgr->ReadCreatable(S)) : NULL);
-    setExitMsg(S->readBool() ? plMessage::Convert(mgr->ReadCreatable(S)) : NULL);
+    setEnterMsg(S->readBool() ? mgr->ReadCreatableC<plMessage>(S) : nullptr);
+    setExitMsg(S->readBool() ? mgr->ReadCreatableC<plMessage>(S) : nullptr);
 }
 
 void plSimpleRegionSensor::write(hsStream* S, plResManager* mgr)
@@ -79,12 +79,12 @@ void plSimpleRegionSensor::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
         if (tag->getParam("NULL", "false").to_bool())
             setEnterMsg(nullptr);
         else if (tag->hasChildren())
-            setEnterMsg(plMessage::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setEnterMsg(mgr->prcParseCreatableC<plMessage>(tag->getFirstChild()));
     } else if (tag->getName() == "ExitMsg") {
         if (tag->getParam("NULL", "false").to_bool())
             setExitMsg(nullptr);
         else if (tag->hasChildren())
-            setExitMsg(plMessage::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setExitMsg(mgr->prcParseCreatableC<plMessage>(tag->getFirstChild()));
     } else {
         plSingleModifier::IPrcParse(tag, mgr);
     }

--- a/core/PRP/Region/plSoftVolume.cpp
+++ b/core/PRP/Region/plSoftVolume.cpp
@@ -69,7 +69,7 @@ void plSoftVolumeSimple::read(hsStream* S, plResManager* mgr)
     plSoftVolume::read(S, mgr);
 
     fSoftDist = S->readFloat();
-    setVolume(plVolumeIsect::Convert(mgr->ReadCreatable(S)));
+    setVolume(mgr->ReadCreatableC<plVolumeIsect>(S));
 }
 
 void plSoftVolumeSimple::write(hsStream* S, plResManager* mgr)
@@ -101,7 +101,7 @@ void plSoftVolumeSimple::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
     if (tag->getName() == "Volume") {
         fSoftDist = tag->getParam("SoftDist", "0").to_float();
         if (tag->hasChildren())
-            setVolume(plVolumeIsect::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setVolume(mgr->prcParseCreatableC<plVolumeIsect>(tag->getFirstChild()));
         else
             setVolume(nullptr);
     } else {

--- a/core/PRP/Region/plVolumeIsect.cpp
+++ b/core/PRP/Region/plVolumeIsect.cpp
@@ -501,7 +501,7 @@ void plComplexIsect::read(hsStream* S, plResManager* mgr)
     clearVolumes();
     fVolumes.resize(S->readShort());
     for (size_t i=0; i<fVolumes.size(); i++)
-        fVolumes[i] = plVolumeIsect::Convert(mgr->ReadCreatable(S));
+        fVolumes[i] = mgr->ReadCreatableC<plVolumeIsect>(S);
 }
 
 void plComplexIsect::write(hsStream* S, plResManager* mgr)
@@ -526,7 +526,7 @@ void plComplexIsect::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
         fVolumes.resize(tag->countChildren());
         const pfPrcTag* child = tag->getFirstChild();
         for (size_t i=0; i<fVolumes.size(); i++) {
-            fVolumes[i] = plVolumeIsect::Convert(mgr->prcParseCreatable(child));
+            fVolumes[i] = mgr->prcParseCreatableC<plVolumeIsect>(child);
             child = child->getNextSibling();
         }
     } else {

--- a/core/PRP/Region/plVolumeIsect.h
+++ b/core/PRP/Region/plVolumeIsect.h
@@ -18,6 +18,7 @@
 #define _PLVOLUMEISECT_H
 
 #include "PRP/plCreatable.h"
+#include "ResManager/plResManager.h"
 #include "Math/hsGeometry3.h"
 #include "Math/hsMatrix44.h"
 #include "hsBounds.h"

--- a/core/PRP/Surface/plDynaRippleMgr.cpp
+++ b/core/PRP/Surface/plDynaRippleMgr.cpp
@@ -134,7 +134,7 @@ void plDynaWakeMgr::read(hsStream* S, plResManager* mgr)
     plDynaRippleMgr::read(S, mgr);
 
     fDefaultDir.read(S);
-    setAnimPath(plAnimPath::Convert(mgr->ReadCreatable(S)));
+    setAnimPath(mgr->ReadCreatableC<plAnimPath>(S));
     fAnimWgt = S->readFloat();
     fVelWgt = S->readFloat();
 }
@@ -184,7 +184,7 @@ void plDynaWakeMgr::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
             setAnimPath(nullptr);
         } else {
             if (tag->hasChildren())
-                setAnimPath(plAnimPath::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+                setAnimPath(mgr->prcParseCreatableC<plAnimPath>(tag->getFirstChild()));
         }
     } else {
         plDynaRippleMgr::IPrcParse(tag, mgr);

--- a/core/PRP/Surface/plLayerAnimation.cpp
+++ b/core/PRP/Surface/plLayerAnimation.cpp
@@ -31,12 +31,12 @@ void plLayerAnimationBase::read(hsStream* S, plResManager* mgr)
 {
     plLayerInterface::read(S, mgr);
 
-    setPreshadeCtl(plController::Convert(mgr->ReadCreatable(S)));
-    setRuntimeCtl(plController::Convert(mgr->ReadCreatable(S)));
-    setAmbientCtl(plController::Convert(mgr->ReadCreatable(S)));
-    setSpecularCtl(plController::Convert(mgr->ReadCreatable(S)));
-    setOpacityCtl(plController::Convert(mgr->ReadCreatable(S)));
-    setTransformCtl(plController::Convert(mgr->ReadCreatable(S)));
+    setPreshadeCtl(mgr->ReadCreatableC<plController>(S));
+    setRuntimeCtl(mgr->ReadCreatableC<plController>(S));
+    setAmbientCtl(mgr->ReadCreatableC<plController>(S));
+    setSpecularCtl(mgr->ReadCreatableC<plController>(S));
+    setOpacityCtl(mgr->ReadCreatableC<plController>(S));
+    setTransformCtl(mgr->ReadCreatableC<plController>(S));
 }
 
 void plLayerAnimationBase::write(hsStream* S, plResManager* mgr)
@@ -96,22 +96,22 @@ void plLayerAnimationBase::IPrcParse(const pfPrcTag* tag, plResManager* mgr)
 {
     if (tag->getName() == "PreshadeColorCtl") {
         if (tag->hasChildren())
-            setPreshadeCtl(plController::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setPreshadeCtl(mgr->prcParseCreatableC<plController>(tag->getFirstChild()));
     } else if (tag->getName() == "RuntimeColorCtl") {
         if (tag->hasChildren())
-            setRuntimeCtl(plController::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setRuntimeCtl(mgr->prcParseCreatableC<plController>(tag->getFirstChild()));
     } else if (tag->getName() == "AmbientColorCtl") {
         if (tag->hasChildren())
-            setAmbientCtl(plController::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setAmbientCtl(mgr->prcParseCreatableC<plController>(tag->getFirstChild()));
     } else if (tag->getName() == "SpecularColorCtl") {
         if (tag->hasChildren())
-            setSpecularCtl(plController::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setSpecularCtl(mgr->prcParseCreatableC<plController>(tag->getFirstChild()));
     } else if (tag->getName() == "OpacityCtl") {
         if (tag->hasChildren())
-            setOpacityCtl(plController::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setOpacityCtl(mgr->prcParseCreatableC<plController>(tag->getFirstChild()));
     } else if (tag->getName() == "TransformCtl") {
         if (tag->hasChildren())
-            setTransformCtl(plController::Convert(mgr->prcParseCreatable(tag->getFirstChild())));
+            setTransformCtl(mgr->prcParseCreatableC<plController>(tag->getFirstChild()));
     } else {
         plLayerInterface::IPrcParse(tag, mgr);
     }

--- a/core/PRP/plCreatable.h
+++ b/core/PRP/plCreatable.h
@@ -17,8 +17,9 @@
 #ifndef _PLCREATABLE_H
 #define _PLCREATABLE_H
 
+#include "Stream/pfPrcHelper.h"
+#include "Stream/pfPrcParser.h"
 #include "ResManager/pdUnifiedTypeMap.h"
-#include "ResManager/plResManager.h"
 #include <string_theory/format>
 
 #define CREATABLE(classname, classid, parentclass) \
@@ -47,6 +48,8 @@ public: \
         } \
     }
 
+
+class plResManager;
 
 class PLASMA_DLL plCreatable
 {

--- a/core/PRP/plCreatableListHelper.h
+++ b/core/PRP/plCreatableListHelper.h
@@ -18,6 +18,7 @@
 #define _PLCREATABLELISTHELPER_H
 
 #include "plCreatable.h"
+#include "ResManager/plResManager.h"
 
 class PLASMA_DLL plCreatableListHelper : public plCreatable
 {

--- a/core/ResManager/plResManager.cpp
+++ b/core/ResManager/plResManager.cpp
@@ -215,7 +215,7 @@ plPageInfo* plResManager::ReadPagePrc(const pfPrcTag* root)
 
     const pfPrcTag* tag = root->getFirstChild();
     while (tag) {
-        hsKeyedObject* ko = hsKeyedObject::Convert(prcParseCreatable(tag));
+        hsKeyedObject* ko = prcParseCreatableC<hsKeyedObject>(tag);
         if (ko)
             ko->getKey()->setObj(ko);
         tag = tag->getNextSibling();
@@ -659,7 +659,8 @@ unsigned int plResManager::WriteObjects(hsStream* S, const plLocation& loc)
     return nWritten;
 }
 
-plCreatable* plResManager::ReadCreatable(hsStream* S, bool canStub, int stubLen) {
+plCreatable* plResManager::ReadCreatable(hsStream* S, bool canStub, int stubLen)
+{
     unsigned short type = S->readShort();
     plCreatable* pCre;
     if (mustStub) {
@@ -704,10 +705,13 @@ void plResManager::WriteCreatable(hsStream* S, plCreatable* pCre)
     }
 }
 
-plCreatable* plResManager::prcParseCreatable(const pfPrcTag* tag) {
+plCreatable* plResManager::prcParseCreatable(const pfPrcTag* tag)
+{
     plCreatable* pCre = plFactory::Create(tag->getName().c_str());
     if (pCre)
         pCre->prcParse(tag, this);
+    else
+        throw pfPrcTagException(__FILE__, __LINE__, tag->getName());
     return pCre;
 }
 

--- a/core/SDL/plStateVariable.h
+++ b/core/SDL/plStateVariable.h
@@ -24,6 +24,7 @@
 #include "Sys/hsColor.h"
 #include "Sys/plUnifiedTime.h"
 #include "PRP/plCreatable.h"
+#include "PRP/KeyedObject/plUoid.h"
 
 class PLASMA_DLL plStateVarNotificationInfo
 {

--- a/net/auth/pnAuthClient.cpp
+++ b/net/auth/pnAuthClient.cpp
@@ -16,6 +16,7 @@
 
 #include "pnAuthClient.h"
 #include "AuthMessages.h"
+#include "ResManager/plResManager.h"
 #include "Debug/plDebug.h"
 #include "Stream/hsRAMStream.h"
 #include "crypt/pnBigInteger.h"
@@ -297,7 +298,7 @@ bool pnAuthClient::Dispatch::dispatch(pnSocket* sock)
                 std::lock_guard<plResManager> resMgrLock(*fReceiver->fResMgr);
                 try {
                     pCre = fReceiver->fResMgr->ReadCreatable(&rs, true, msgbuf[1].fUint);
-                } catch (hsException& ex) {
+                } catch (const hsException& ex) {
                     plDebug::Error("Error reading propagated message: {}\n", ex.what());
                     delete pCre;
                     pCre = nullptr;

--- a/net/game/pnGameClient.cpp
+++ b/net/game/pnGameClient.cpp
@@ -16,6 +16,7 @@
 
 #include "pnGameClient.h"
 #include "GameMessages.h"
+#include "ResManager/plResManager.h"
 #include "Debug/plDebug.h"
 #include "Stream/hsRAMStream.h"
 #include "crypt/pnBigInteger.h"


### PR DESCRIPTION
Add a safe variant of plResManager::ReadCreatable and prcParseCreatable which automatically converts to the requested type or frees the allocated creatable when no conversion is possible.