### PR TITLE
Return the index when adding DSpan bone transforms

### DIFF
--- a/Python/PRP/Geometry/pyDrawableSpans.cpp
+++ b/Python/PRP/Geometry/pyDrawableSpans.cpp
@@ -264,8 +264,7 @@ PY_METHOD_VA(DrawableSpans, addTransform,
         PyErr_SetString(PyExc_TypeError, "addTransform expects 4 hsMatrix44s");
         return nullptr;
     }
-    self->fThis->addTransform(*l2w->fThis, *w2l->fThis, *l2b->fThis, *b2l->fThis);
-    Py_RETURN_NONE;
+    return pyPlasma_convert(self->fThis->addTransform(*l2w->fThis, *w2l->fThis, *l2b->fThis, *b2l->fThis));
 }
 
 PY_METHOD_NOARGS(DrawableSpans, clearMaterials,

--- a/core/PRP/Geometry/plDrawableSpans.cpp
+++ b/core/PRP/Geometry/plDrawableSpans.cpp
@@ -727,13 +727,14 @@ void plDrawableSpans::clearTransforms()
     fBoneToLocals.clear();
 }
 
-void plDrawableSpans::addTransform(const hsMatrix44& l2w, const hsMatrix44& w2l,
-                                   const hsMatrix44& l2b, const hsMatrix44& b2l)
+size_t plDrawableSpans::addTransform(const hsMatrix44& l2w, const hsMatrix44& w2l,
+                                     const hsMatrix44& l2b, const hsMatrix44& b2l)
 {
     fLocalToWorlds.push_back(l2w);
     fWorldToLocals.push_back(w2l);
     fLocalToBones.push_back(l2b);
     fBoneToLocals.push_back(b2l);
+    return fLocalToBones.size() - 1;
 }
 
 void plDrawableSpans::setSpaceTree(plSpaceTree* tree)

--- a/core/PRP/Geometry/plDrawableSpans.h
+++ b/core/PRP/Geometry/plDrawableSpans.h
@@ -188,8 +188,8 @@ public:
     hsMatrix44 getLocalToBone(size_t idx) const { return fLocalToBones[idx]; }
     hsMatrix44 getBoneToLocal(size_t idx) const { return fBoneToLocals[idx]; }
     void clearTransforms();
-    void addTransform(const hsMatrix44& l2w, const hsMatrix44& w2l,
-                      const hsMatrix44& l2b, const hsMatrix44& b2l);
+    size_t addTransform(const hsMatrix44& l2w, const hsMatrix44& w2l,
+                        const hsMatrix44& l2b, const hsMatrix44& b2l);
 
     const hsBounds3Ext& getLocalBounds() { return fLocalBounds; }
     const hsBounds3Ext& getWorldBounds() { return fWorldBounds; }


### PR DESCRIPTION
We need this index so that we can point our `kMatrixOnly` DISpanIndices to the correct transform index.