### PR TITLE
Cmake modernization for vcpkg port.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ endif()
 
 if(MSVC)
     add_definitions("-D_CRT_SECURE_NO_WARNINGS")
-    set(CMAKE_CXX_FLAGS "/wd4996 /wd4244 /wd4251 /wd4351 ${CMAKE_CXX_FLAGS}")
+    set(CMAKE_CXX_FLAGS "/bigobj /wd4996 /wd4244 /wd4251 /wd4351 ${CMAKE_CXX_FLAGS}")
     set(CMAKE_C_FLAGS "/wd4996 /wd4244 /wd4251 /wd4351 ${CMAKE_C_FLAGS}")
 endif()
 

--- a/Python/CMakeLists.txt
+++ b/Python/CMakeLists.txt
@@ -22,7 +22,6 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
     endif()
 endif()
 
-include_directories(${PROJECT_SOURCE_DIR}/core)
 include_directories(${PYTHON_INCLUDE_DIRS})
 include_directories(./)
 

--- a/Tools/CMakeLists.txt
+++ b/Tools/CMakeLists.txt
@@ -1,5 +1,3 @@
-include_directories(${PROJECT_SOURCE_DIR}/core)
-
 try_compile(DIRENT_IS_CONST ${PROJECT_BINARY_DIR}
             ${PROJECT_SOURCE_DIR}/cmake/check_dirent.cpp
             OUTPUT_VARIABLE OUTPUT)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -806,6 +806,10 @@ if(PHYSX_FOUND AND ENABLE_PHYSX)
     target_link_libraries(HSPlasma ${PHYSX_COOKING_LIBRARY})
 endif(PHYSX_FOUND AND ENABLE_PHYSX)
 
+target_include_directories(HSPlasma PUBLIC
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
+                           $<INSTALL_INTERFACE:include/HSPlasma>)
+
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libhsplasma.pc.in.cmake ${CMAKE_CURRENT_BINARY_DIR}/libhsplasma.pc @ONLY)
 
 # Package Installation

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -819,7 +819,14 @@ install(TARGETS HSPlasma
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib
 )
-install(FILES HSPlasmaConfig.cmake DESTINATION share/cmake/HSPlasma)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(HSPlasmaConfig.cmake.in
+                              ${CMAKE_CURRENT_BINARY_DIR}/HSPlasmaConfig.cmake
+                              INSTALL_DESTINATION ${CMAKE_INSTALL_PREFIX}/share/cmake/HSPlasma)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/HSPlasmaConfig.cmake
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/share/cmake/HSPlasma)
+
 install(FILES ${DEBUG_HEADERS} DESTINATION include/HSPlasma/Debug)
 install(FILES ${MATH_HEADERS} DESTINATION include/HSPlasma/Math)
 install(FILES ${PRP_ANIM_HEADERS} DESTINATION include/HSPlasma/PRP/Animation)

--- a/core/HSPlasmaConfig.cmake
+++ b/core/HSPlasmaConfig.cmake
@@ -1,3 +1,0 @@
-get_filename_component(SELF_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-include(${SELF_DIR}/HSPlasma-targets.cmake)
-get_filename_component(HSPlasma_INCLUDE_DIRS "${SELF_DIR}/../../../include/HSPlasma" ABSOLUTE)

--- a/core/HSPlasmaConfig.cmake.in
+++ b/core/HSPlasmaConfig.cmake.in
@@ -1,0 +1,5 @@
+include(${CMAKE_CURRENT_LIST_DIR}/HSPlasma-targets.cmake)
+
+@PACKAGE_INIT@
+
+set_and_check(HSPlasma_INCLUDE_DIRS "${PACKAGE_PREFIX_DIR}/include/HSPlasma")

--- a/net/CMakeLists.txt
+++ b/net/CMakeLists.txt
@@ -104,6 +104,10 @@ if(WIN32)
     target_link_libraries(HSPlasmaNet ws2_32)
 endif(WIN32)
 
+target_include_directories(HSPlasmaNet PUBLIC
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
+                           $<INSTALL_INTERFACE:include/HSPlasmaNet>)
+
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libhsplasmanet.pc.in.cmake ${CMAKE_CURRENT_BINARY_DIR}/libhsplasmanet.pc @ONLY)
 
 # Package installation

--- a/net/CMakeLists.txt
+++ b/net/CMakeLists.txt
@@ -117,7 +117,14 @@ install(TARGETS HSPlasmaNet
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib
 )
-install(FILES HSPlasmaNetConfig.cmake DESTINATION share/cmake/HSPlasmaNet)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(HSPlasmaNetConfig.cmake.in
+                              ${CMAKE_CURRENT_BINARY_DIR}/HSPlasmaNetConfig.cmake
+                              INSTALL_DESTINATION ${CMAKE_INSTALL_PREFIX}/share/cmake/HSPlasmaNet)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/HSPlasmaNetConfig.cmake
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/share/cmake/HSPlasmaNet)
+
 install(FILES ${PN_AUTH_HEADERS} DESTINATION include/HSPlasmaNet/auth)
 install(FILES ${PN_CRYPT_HEADERS} DESTINATION include/HSPlasmaNet/crypt)
 install(FILES ${PN_FILE_HEADERS} DESTINATION include/HSPlasmaNet/file)

--- a/net/HSPlasmaNetConfig.cmake
+++ b/net/HSPlasmaNetConfig.cmake
@@ -1,5 +1,0 @@
-find_package(HSPlasma)
-get_filename_component(SELF_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-get_filename_component(HSPlasmaNet_INCLUDE_DIR "${SELF_DIR}/../../../include/HSPlasmaNet" ABSOLUTE)
-set(HSPlasmaNet_INCLUDE_DIRS ${HSPlasmaNet_INCLUDE_DIR} ${HSPlasma_INCLUDE_DIRS})
-set(HSPlasmaNet_LIBRARIES HSPlasmaNet HSPlasma)

--- a/net/HSPlasmaNetConfig.cmake.in
+++ b/net/HSPlasmaNetConfig.cmake.in
@@ -1,0 +1,8 @@
+include(${CMAKE_CURRENT_LIST_DIR}/HSPlasmaNet-targets.cmake)
+
+@PACKAGE_INIT@
+
+find_package(HSPlasma)
+set_and_check(HSPlasmaNet_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/include/HSPlasmaNet")
+set(HSPlasmaNet_INCLUDE_DIRS ${HSPlasmaNet_INCLUDE_DIR} ${HSPlasma_INCLUDE_DIRS})
+set(HSPlasmaNet_LIBRARIES HSPlasmaNet HSPlasma)


### PR DESCRIPTION
When working on the Microsoft/vcpkg#13174, I discovered that libHSPlasma's cmake config broke when vcpkg attempted to move it to another directory. vcpkg does some peculiar string replacements that depend on our using more modern cmake standards.

Bonuses:
- linking with the HSPlasma target now brings in the include directories for you.
- compile with `/bigobj` on MSVC due to compile errors exposed by vcpkg's CI with plFactory on x64-windows.