### PR TITLE
Return pyKeyFrames as the correct subtype

### DIFF
--- a/Python/PRP/Animation/pyKeys.h
+++ b/Python/PRP/Animation/pyKeys.h
@@ -17,17 +17,48 @@
 #ifndef _PYKEYS_H
 #define _PYKEYS_H
 
+#include <PRP/Animation/hsKeys.h>
+
 #include "PyPlasma.h"
 
-PY_WRAP_PLASMA(KeyFrame, struct hsKeyFrame);
-PY_WRAP_PLASMA(Point3Key, struct hsPoint3Key);
-PY_WRAP_PLASMA(ScalarKey, struct hsScalarKey);
-PY_WRAP_PLASMA(ScaleKey, struct hsScaleKey);
-PY_WRAP_PLASMA(QuatKey, struct hsQuatKey);
-PY_WRAP_PLASMA(CompressedQuatKey32, struct hsCompressedQuatKey32);
-PY_WRAP_PLASMA(CompressedQuatKey64, struct hsCompressedQuatKey64);
-PY_WRAP_PLASMA(G3DSMaxKeyFrame, struct hsG3DSMaxKeyFrame);
-PY_WRAP_PLASMA(Matrix33Key, struct hsMatrix33Key);
-PY_WRAP_PLASMA(Matrix44Key, struct hsMatrix44Key);
+PY_WRAP_PLASMA(KeyFrame, hsKeyFrame);
+PY_WRAP_PLASMA(Point3Key, hsPoint3Key);
+PY_WRAP_PLASMA(ScalarKey, hsScalarKey);
+PY_WRAP_PLASMA(ScaleKey, hsScaleKey);
+PY_WRAP_PLASMA(QuatKey, hsQuatKey);
+PY_WRAP_PLASMA(CompressedQuatKey32, hsCompressedQuatKey32);
+PY_WRAP_PLASMA(CompressedQuatKey64, hsCompressedQuatKey64);
+PY_WRAP_PLASMA(G3DSMaxKeyFrame, hsG3DSMaxKeyFrame);
+PY_WRAP_PLASMA(Matrix33Key, hsMatrix33Key);
+PY_WRAP_PLASMA(Matrix44Key, hsMatrix44Key);
+
+inline PyObject* pyPlasma_convert(hsKeyFrame* key)
+{
+    switch (key->getType()) {
+    case hsKeyFrame::kPoint3KeyFrame:
+    case hsKeyFrame::kBezPoint3KeyFrame:
+        return pyPoint3Key_FromPoint3Key((hsPoint3Key*)key);
+    case hsKeyFrame::kScalarKeyFrame:
+    case hsKeyFrame::kBezScalarKeyFrame:
+        return pyScalarKey_FromScalarKey((hsScalarKey*)key);
+    case hsKeyFrame::kScaleKeyFrame:
+    case hsKeyFrame::kBezScaleKeyFrame:
+        return pyScaleKey_FromScaleKey((hsScaleKey*)key);
+    case hsKeyFrame::kQuatKeyFrame:
+        return pyQuatKey_FromQuatKey((hsQuatKey*)key);
+    case hsKeyFrame::kCompressedQuatKeyFrame32:
+        return pyCompressedQuatKey32_FromCompressedQuatKey32((hsCompressedQuatKey32*)key);
+    case hsKeyFrame::kCompressedQuatKeyFrame64:
+        return pyCompressedQuatKey64_FromCompressedQuatKey64((hsCompressedQuatKey64*)key);
+    case hsKeyFrame::k3dsMaxKeyFrame:
+        return pyG3DSMaxKeyFrame_FromG3DSMaxKeyFrame((hsG3DSMaxKeyFrame*)key);
+    case hsKeyFrame::kMatrix33KeyFrame:
+        return pyMatrix33Key_FromMatrix33Key((hsMatrix33Key*)key);
+    case hsKeyFrame::kMatrix44KeyFrame:
+        return pyMatrix44Key_FromMatrix44Key((hsMatrix44Key*)key);
+    default:
+        return pyKeyFrame_FromKeyFrame(key);
+    }
+}
 
 #endif

--- a/Python/PRP/Animation/pyLeafController.cpp
+++ b/Python/PRP/Animation/pyLeafController.cpp
@@ -58,7 +58,7 @@ PY_GETSET_GETTER_DECL(LeafController, keys)
     const std::vector<hsKeyFrame*>& keys = self->fThis->getKeys();
     PyObject* keyTup = PyTuple_New(keys.size());
     for (size_t i=0; i<keys.size(); i++)
-        PyTuple_SET_ITEM(keyTup, i, pyKeyFrame_FromKeyFrame(keys[i]));
+        PyTuple_SET_ITEM(keyTup, i, pyPlasma_convert(keys[i]));
     PyObject* tup = PyTuple_New(2);
     PyTuple_SET_ITEM(tup, 0, keyTup);
     PyTuple_SET_ITEM(tup, 1, pyPlasma_convert(self->fThis->getType()));


### PR DESCRIPTION
Returning the `.keys` of a plLeafController in Python would return a tuple containing an array of hsKeyFrames. In reality, that should be an array of the specific hsKeyFrame subclasses.

/cc @Jrius This should resolve the need for haxKeyFrames in ZLZ