### PR TITLE
Support GCC on macOS CI builds

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -4,14 +4,24 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: macOS-latest
+    strategy:
+      matrix:
+        compiler: [gcc, clang]
     steps:
       - uses: actions/checkout@v1
       - name: Install dependencies
         run: |
           brew install libjpeg-turbo libpng
+          if [[ "${{ matrix.compiler }}" == "gcc" ]]; then
+            brew install gcc@9
+          fi
       - name: Build string_theory
         run: |
           mkdir -p build_deps && cd build_deps
+          if [[ "${{ matrix.compiler }}" == "gcc" ]]; then
+            export CC=gcc-9
+            export CXX=g++-9
+          fi
           git clone https://github.com/zrax/string_theory
           mkdir -p string_theory/build && cd string_theory/build
           cmake -DCMAKE_BUILD_TYPE=Debug -DST_BUILD_TESTS=OFF \
@@ -20,6 +30,10 @@ jobs:
       - name: Build libhsplasma
         run: |
           mkdir build && cd build
+          if [[ "${{ matrix.compiler }}" == "gcc" ]]; then
+            export CC=gcc-9
+            export CXX=g++-9
+          fi
           cmake -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/build_deps/prefix;/usr/local/opt/jpeg-turbo;/usr/local/opt/openssl" \
             -DENABLE_PYTHON=ON -DENABLE_TOOLS=ON -DENABLE_NET=ON -DENABLE_PHYSX=OFF ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,6 @@ endif()
 
 if(APPLE)
     add_definitions("-DMACOSX")
-    set(CMAKE_CXX_FLAGS "-stdlib=libc++ ${CMAKE_CXX_FLAGS}")
     set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++11")
     set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
 endif()


### PR DESCRIPTION
This also fixes a leftover hard-coded `-stdlib` clang parameter that should be automatically applied by CMake's `CMAKE_CXX_STANDARD` setting.