### PR TITLE
Add a vcpkg manifest.

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -1,0 +1,77 @@
+name: Windows-CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.platform.image }}
+    strategy:
+      matrix:
+        platform:
+          - { image: windows-2019, generator: Visual Studio 16 2019, cmake-arch: Win32, arch: x86, python: 3.9, str: windows-x86-v142 }
+          - { image: windows-2019, generator: Visual Studio 16 2019, cmake-arch: x64, arch: x64, python: 3.8, str: windows-x64-v142 }
+          - { image: windows-2016, generator: Visual Studio 15 2017, cmake-arch: Win32, arch: x86, python: 3.7, str: windows-x86-v141 }
+          - { image: windows-2016, generator: Visual Studio 15 2017, cmake-arch: x64, arch: x64, python: 3.6, str: windows-x64-v141 }
+    env:
+      VCPKG_BINARY_SOURCES: 'clear'
+
+    steps:
+      - name: Checkout HSPlasma
+        uses: actions/checkout@v2
+      - name: Checkout vcpkg
+        uses: actions/checkout@v2
+        with:
+          repository: microsoft/vcpkg
+          path: vcpkg
+
+      # Use actions/cache for our library cache because we use multiple compilers per triplet.
+      # This would cause package hash collisions in the NuGet store, triggering upload race failures.
+      - name: Determine vcpkg rev
+        id: vcpkg-rev
+        run: |
+          Set-Location vcpkg
+          Write-Host "::set-output name=ref::$(git rev-parse HEAD)"
+
+      - name: Restore Dependency Libraries
+        uses: actions/cache@v2
+        with:
+          path: build/vcpkg_installed
+          key: vcpkg-${{ matrix.platform.str }} ${{ steps.vcpkg-rev.outputs.ref }} ${{ hashFiles('vcpkg.json') }}
+          restore-keys: |
+            vcpkg-${{ matrix.platform.str }} ${{ steps.vcpkg-rev.outputs.ref }}
+            vcpkg-${{ matrix.platform.str }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.platform.python }}
+          architecture: ${{ matrix.platform.arch }}
+
+      - name: Configure
+        run: |
+          cmake `
+            -G "${{ matrix.platform.generator }}" -A "${{ matrix.platform.cmake-arch }}" `
+            -DCMAKE_TOOLCHAIN_FILE="${{ github.workspace }}"/vcpkg/scripts/buildsystems/vcpkg.cmake `
+            -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/build/install" `
+            -DVCPKG_TARGET_TRIPLET=${{ matrix.platform.arch }}-windows-static-md `
+            -DPYTHON_EXECUTABLE="${{ env.pythonLocation }}/python.exe" `
+            -DPYTHON_LIBRARY="${{ env.pythonLocation }}/libs/python$("${{ matrix.platform.python }}".replace('.', '')).lib" `
+            -S . -B build
+
+      - name: Build
+        run: |
+          cmake --build build --config Release -j 2
+
+      - name: Install
+        run: |
+          cmake --build build --target INSTALL --config Release -j 2
+
+      - name: Test
+        run: |
+          Set-Location build/install/bin
+          python -c "import PyHSPlasma; print(dir(PyHSPlasma))"
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: libhsplasma-${{ matrix.platform.str }}-py${{ matrix.platform.python }}
+          path: build/install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,22 +18,12 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       VisualStudioVersion: 14.0
       CMAKE_GENERATOR: Visual Studio 14 2015
-      PYTHON_PREFIX: C:\Python36
-      CMAKE_PARAMS: -DPYTHON_INCLUDE_DIR=C:/Python36/include
-        -DPYTHON_LIBRARY=C:/Python36/libs/python36.lib
-        -DPYTHON_EXECUTABLE=C:/Python36/python.exe
+      PYTHON_PREFIX: C:\Python35
+      CMAKE_PARAMS: -DPYTHON_INCLUDE_DIR=C:/Python35/include
+        -DPYTHON_LIBRARY=C:/Python35/libs/python35.lib
+        -DPYTHON_EXECUTABLE=C:/Python35/python.exe
       PREFIX_TARGET: vc2015-x86-static
-      DIST_SUFFIX: '%PREFIX_TARGET%-py36'
-
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      VisualStudioVersion: 15.0
-      CMAKE_GENERATOR: Visual Studio 15 2017 Win64
-      PYTHON_PREFIX: C:\Python36-x64
-      CMAKE_PARAMS: -DPYTHON_INCLUDE_DIR=C:/Python36-x64/include
-        -DPYTHON_LIBRARY=C:/Python36-x64/libs/python36.lib
-        -DPYTHON_EXECUTABLE=C:/Python36-x64/python.exe
-      PREFIX_TARGET: vc2017-x64-static
-      DIST_SUFFIX: '%PREFIX_TARGET%-py36'
+      DIST_SUFFIX: '%PREFIX_TARGET%-py35'
 
 before_build:
   # Download prefix libs

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,16 +15,6 @@ environment:
       PREFIX_TARGET: vc2013-x86-static
       DIST_SUFFIX: '%PREFIX_TARGET%-py27'
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      VisualStudioVersion: 14.0
-      CMAKE_GENERATOR: Visual Studio 14 2015
-      PYTHON_PREFIX: C:\Python35
-      CMAKE_PARAMS: -DPYTHON_INCLUDE_DIR=C:/Python35/include
-        -DPYTHON_LIBRARY=C:/Python35/libs/python35.lib
-        -DPYTHON_EXECUTABLE=C:/Python35/python.exe
-      PREFIX_TARGET: vc2015-x86-static
-      DIST_SUFFIX: '%PREFIX_TARGET%-py35'
-
 before_build:
   # Download prefix libs
   - mkdir build_deps && cd build_deps

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "libhsplasma",
+  "version-string": "2021.02.05",
+  "description": "Cross-platform Plasma data and network library",
+  "dependencies": [
+    "libjpeg-turbo",
+    "libpng",
+    "string-theory",
+    "zlib"
+  ],
+  "features": {
+    "net": {
+      "description": "MOUL networking support",
+      "dependencies": [
+        "openssl"
+      ]
+    }
+  },
+  "default-features": [
+    "net"
+  ]
+}


### PR DESCRIPTION
This adds a vcpkg manifest so there is less need to rely on the old PlasmaPrefix libs and to better enable adding/removing dependencies. I omitted `python3` from the manifest because vcpkg does not integrate with the deprecated `FindPythonLibs` and `FindPythonInterp` modules. I have also moved the "modern" Visual Studio compilers from AppVeyor to GHA to improve CI parallelism. The older compilers/pythons remain on AppVeyor.

Currently, there is still interest in Visual Studio 2013 and Python 3.5 because that is what Blender 2.79b is using on Windows.

~~Still TODO: switch AppVeyor over to using the vcpkg manifest.~~