### PR TITLE
Don't process blank lines in an age file.

### DIFF
--- a/core/ResManager/plAgeInfo.cpp
+++ b/core/ResManager/plAgeInfo.cpp
@@ -44,6 +44,9 @@ void plAgeInfo::readFromStream(hsStream* S)
 {
     while (!S->eof()) {
         ST::string ln = S->readLine();
+        if (ln.trim().empty())
+            continue;
+
         std::vector<ST::string> parts = ln.split('=', 1);
         ST::string field = parts.at(0).to_lower();
         ST::string value = parts.at(1);


### PR DESCRIPTION
This fixes a crash in libHSPlasma when reading in the spyroom.age file shipped with MOULa. The file has empty lines separating each content line.