### PR TITLE
Fix missing cstring include for memcpy

### DIFF
--- a/core/PRP/Geometry/plGBufferGroup.cpp
+++ b/core/PRP/Geometry/plGBufferGroup.cpp
@@ -17,6 +17,7 @@
 #include "plGBufferGroup.h"
 #include "plGeometrySpan.h"
 #include "plIcicle.h"
+#include <cstring>
 #include <string_theory/format>
 
 /* plGBufferCell */


### PR DESCRIPTION
This was a compile error for me, but I don't know how the CI builds somehow managed to not hit this :man_shrugging: 