### PR TITLE
Suggested fix for issue #168 Python CMakeLists incorrectly determines…

### DIFF
--- a/Python/CMakeLists.txt
+++ b/Python/CMakeLists.txt
@@ -752,7 +752,7 @@ if(NOT WIN32)
                           SUFFIX ".so"
     )
 
-    execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import sys, distutils.sysconfig; sys.stdout.write(distutils.sysconfig.get_python_lib())"
+    execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import sys, distutils.sysconfig; sys.stdout.write(distutils.sysconfig.get_python_lib(prefix='${CMAKE_INSTALL_PREFIX}'))"
                     OUTPUT_VARIABLE _PYTHON_LIB_DIR
     )
     install(TARGETS PyHSPlasma


### PR DESCRIPTION
… PYTHON_LIB_DIR

Allow ${CMAKE_INSTALL_PREFIX} to override Python's installation prefix
when determining where to place PyHSPlasma.so library for Python.

Fixes #168.