### PR TITLE
Add plConvexIsect::SinglePlane python bindings

### DIFF
--- a/Python/PRP/Region/pyConvexIsect.cpp
+++ b/Python/PRP/Region/pyConvexIsect.cpp
@@ -63,7 +63,7 @@ PY_GETSET_GETTER_DECL(ConvexIsect, planes)
 {
     PyObject* list = PyTuple_New(self->fThis->getPlanes().size());
     for (size_t i = 0; i < self->fThis->getPlanes().size(); i++)
-        PyTuple_SET_ITEM(list, i, pySinglePlane_FromSinglePlane(&(self->fThis->getPlanes()[i])));
+        PyTuple_SET_ITEM(list, i, pySinglePlane_FromSinglePlane(self->fThis->getPlanes()[i]));
     return list;
 }
 
@@ -98,7 +98,9 @@ PY_PLASMA_IFC_METHODS(ConvexIsect, plConvexIsect)
 
 /* pySinglePlane */
 
-PY_PLASMA_NEW(SinglePlane, plConvexIsect::SinglePlane)
+PY_PLASMA_VALUE_DEALLOC(SinglePlane)
+PY_PLASMA_EMPTY_INIT(SinglePlane)
+PY_PLASMA_VALUE_NEW(SinglePlane, plConvexIsect::SinglePlane)
 
 PY_PROPERTY(hsVector3, SinglePlane, norm, getNorm, setNorm)
 PY_PROPERTY(hsVector3, SinglePlane, pos, getPos, setPos)
@@ -119,6 +121,8 @@ PY_PLASMA_TYPE(SinglePlane, plConvexIsect::SinglePlane, "plConvexIsect::SinglePl
 
 PY_PLASMA_TYPE_INIT(SinglePlane)
 {
+    pySinglePlane_Type.tp_dealloc = pySinglePlane_dealloc;
+    pySinglePlane_Type.tp_init = pySinglePlane___init__;
     pySinglePlane_Type.tp_new = pySinglePlane_new;
     pySinglePlane_Type.tp_getset = pySinglePlane_GetSet;
     if (PyType_CheckAndReady(&pySinglePlane_Type) < 0)
@@ -128,4 +132,4 @@ PY_PLASMA_TYPE_INIT(SinglePlane)
     return (PyObject*)&pySinglePlane_Type;
 }
 
-PY_PLASMA_IFC_METHODS(SinglePlane, plConvexIsect::SinglePlane)
+PY_PLASMA_VALUE_IFC_METHODS(SinglePlane, plConvexIsect::SinglePlane)

--- a/Python/PRP/Region/pyConvexIsect.cpp
+++ b/Python/PRP/Region/pyConvexIsect.cpp
@@ -26,17 +26,22 @@ PY_PLASMA_NEW(ConvexIsect, plConvexIsect)
 
 PY_METHOD_VA(ConvexIsect, addPlane,
     "Adds or updates a given plane\n"
-    "Params: normal, position")
+    "Params: normal, position, or a plConvexIsect.SinglePlane")
 {
     PyObject* normal;
     PyObject* position;
-    if (!PyArg_ParseTuple(args, "OO", &normal, &position) || !pyVector3_Check(normal) ||
-        !pyVector3_Check(position)) {
-        PyErr_SetString(PyExc_TypeError, "addPlane expects hsVector3, hsVector3");
+    PyObject* plane;
+    if (PyArg_ParseTuple(args, "OO", &normal, &position) && pyVector3_Check(normal) &&
+        pyVector3_Check(position)) {
+        self->fThis->addPlane(*((pyVector3*)normal)->fThis, *((pyVector3*)position)->fThis);
+        Py_RETURN_NONE;
+    } else if (PyErr_Clear(), PyArg_ParseTuple(args, "O", &plane) && pySinglePlane_Check(plane)) {
+        self->fThis->addPlane(*(((pySinglePlane*)plane)->fThis));
+        Py_RETURN_NONE;
+    } else {
+        PyErr_SetString(PyExc_TypeError, "addPlane expects hsVector3, hsVector3, or a plConvexIsect.SinglePlane");
         return nullptr;
     }
-    self->fThis->addPlane(*((pyVector3*)normal)->fThis, *((pyVector3*)position)->fThis);
-    Py_RETURN_NONE;
 }
 
 PY_METHOD_VA(ConvexIsect, transform,

--- a/Python/PRP/Region/pyConvexIsect.cpp
+++ b/Python/PRP/Region/pyConvexIsect.cpp
@@ -20,6 +20,8 @@
 #include "Math/pyGeometry3.h"
 #include "Math/pyMatrix.h"
 
+/* pyConvexIsect */
+
 PY_PLASMA_NEW(ConvexIsect, plConvexIsect)
 
 PY_METHOD_VA(ConvexIsect, addPlane,
@@ -57,18 +59,73 @@ PyMethodDef pyConvexIsect_Methods[] = {
     PY_METHOD_TERMINATOR
 };
 
+PY_GETSET_GETTER_DECL(ConvexIsect, planes)
+{
+    PyObject* list = PyTuple_New(self->fThis->getPlanes().size());
+    for (size_t i = 0; i < self->fThis->getPlanes().size(); i++)
+        PyTuple_SET_ITEM(list, i, pySinglePlane_FromSinglePlane(&(self->fThis->getPlanes()[i])));
+    return list;
+}
+
+PY_PROPERTY_SETTER_MSG(ConvexIsect, planes, "To add planes, use addPlane")
+PY_PROPERTY_GETSET_DECL(ConvexIsect, planes)
+
+PyGetSetDef pyConvexIsect_GetSet[] = {
+    pyConvexIsect_planes_getset,
+    PY_GETSET_TERMINATOR
+};
+
 PY_PLASMA_TYPE(ConvexIsect, plConvexIsect, "plConvexIsect wrapper")
 
 PY_PLASMA_TYPE_INIT(ConvexIsect)
 {
     pyConvexIsect_Type.tp_new = pyConvexIsect_new;
     pyConvexIsect_Type.tp_methods = pyConvexIsect_Methods;
+    pyConvexIsect_Type.tp_getset = pyConvexIsect_GetSet;
     pyConvexIsect_Type.tp_base = &pyVolumeIsect_Type;
     if (PyType_CheckAndReady(&pyConvexIsect_Type) < 0)
         return nullptr;
+
+    /* SinglePlane class */
+    PyDict_SetItemString(pyConvexIsect_Type.tp_dict, "SinglePlane",
+        Init_pySinglePlane_Type());
 
     Py_INCREF(&pyConvexIsect_Type);
     return (PyObject*)&pyConvexIsect_Type;
 }
 
 PY_PLASMA_IFC_METHODS(ConvexIsect, plConvexIsect)
+
+/* pySinglePlane */
+
+PY_PLASMA_NEW(SinglePlane, plConvexIsect::SinglePlane)
+
+PY_PROPERTY(hsVector3, SinglePlane, norm, getNorm, setNorm)
+PY_PROPERTY(hsVector3, SinglePlane, pos, getPos, setPos)
+PY_PROPERTY(hsVector3, SinglePlane, worldNorm, getWorldNorm, setWorldNorm)
+PY_PROPERTY(float, SinglePlane, dist, getDist, setDist)
+PY_PROPERTY(float, SinglePlane, worldDist, getWorldDist, setWorldDist)
+
+PyGetSetDef pySinglePlane_GetSet[] = {
+    pySinglePlane_norm_getset,
+    pySinglePlane_pos_getset,
+    pySinglePlane_worldNorm_getset,
+    pySinglePlane_dist_getset,
+    pySinglePlane_worldDist_getset,
+    PY_GETSET_TERMINATOR
+};
+
+PY_PLASMA_TYPE(SinglePlane, plConvexIsect::SinglePlane, "plConvexIsect::SinglePlane wrapper")
+
+PY_PLASMA_TYPE_INIT(SinglePlane)
+{
+    pySinglePlane_Type.tp_new = pySinglePlane_new;
+    pySinglePlane_Type.tp_getset = pySinglePlane_GetSet;
+    if (PyType_CheckAndReady(&pySinglePlane_Type) < 0)
+        return nullptr;
+
+    Py_INCREF(&pySinglePlane_Type);
+    return (PyObject*)&pySinglePlane_Type;
+}
+
+PY_PLASMA_IFC_METHODS(SinglePlane, plConvexIsect::SinglePlane)

--- a/Python/PRP/Region/pyVolumeIsect.h
+++ b/Python/PRP/Region/pyVolumeIsect.h
@@ -20,8 +20,8 @@
 #include "PyPlasma.h"
 #include <PRP/Region/plVolumeIsect.h>
 
-PY_WRAP_PLASMA(VolumeIsect, class plVolumeIsect);
-PY_WRAP_PLASMA(SinglePlane, class plConvexIsect::SinglePlane);
-PY_WRAP_PLASMA(ConvexIsect, class plConvexIsect);
+PY_WRAP_PLASMA(VolumeIsect, plVolumeIsect);
+PY_WRAP_PLASMA_VALUE(SinglePlane, plConvexIsect::SinglePlane);
+PY_WRAP_PLASMA(ConvexIsect, plConvexIsect);
 
 #endif

--- a/Python/PRP/Region/pyVolumeIsect.h
+++ b/Python/PRP/Region/pyVolumeIsect.h
@@ -18,8 +18,10 @@
 #define _PYVOLUMEISECT_H
 
 #include "PyPlasma.h"
+#include <PRP/Region/plVolumeIsect.h>
 
 PY_WRAP_PLASMA(VolumeIsect, class plVolumeIsect);
+PY_WRAP_PLASMA(SinglePlane, class plConvexIsect::SinglePlane);
 PY_WRAP_PLASMA(ConvexIsect, class plConvexIsect);
 
 #endif

--- a/core/PRP/Region/plVolumeIsect.cpp
+++ b/core/PRP/Region/plVolumeIsect.cpp
@@ -207,16 +207,13 @@ void plConvexIsect::SinglePlane::prcParse(const pfPrcTag* tag)
         if (child->getName() == "Normal") {
             if (child->hasChildren())
                 fNorm.prcParse(child->getFirstChild());
-        }
-        else if (child->getName() == "Position") {
+        } else if (child->getName() == "Position") {
             if (child->hasChildren())
                 fPos.prcParse(child->getFirstChild());
-        }
-        else if (child->getName() == "WorldNormal") {
+        } else if (child->getName() == "WorldNormal") {
             if (child->hasChildren())
                 fWorldNorm.prcParse(child->getFirstChild());
-        }
-        else {
+        } else {
             throw pfPrcTagException(__FILE__, __LINE__, child->getName());
         }
         child = child->getNextSibling();

--- a/core/PRP/Region/plVolumeIsect.h
+++ b/core/PRP/Region/plVolumeIsect.h
@@ -75,12 +75,32 @@ class PLASMA_DLL plConvexIsect : public plVolumeIsect
     CREATABLE(plConvexIsect, kConvexIsect, plVolumeIsect)
 
 public:
-    struct PLASMA_DLL SinglePlane
+    class PLASMA_DLL SinglePlane
     {
+    protected:
         hsVector3 fNorm, fPos, fWorldNorm;
         float fDist, fWorldDist;
 
+    public:
         SinglePlane() : fDist(), fWorldDist() { }
+
+        void read(hsStream* S);
+        void write(hsStream* S);
+        void prcWrite(pfPrcHelper* prc);
+        void prcParse(const pfPrcTag* tag);
+
+    public:
+        hsVector3 getNorm() const { return fNorm; }
+        hsVector3 getPos() const { return fPos; }
+        hsVector3 getWorldNorm() const { return fWorldNorm; }
+        float getDist() const { return fDist; }
+        float getWorldDist() const { return fWorldDist; }
+
+        void setNorm(hsVector3 norm) { fNorm = norm; }
+        void setPos(hsVector3 pos) { fPos = pos; }
+        void setWorldNorm(hsVector3 worldNorm) { fWorldNorm = worldNorm; }
+        void setDist(float dist) { fDist = dist; }
+        void setWorldDist(float worldDist) { fWorldDist = worldDist; }
     };
 
 protected:
@@ -95,6 +115,9 @@ protected:
     void IPrcParse(const pfPrcTag* tag, plResManager* mgr) HS_OVERRIDE;
 
 public:
+    const std::vector<SinglePlane>& getPlanes() const { return fPlanes; }
+    std::vector<SinglePlane>& getPlanes() { return fPlanes; }
+
     /** Adds or updates a given plane */
     void addPlane(hsVector3 normal, const hsVector3& pos);
 

--- a/core/PRP/Region/plVolumeIsect.h
+++ b/core/PRP/Region/plVolumeIsect.h
@@ -96,9 +96,9 @@ public:
         float getDist() const { return fDist; }
         float getWorldDist() const { return fWorldDist; }
 
-        void setNorm(hsVector3 norm) { fNorm = norm; }
-        void setPos(hsVector3 pos) { fPos = pos; }
-        void setWorldNorm(hsVector3 worldNorm) { fWorldNorm = worldNorm; }
+        void setNorm(hsVector3 norm) { fNorm = std::move(norm); }
+        void setPos(hsVector3 pos) { fPos = std::move(pos); }
+        void setWorldNorm(hsVector3 worldNorm) { fWorldNorm = std::move(worldNorm); }
         void setDist(float dist) { fDist = dist; }
         void setWorldDist(float worldDist) { fWorldDist = worldDist; }
     };
@@ -120,6 +120,7 @@ public:
 
     /** Adds or updates a given plane */
     void addPlane(hsVector3 normal, const hsVector3& pos);
+    void addPlane(SinglePlane plane) { fPlanes.push_back(std::move(plane)); };
 
     /** Calculates worldspace transformation for this volume  */
     void transform(const hsMatrix44& localToWorld, const hsMatrix44& worldToLocal);

--- a/core/PRP/Region/plVolumeIsect.h
+++ b/core/PRP/Region/plVolumeIsect.h
@@ -120,7 +120,7 @@ public:
 
     /** Adds or updates a given plane */
     void addPlane(hsVector3 normal, const hsVector3& pos);
-    void addPlane(SinglePlane plane) { fPlanes.push_back(std::move(plane)); };
+    void addPlane(SinglePlane plane) { fPlanes.emplace_back(std::move(plane)); };
 
     /** Calculates worldspace transformation for this volume  */
     void transform(const hsMatrix44& localToWorld, const hsMatrix44& worldToLocal);


### PR DESCRIPTION
Needed to add support for softvolumes in ZLZ, figured it would be a good time to finally get familiar with writing Python bindings...

Allows accessing the list of planes of a `plConvexIsect`, and retrieve each plane's position, normal, etc.

This is heavily inspired by the bindings for the very similar `plCameraModifier::CamTrans` class. It required making `SinglePlane`'s fields protected and add getter/setter methods, and move some of the PRC read/write logic from `plConvexIsect` into `SinglePlane`.