### PR TITLE
Clean up uses of the recently deprecated ST::null and ST::null_t

### DIFF
--- a/Tools/src/PlasmaSum.cpp
+++ b/Tools/src/PlasmaSum.cpp
@@ -70,7 +70,7 @@ static ST::string cdUp(ST::string path)
         return up + PATHSEPSTR;
     } else {
         // Relative path specified
-        return up.empty() ? ST::null : up + PATHSEPSTR;
+        return up.empty() ? ST::string() : up + PATHSEPSTR;
     }
 }
 
@@ -354,7 +354,7 @@ int main(int argc, char* argv[])
             }
 
             for (const ST::string& path : addPaths) {
-                std::unique_ptr<hsFileStream> IS = FindFilePath(path, ST::null);
+                std::unique_ptr<hsFileStream> IS = FindFilePath(path, ST::string());
                 if (!IS) {
                     ST::printf(stderr, "Warning: path '{}' not found\n", path);
                     continue;

--- a/Tools/src/prpgrep.cpp
+++ b/Tools/src/prpgrep.cpp
@@ -52,7 +52,7 @@ static ST::string GetLine(hsStream* S)
     }
 
     // Should never get here...
-    return ST::null;
+    return ST::string();
 }
 
 static void DoSearch(hsStream* S, const ST::string& pattern,

--- a/core/Debug/hsExceptions.hpp
+++ b/core/Debug/hsExceptions.hpp
@@ -49,7 +49,7 @@ protected:
 class hsNotImplementedException : public hsException {
 public:
     inline hsNotImplementedException(const char* file, unsigned long line,
-                                     const ST::string& feature = ST::null) HS_NOEXCEPT
+                                     const ST::string& feature = {}) HS_NOEXCEPT
         : hsException(file, line)
     {
         if (feature.empty())
@@ -62,7 +62,7 @@ public:
 class hsBadParamException : public hsException {
 public:
     inline hsBadParamException(const char* file, unsigned long line,
-                               const ST::string& details = ST::null) HS_NOEXCEPT
+                               const ST::string& details = {}) HS_NOEXCEPT
         : hsException(ST_LITERAL("Bad parameter"), file, line)
     {
         if (!details.empty())

--- a/core/PRP/GUI/pfGUITextBoxMod.cpp
+++ b/core/PRP/GUI/pfGUITextBoxMod.cpp
@@ -33,7 +33,7 @@ void pfGUITextBoxMod::read(hsStream* S, plResManager* mgr)
             && S->readBool())
         fLocalizationPath = S->readSafeWStr();
     else
-        fLocalizationPath = ST::null;
+        fLocalizationPath = ST::string();
 }
 
 void pfGUITextBoxMod::write(hsStream* S, plResManager* mgr)

--- a/core/PRP/Misc/plAgeLinkInfo.cpp
+++ b/core/PRP/Misc/plAgeLinkInfo.cpp
@@ -198,13 +198,13 @@ void plAgeInfoStruct::setAgeLanguage(int lang)
 
 void plAgeInfoStruct::clearAgeFilename()
 {
-    fAgeFilename = ST::null;
+    fAgeFilename = ST::string();
     fFlags &= ~kHasAgeFilename;
 }
 
 void plAgeInfoStruct::clearAgeInstanceName()
 {
-    fAgeInstanceName = ST::null;
+    fAgeInstanceName = ST::string();
     fFlags &= ~kHasAgeInstanceName;
 }
 
@@ -216,13 +216,13 @@ void plAgeInfoStruct::clearAgeInstanceGuid()
 
 void plAgeInfoStruct::clearAgeUserDefinedName()
 {
-    fAgeUserDefinedName = ST::null;
+    fAgeUserDefinedName = ST::string();
     fFlags &= ~kHasAgeUserDefinedName;
 }
 
 void plAgeInfoStruct::clearAgeDescription()
 {
-    fAgeDescription = ST::null;
+    fAgeDescription = ST::string();
     fFlags &= ~kHasAgeDescription;
 }
 
@@ -452,7 +452,7 @@ void plAgeLinkStruct::clearAmCCR()
 
 void plAgeLinkStruct::clearParentAgeFilename()
 {
-    fParentAgeFilename = ST::null;
+    fParentAgeFilename = ST::string();
     fFlags &= ~kHasParentAgeFilename;
 }
 

--- a/core/PRP/Modifier/plPythonFileMod.cpp
+++ b/core/PRP/Modifier/plPythonFileMod.cpp
@@ -82,7 +82,7 @@ void plPythonParameter::read(hsStream* S, plResManager* mgr)
     case kSubtitle:
         size = S->readInt();
         if (size == 0) {
-            fStrValue = ST::null;
+            fStrValue = ST::string();
             return;
         }
         fStrValue = S->readStr(size - 1);

--- a/core/Stream/hsStream.cpp
+++ b/core/Stream/hsStream.cpp
@@ -125,7 +125,7 @@ ST::string hsStream::readSafeStr()
         if (ver < MAKE_VERSION(2, 0, 63, 5) && readShort() != 0) {
             skip(-2);
         }
-        return ST::null;
+        return ST::string();
     }
 
     ST::char_buffer result;

--- a/core/Stream/hsTokenStream.cpp
+++ b/core/Stream/hsTokenStream.cpp
@@ -52,7 +52,7 @@ ST::string hsTokenStream::peekNext()
 {
     if (hasNext())
         return fLineTokens.front();
-    return ST::null;
+    return ST::string();
 }
 
 void hsTokenStream::setDelimiters(const char* delims)

--- a/net/auth/pnVaultNode.cpp
+++ b/net/auth/pnVaultNode.cpp
@@ -362,7 +362,7 @@ uint32_t pnVaultNode::getModifyTime() const
 ST::string pnVaultNode::getCreateAgeName() const
 {
     return (fFieldMask & (1<<kCreateAgeName)) != 0
-           ? fCreateAgeName : ST::null;
+           ? fCreateAgeName : ST::string();
 }
 
 plUuid pnVaultNode::getCreateAgeUuid() const
@@ -406,19 +406,19 @@ plUuid pnVaultNode::getUuid(size_t which) const
 ST::string pnVaultNode::getString64(size_t which) const
 {
     return (fFieldMask & (uint64_t)((1<<kString64_1) << which)) != 0
-           ? fString64[which] : ST::null;
+           ? fString64[which] : ST::string();
 }
 
 ST::string pnVaultNode::getIString64(size_t which) const
 {
     return (fFieldMask & (uint64_t)((1<<kIString64_1) << which)) != 0
-           ? fIString64[which] : ST::null;
+           ? fIString64[which] : ST::string();
 }
 
 ST::string pnVaultNode::getText(size_t which) const
 {
     return (fFieldMask & (uint64_t)((1<<kText_1) << which)) != 0
-           ? fText[which] : ST::null;
+           ? fText[which] : ST::string();
 }
 
 plVaultBlob pnVaultNode::getBlob(size_t which) const


### PR DESCRIPTION
NOTE: Intentionally not using `clear()` since that would require an increase of the minimum string_theory version to 3.4.