### PR TITLE
Support `os.PathLike` for paths and filenames.

### DIFF
--- a/Python/Debug/pyDebug.cpp
+++ b/Python/Debug/pyDebug.cpp
@@ -44,9 +44,9 @@ PY_METHOD_STATIC_VA(Debug, InitFile,
     "Initialize the debug logger to a file output")
 {
     int level = plDebug::kDLWarning;
-    const char* filename = "Plasma.log";
-    if (!PyArg_ParseTuple(args, "|is", &level, &filename)) {
-        PyErr_SetString(PyExc_TypeError, "InitFile expects int, string");
+    ST::string filename = ST_LITERAL("Plasma.log");
+    if (!PyArg_ParseTuple(args, "|iO&", &level, PyAnyString_PathDecoder, &filename)) {
+        PyErr_SetString(PyExc_TypeError, "InitFile expects int, string (or an os.PathLike object)");
         return nullptr;
     }
     plDebug::InitFile(level, filename);

--- a/Python/PRP/Audio/pySoundBuffer.cpp
+++ b/Python/PRP/Audio/pySoundBuffer.cpp
@@ -23,7 +23,7 @@
 PY_PLASMA_NEW(SoundBuffer, plSoundBuffer)
 
 PY_PROPERTY_PROXY(plWAVHeader, SoundBuffer, header, getHeader)
-PY_PROPERTY(ST::string, SoundBuffer, fileName, getFileName, setFileName)
+PY_PROPERTY_PATHLIKE(SoundBuffer, fileName, getFileName, setFileName)
 PY_PROPERTY(unsigned int, SoundBuffer, flags, getFlags, setFlags)
 PY_PROPERTY(size_t, SoundBuffer, dataLength, getDataLength, setDataLength)
 

--- a/Python/PRP/Avatar/pyAGAnimBink.cpp
+++ b/Python/PRP/Avatar/pyAGAnimBink.cpp
@@ -21,8 +21,8 @@
 
 PY_PLASMA_NEW(AGAnimBink, plAGAnimBink)
 
-PY_PROPERTY(ST::string, AGAnimBink, binkFilename, getBinkFilename, setBinkFilename)
-PY_PROPERTY(ST::string, AGAnimBink,sgtFilename, getSgtFilename, setSgtFilename)
+PY_PROPERTY_PATHLIKE(AGAnimBink, binkFilename, getBinkFilename, setBinkFilename)
+PY_PROPERTY_PATHLIKE(AGAnimBink, sgtFilename, getSgtFilename, setSgtFilename)
 PY_PROPERTY(ST::string, AGAnimBink,subtitleId, getSubtitleId, setSubtitleId)
 
 static PyGetSetDef pyAGAnimBink_GetSet[] = {

--- a/Python/PRP/Modifier/pyPythonFileMod.cpp
+++ b/Python/PRP/Modifier/pyPythonFileMod.cpp
@@ -101,7 +101,7 @@ PY_GETSET_GETTER_DECL(PythonFileMod, parameters)
 PY_PROPERTY_SETTER_MSG(PythonFileMod, parameters, "To add parameters, use addParameter")
 PY_PROPERTY_GETSET_DECL(PythonFileMod, parameters)
 
-PY_PROPERTY(ST::string, PythonFileMod, filename, getFilename, setFilename)
+PY_PROPERTY_PATHLIKE(PythonFileMod, filename, getFilename, setFilename)
 
 static PyGetSetDef pyPythonFileMod_GetSet[] = {
     pyPythonFileMod_filename_getset,

--- a/Python/PRP/Surface/pyLayerMovie.cpp
+++ b/Python/PRP/Surface/pyLayerMovie.cpp
@@ -22,7 +22,7 @@
 
 PY_PLASMA_NEW(LayerMovie, plLayerMovie)
 
-PY_PROPERTY(ST::string, LayerMovie, movieName, getMovieName, setMovieName)
+PY_PROPERTY_PATHLIKE(LayerMovie, movieName, getMovieName, setMovieName)
 
 static PyGetSetDef pyLayerMovie_GetSet[] = {
     pyLayerMovie_movieName_getset,

--- a/Python/PyPlasma.cpp
+++ b/Python/PyPlasma.cpp
@@ -44,6 +44,25 @@ ST::string PyAnyString_AsSTString(PyObject* str)
     }
 }
 
+int PyAnyString_PathDecoder(PyObject* obj, void* str)
+{
+#if (PY_MAJOR_VERSION > 3) || ((PY_MAJOR_VERSION == 3) && (PY_MINOR_VERSION >= 2))
+    PyObject* fsConvert;
+    if (PyUnicode_FSDecoder(obj, &fsConvert)) {
+        *((ST::string*)str) = PyAnyString_AsSTString(fsConvert);
+        Py_DECREF(fsConvert);
+        return 1;
+    }
+    return 0;
+#else
+    if (PyAnyString_Check(obj)) {
+        *((ST::string*)str) = PyAnyString_AsSTString(obj);
+        return 1;
+    }
+    return 0;
+#endif
+}
+
 int PyType_CheckAndReady(PyTypeObject* type)
 {
     static std::unordered_set<PyTypeObject*> init_bases;

--- a/Python/ResManager/pyAgeInfo.cpp
+++ b/Python/ResManager/pyAgeInfo.cpp
@@ -28,11 +28,12 @@ PY_METHOD_VA(AgeInfo, readFromFile,
     "Params: filename\n"
     "Reads the AgeInfo from a .age file")
 {
-    const char* filename;
-    if (!PyArg_ParseTuple(args, "s", &filename)) {
-        PyErr_SetString(PyExc_TypeError, "readFromFile expects a string");
+    ST::string filename;
+    if (!PyArg_ParseTuple(args, "O&", PyAnyString_PathDecoder, &filename)) {
+        PyErr_SetString(PyExc_TypeError, "readFromFile expects a string or an os.PathLike object");
         return nullptr;
     }
+
     try {
         self->fThis->readFromFile(filename);
         Py_RETURN_NONE;
@@ -59,10 +60,10 @@ PY_METHOD_VA(AgeInfo, writeToFile,
     "Params: filename, version\n"
     "Write the AgeInfo to a .age file")
 {
-    const char* filename;
+    ST::string filename;
     int version;
-    if (!PyArg_ParseTuple(args, "si", &filename, &version)) {
-        PyErr_SetString(PyExc_TypeError, "writeToFile expects string, int");
+    if (!PyArg_ParseTuple(args, "O&i", PyAnyString_PathDecoder, &filename, &version)) {
+        PyErr_SetString(PyExc_TypeError, "writeToFile expects string or an os.PathLike object, int");
         return nullptr;
     }
     try {
@@ -258,7 +259,7 @@ static PyMethodDef pyAgeInfo_Methods[] = {
     PY_METHOD_TERMINATOR
 };
 
-PY_PROPERTY(ST::string, AgeInfo, name, getAgeName, setAgeName)
+PY_PROPERTY_PATHLIKE(AgeInfo, name, getAgeName, setAgeName)
 PY_PROPERTY(unsigned int, AgeInfo, startDateTime, getStartDateTime, setStartDateTime)
 PY_PROPERTY(float, AgeInfo, dayLength, getDayLength, setDayLength)
 PY_PROPERTY(short, AgeInfo, maxCapacity, getMaxCapacity, setMaxCapacity)

--- a/Python/ResManager/pyPageInfo.cpp
+++ b/Python/ResManager/pyPageInfo.cpp
@@ -101,9 +101,9 @@ static PyMethodDef pyPageInfo_Methods[] = {
     PY_METHOD_TERMINATOR
 };
 
-PY_PROPERTY(ST::string, PageInfo, age, getAge, setAge)
+PY_PROPERTY_PATHLIKE(PageInfo, age, getAge, setAge)
 PY_PROPERTY_RO(PageInfo, chapter, getChapter)
-PY_PROPERTY(ST::string, PageInfo, page, getPage, setPage)
+PY_PROPERTY_PATHLIKE(PageInfo, page, getPage, setPage)
 PY_PROPERTY(unsigned int, PageInfo, releaseVersion, getReleaseVersion, setReleaseVersion)
 PY_PROPERTY(unsigned int, PageInfo, flags, getFlags, setFlags)
 PY_PROPERTY(plLocation, PageInfo, location, getLocation, setLocation)

--- a/Python/ResManager/pyResManager.cpp
+++ b/Python/ResManager/pyResManager.cpp
@@ -161,11 +161,11 @@ PY_METHOD_VA(ResManager, ReadPage,
     "Params: filename, [stub]\n"
     "Reads an entire PRP file and returns the plPageInfo for it")
 {
-    const char* filename;
+    ST::string filename;
     pyStream* prxStream;
     pyStream* prmStream = nullptr;
     int stub = false;
-    if (PyArg_ParseTuple(args, "s|i", &filename, &stub)) {
+    if (PyArg_ParseTuple(args, "O&|i", PyAnyString_PathDecoder, &filename, &stub)) {
         try {
             return pyPageInfo_FromPageInfo(self->fThis->ReadPage(filename, (stub != 0)));
         } catch (...) {
@@ -174,7 +174,7 @@ PY_METHOD_VA(ResManager, ReadPage,
         }
     } else if (PyErr_Clear(), PyArg_ParseTuple(args, "O|Oi", &prxStream, &prmStream, &stub)) {
         if (!pyStream_Check((PyObject*)prxStream) || (prmStream && !pyStream_Check((PyObject*)prmStream))) {
-            PyErr_SetString(PyExc_TypeError, "ReadPage expects a string or stream");
+            PyErr_SetString(PyExc_TypeError, "ReadPage expects a string, an hsStream, or an os.PathLike object");
             return nullptr;
         }
 
@@ -187,7 +187,7 @@ PY_METHOD_VA(ResManager, ReadPage,
             return nullptr;
         }
     } else {
-        PyErr_SetString(PyExc_TypeError, "ReadPage expects a string or stream");
+        PyErr_SetString(PyExc_TypeError, "ReadPage expects a string, an hsStream, or an os.PathLike object");
         return nullptr;
     }
 }
@@ -196,12 +196,12 @@ PY_METHOD_VA(ResManager, WritePage,
     "Params: filename, page\n"
     "Writes an entire page to a PRP file")
 {
-    const char* filename;
+    ST::string filename;
     pyStream* stream;
     pyPageInfo* page;
-    if (PyArg_ParseTuple(args, "sO", &filename, &page)) {
+    if (PyArg_ParseTuple(args, "O&O", PyAnyString_PathDecoder, &filename, &page)) {
         if (!pyPageInfo_Check((PyObject*)page)) {
-            PyErr_SetString(PyExc_TypeError, "WritePage expects string or hsStream, plPageInfo");
+            PyErr_SetString(PyExc_TypeError, "WritePage expects a string, hsStream, or os.PathLike object, and a plPageInfo");
             return nullptr;
         }
 
@@ -214,7 +214,7 @@ PY_METHOD_VA(ResManager, WritePage,
         }
     } else if (PyErr_Clear(), PyArg_ParseTuple(args, "OO", &stream, &page)) {
         if (!pyPageInfo_Check((PyObject*)page) || !pyStream_Check((PyObject*)stream)) {
-            PyErr_SetString(PyExc_TypeError, "WritePage expects string or hsStream, plPageInfo");
+            PyErr_SetString(PyExc_TypeError, "WritePage expects a string, hsStream, or os.PathLike object, and a plPageInfo");
             return nullptr;
         }
 
@@ -226,7 +226,7 @@ PY_METHOD_VA(ResManager, WritePage,
             return nullptr;
         }
     } else {
-        PyErr_SetString(PyExc_TypeError, "WritePage expects string or hsStream, plPageInfo");
+        PyErr_SetString(PyExc_TypeError, "WritePage expects a string, hsStream, or os.PathLike object, and a plPageInfo");
         return nullptr;
     }
 }
@@ -275,9 +275,9 @@ PY_METHOD_VA(ResManager, ReadAge,
     "Reads a .age file. If readPages is True, also loads all PRPs\n"
     "identified in the .age file")
 {
-    const char* filename;
+    ST::string filename;
     char readPages;
-    if (!PyArg_ParseTuple(args, "sb", &filename, &readPages)) {
+    if (!PyArg_ParseTuple(args, "O&b", PyAnyString_PathDecoder, &filename, &readPages)) {
         PyErr_SetString(PyExc_TypeError, "ReadAge expects string, bool");
         return nullptr;
     }
@@ -304,14 +304,14 @@ PY_METHOD_VA(ResManager, WriteAge,
     "Writes a plAgeInfo to the specified file\n"
     "Does NOT write any PRP files!")
 {
-    const char* filename;
+    ST::string filename;
     pyAgeInfo* age;
-    if (!PyArg_ParseTuple(args, "sO", &filename, &age)) {
-        PyErr_SetString(PyExc_TypeError, "WriteAge expects string, plAgeInfo");
+    if (!PyArg_ParseTuple(args, "O&O", PyAnyString_PathDecoder, &filename, &age)) {
+        PyErr_SetString(PyExc_TypeError, "WriteAge expects string or an os.PathLike object, plAgeInfo");
         return nullptr;
     }
     if (!pyAgeInfo_Check((PyObject*)age)) {
-        PyErr_SetString(PyExc_TypeError, "WriteAge expects string, plAgeInfo");
+        PyErr_SetString(PyExc_TypeError, "WriteAge expects string or an os.PathLike object, plAgeInfo");
         return nullptr;
     }
     try {

--- a/Python/SDL/pySDLMgr.cpp
+++ b/Python/SDL/pySDLMgr.cpp
@@ -27,8 +27,8 @@ PY_METHOD_VA(SDLMgr, readDescriptors,
     "Params: filename or stream\n"
     "Reads SDL Descriptors from the provided filename or stream")
 {
-    const char* filename;
-    if (PyArg_ParseTuple(args, "s", &filename)) {
+    ST::string filename;
+    if (PyArg_ParseTuple(args, "O&", PyAnyString_PathDecoder, &filename)) {
         try {
             self->fThis->ReadDescriptors(filename);
         } catch (const hsException& ex) {
@@ -49,7 +49,7 @@ PY_METHOD_VA(SDLMgr, readDescriptors,
         Py_RETURN_NONE;
     }
 
-    PyErr_SetString(PyExc_TypeError, "readDescriptors expects a string or an hsStream");
+    PyErr_SetString(PyExc_TypeError, "readDescriptors expects a string, an hsStream, or an os.PathLike object");
     return nullptr;
 }
 

--- a/Python/Stream/pyEncryptedStream.cpp
+++ b/Python/Stream/pyEncryptedStream.cpp
@@ -26,14 +26,13 @@ PY_METHOD_VA(EncryptedStream, open,
     "Mode is: fmRead, fmWrite, fmReadWrite, fmCreate\n"
     "Encryption is: kEncNone, kEncXtea, kEncAES, kEncDroid, kEncAuto")
 {
-    const char* filename;
+    ST::string filename;
     pyStream* stream;
     int mode, encryption;
 
-    if (PyArg_ParseTuple(args, "sii", &filename, &mode, &encryption)) {
+    if (PyArg_ParseTuple(args, "O&ii", PyAnyString_PathDecoder, &filename, &mode, &encryption)) {
         try {
-            if (!self->fThis->open(filename, (FileMode)mode,
-                                   (plEncryptedStream::EncryptionType)encryption)) {
+            if (!self->fThis->open(filename, (FileMode)mode, (plEncryptedStream::EncryptionType)encryption)) {
                 PyErr_SetString(PyExc_IOError, "Error opening file");
                 return nullptr;
             }
@@ -45,7 +44,7 @@ PY_METHOD_VA(EncryptedStream, open,
         }
     } else if (PyErr_Clear(), PyArg_ParseTuple(args, "Oii", &stream, &mode, &encryption)) {
         if (!pyStream_Check((PyObject*)stream)) {
-            PyErr_SetString(PyExc_TypeError, "open expects string or stream, int, int");
+            PyErr_SetString(PyExc_TypeError, "open expects a string, hsStream stream, or an os.PathLike object, an int, and an int");
             return nullptr;
         }
 
@@ -62,7 +61,7 @@ PY_METHOD_VA(EncryptedStream, open,
             return nullptr;
         }
     } else {
-        PyErr_SetString(PyExc_TypeError, "open expects string or stream, int, int");
+        PyErr_SetString(PyExc_TypeError, "open expects a string, hsStream stream, or an os.PathLike object, an int, and an int");
         return nullptr;
     }
 }
@@ -108,9 +107,9 @@ PY_METHOD_STATIC_VA(EncryptedStream, IsFileEncrypted,
     "Params: filename\n"
     "Tests whether the specified file is encrypted")
 {
-    const char* filename;
-    if (!PyArg_ParseTuple(args, "s", &filename)) {
-        PyErr_SetString(PyExc_TypeError, "IsFileEncrypted expects a string");
+    ST::string filename;
+    if (!PyArg_ParseTuple(args, "O&", PyAnyString_PathDecoder, &filename)) {
+        PyErr_SetString(PyExc_TypeError, "IsFileEncrypted expects a string or an os.PathLike object");
         return nullptr;
     }
     return pyPlasma_convert(plEncryptedStream::IsFileEncrypted(filename));

--- a/Python/Stream/pyFileStream.cpp
+++ b/Python/Stream/pyFileStream.cpp
@@ -25,11 +25,11 @@ PY_METHOD_VA(FileStream, open,
     "Opens the specified file.\n"
     "Mode is: fmRead, fmWrite, fmReadWrite, fmCreate")
 {
-    const char* filename;
+    ST::string filename;
     int mode;
 
-    if (!PyArg_ParseTuple(args, "si", &filename, &mode)) {
-        PyErr_SetString(PyExc_TypeError, "open expects string, int");
+    if (!PyArg_ParseTuple(args, "O&i", PyAnyString_PathDecoder, &filename, &mode)) {
+        PyErr_SetString(PyExc_TypeError, "open expects string or an os.PathLike object, int");
         return nullptr;
     }
     try {

--- a/core/Debug/plDebug.cpp
+++ b/core/Debug/plDebug.cpp
@@ -44,7 +44,7 @@ void plDebug::Init(int level, hsStream* stream)
     }
 }
 
-void plDebug::InitFile(int level, const char* filename)
+void plDebug::InitFile(int level, const ST::string& filename)
 {
     DeInit();
 

--- a/core/Debug/plDebug.h
+++ b/core/Debug/plDebug.h
@@ -34,7 +34,7 @@ private:
 
 public:
     static void Init(int level, hsStream* stream = nullptr);
-    static void InitFile(int level, const char* filename = "Plasma.log");
+    static void InitFile(int level, const ST::string& filename = ST_LITERAL("Plasma.log"));
 
     static void Error(const char* line)
     {


### PR DESCRIPTION
This changeset adds support for the `os.PathLike` protocol added in Python 3.6 for any properties or function arguments that expect anything resembling a path or a filename. This allows us to pass `pathlib.Path` objects seemlessly to libHSPlasma in Python 3.6+. CPython seems to use `PyUnicode_FSDecoder` instead of manually calling the `__fspath__` method, so that is the approach I took. Unfortunately, In lower versioned Python 3.5 and lower, it is still required to convert path objects to their string representations before passing them to libHSPlasma.

This closes #148