### PR TITLE
Fix crash in `pyEncryptedStream.IsFileEncrypted`.

### DIFF
--- a/Python/Stream/pyEncryptedStream.cpp
+++ b/Python/Stream/pyEncryptedStream.cpp
@@ -38,8 +38,8 @@ PY_METHOD_VA(EncryptedStream, open,
             }
             Py_INCREF(self);
             return (PyObject*)self;
-        } catch (...) {
-            PyErr_SetString(PyExc_IOError, "Error opening file");
+        } catch (const std::exception& ex) {
+            PyErr_SetString(PyExc_IOError, ex.what());
             return nullptr;
         }
     } else if (PyErr_Clear(), PyArg_ParseTuple(args, "Oii", &stream, &mode, &encryption)) {
@@ -56,8 +56,8 @@ PY_METHOD_VA(EncryptedStream, open,
             }
             Py_INCREF(self);
             return (PyObject*)self;
-        } catch (...) {
-            PyErr_SetString(PyExc_IOError, "Error opening stream");
+        } catch (const std::exception& ex) {
+            PyErr_SetString(PyExc_IOError, ex.what());
             return nullptr;
         }
     } else {
@@ -114,8 +114,8 @@ PY_METHOD_STATIC_VA(EncryptedStream, IsFileEncrypted,
     }
     try {
         return pyPlasma_convert(plEncryptedStream::IsFileEncrypted(filename));
-    } catch (...) {
-        PyErr_SetString(PyExc_IOError, "Error opening file");
+    } catch (const std::exception& ex) {
+        PyErr_SetString(PyExc_IOError, ex.what());
         return nullptr;
     }
 }

--- a/Python/Stream/pyEncryptedStream.cpp
+++ b/Python/Stream/pyEncryptedStream.cpp
@@ -112,7 +112,12 @@ PY_METHOD_STATIC_VA(EncryptedStream, IsFileEncrypted,
         PyErr_SetString(PyExc_TypeError, "IsFileEncrypted expects a string or an os.PathLike object");
         return nullptr;
     }
-    return pyPlasma_convert(plEncryptedStream::IsFileEncrypted(filename));
+    try {
+        return pyPlasma_convert(plEncryptedStream::IsFileEncrypted(filename));
+    } catch (...) {
+        PyErr_SetString(PyExc_IOError, "Error opening file");
+        return nullptr;
+    }
 }
 
 PY_METHOD_NOARGS(EncryptedStream, __enter__, nullptr)


### PR DESCRIPTION
This fixes a crash encountered by Doobes when Korman thought it was a good idea to use `plEncryptedStream.IsFileEncrypted` on a directory path.