### PR TITLE
Fix round-tripping plPythonFileMod through HSPlasma.

### DIFF
--- a/core/PRP/Modifier/plPythonFileMod.cpp
+++ b/core/PRP/Modifier/plPythonFileMod.cpp
@@ -82,10 +82,11 @@ void plPythonParameter::read(hsStream* S, plResManager* mgr)
     case kSubtitle:
         size = S->readInt();
         if (size == 0) {
-            fStrValue = "";
+            fStrValue = ST::null;
             return;
         }
-        fStrValue = S->readStr(size);
+        fStrValue = S->readStr(size - 1);
+        S->readByte();
         return;
     case kNone:
         return;


### PR DESCRIPTION
This fixes an issue in which PythonFileMods with string parameters would be shattered by round-tripping through HSPlasma. The spurious null terminator was being accumulated into the parameter, causing two nulls to be serialized. This caused a null byte to be passed to CWE's Python, resulting in a difficult to debug scenario where we had a seemingly valid string object in Python but the validation in `PyArg_ParseTuple` failed.

To reproduce this issue, load and save Neighborhood_District_nb01.prp in libHSPlasma, then visit the Age in CWE. The resulting error output will look [something like this](https://gist.github.com/Hoikas/4bc4e48b61a0ec89dee7a7ee72a37d57).