### PR TITLE
Pack DSpan GeoSpans into single vertex buffer.

### DIFF
--- a/Python/PRP/Geometry/pyDrawableSpans.cpp
+++ b/Python/PRP/Geometry/pyDrawableSpans.cpp
@@ -48,7 +48,7 @@ PY_METHOD_VA(DrawableSpans, addIcicle,
         PyErr_SetString(PyExc_TypeError, "addIcicle expects a plIcicle");
         return nullptr;
     }
-    return pyPlasma_convert(self->fThis->addIcicle(*ice->fThis));
+    return pyPlasma_convert(self->fThis->addIcicle(ice->fThis));
 }
 
 PY_METHOD_VA(DrawableSpans, createBufferGroup,

--- a/Python/PRP/Geometry/pyGeometrySpan.cpp
+++ b/Python/PRP/Geometry/pyGeometrySpan.cpp
@@ -200,7 +200,9 @@ PY_PROPERTY(plKey, GeometrySpan, material, getMaterial, setMaterial)
 PY_PROPERTY(unsigned int, GeometrySpan, maxBoneIdx, getMaxBoneIdx, setMaxBoneIdx)
 PY_PROPERTY(float, GeometrySpan, maxDist, getMaxDist, setMaxDist)
 PY_PROPERTY(float, GeometrySpan, minDist, getMinDist, setMinDist)
+PY_PROPERTY_RO(GeometrySpan, numIndices, getNumIndices)
 PY_PROPERTY(unsigned int, GeometrySpan, numMatrices, getNumMatrices, setNumMatrices)
+PY_PROPERTY_RO(GeometrySpan, numVertices, getNumVertices)
 PY_PROPERTY(unsigned int, GeometrySpan, penBoneIdx, getPenBoneIdx, setPenBoneIdx)
 PY_PROPERTY(unsigned int, GeometrySpan, props, getProps, setProps)
 PY_PROPERTY(float, GeometrySpan, waterHeight, getWaterHeight, setWaterHeight)
@@ -219,7 +221,9 @@ static PyGetSetDef pyGeometrySpan_GetSet[] = {
     pyGeometrySpan_maxBoneIdx_getset,
     pyGeometrySpan_maxDist_getset,
     pyGeometrySpan_minDist_getset,
+    pyGeometrySpan_numIndices_getset,
     pyGeometrySpan_numMatrices_getset,
+    pyGeometrySpan_numVertices_getset,
     pyGeometrySpan_penBoneIdx_getset,
     pyGeometrySpan_props_getset,
     pyGeometrySpan_vertices_getset,

--- a/core/PRP/Geometry/plDrawableSpans.h
+++ b/core/PRP/Geometry/plDrawableSpans.h
@@ -150,11 +150,16 @@ protected:
                      std::vector<plSpaceBuilderNode*>& right);
     void ISortSpace(std::vector<plSpaceBuilderNode*>& nodes, int axis);
 
+    /**
+     * Finds a buffer group with enough space for the requested amount of vertices.
+     */
+    size_t IFindBufferGroup(unsigned int format, unsigned int vertsNeeded);
+
 public:
     size_t getNumSpans() const { return fSpans.size(); }
     plSpan* getSpan(size_t idx) const { return fSpans[idx]; }
     plIcicle* getIcicle(size_t idx) const { return (plIcicle*)fSpans[idx]; }
-    size_t addIcicle(const plIcicle& span);
+    size_t addIcicle(plIcicle* span);
     void clearSpans();
 
     size_t getNumBufferGroups() const { return fGroups.size(); }

--- a/core/PRP/Geometry/plGeometrySpan.h
+++ b/core/PRP/Geometry/plGeometrySpan.h
@@ -89,7 +89,7 @@ protected:
     float fMinDist, fMaxDist;
     float fWaterHeight;
     unsigned int fProps;
-    unsigned int fNumVerts, fNumIndices;
+    unsigned int fNumVerts;
     std::vector<unsigned char> fVertexData;
     std::vector<unsigned short> fIndexData;
     unsigned int fDecalLevel;
@@ -109,7 +109,7 @@ public:
     plGeometrySpan()
         : fFormat(), fNumMatrices(), fBaseMatrix(), fLocalUVWChans(),
           fMaxBoneIdx(), fPenBoneIdx(), fMinDist(), fMaxDist(), fWaterHeight(),
-          fProps(), fNumVerts(), fNumIndices(), fDecalLevel(), fInstanceGroup() { }
+          fProps(), fNumVerts(), fDecalLevel(), fInstanceGroup() { }
 
     static unsigned int CalcVertexSize(unsigned char format);
 
@@ -120,6 +120,7 @@ public:
 
     std::vector<TempVertex> getVertices() const;
     void setVertices(const std::vector<TempVertex>& verts);
+    unsigned short getIndex(size_t idx) const { return fIndexData[idx]; }
     std::vector<unsigned short> getIndices() const { return fIndexData; }
     void setIndices(const std::vector<unsigned short>& indices) { fIndexData = indices; }
 
@@ -135,6 +136,8 @@ public:
     unsigned int getFormat() const { return fFormat; }
     unsigned int getNumMatrices() const { return fNumMatrices; }
     unsigned int getProps() const { return fProps; }
+    unsigned int getNumVertices() const { return fNumVerts; }
+    unsigned int getNumIndices() const { return fIndexData.size(); }
     unsigned int getBaseMatrix() const { return fBaseMatrix; }
     unsigned int getLocalUVWChans() const { return fLocalUVWChans; }
     unsigned int getMaxBoneIdx() const { return fMaxBoneIdx; }


### PR DESCRIPTION
This changeset optimizes the output of `plDrawableSpans::composeGeometry` by attempting to pack spans into a one vertex buffer in plGBufferGroup. These vertex buffers correspond to DirectX vertex buffers in Plasma. There are many buffer group formats in Plasma, and the code attempts to not obliterate anything another user of the buffer group has done.

This also fixes an issue in which the index data of a `plGeometrySpan` could be lost if the number of indices changed after being initialized or set by IO.