### PR TITLE
Add missing OpenSSL linker dependency.

### DIFF
--- a/net/CMakeLists.txt
+++ b/net/CMakeLists.txt
@@ -100,6 +100,7 @@ if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
 endif()
 
 if(WIN32)
+    target_link_libraries(HSPlasmaNet crypt32)
     target_link_libraries(HSPlasmaNet ws2_32)
 endif(WIN32)
 


### PR DESCRIPTION
This fixes linking with OpenSSL 1.1.1 on Windows.