### PR TITLE
Box bounds: generate indices for PotS/Havok

### DIFF
--- a/core/PRP/Physics/plGenericPhysical.cpp
+++ b/core/PRP/Physics/plGenericPhysical.cpp
@@ -816,18 +816,6 @@ void plGenericPhysical::calcBoxBounds(size_t numPoints, const hsVector3* points)
     hsBounds3Corners corners = bounds.getCorners();
     fVerts.reserve(corners.size());
     std::copy(corners.begin(), corners.end(), std::back_inserter(fVerts));
-    fIndices.insert(fIndices.end(), {
-        0, 2, 1,
-        1, 2, 3,
-        0, 1, 4,
-        1, 5, 4,
-        0, 4, 2,
-        2, 4, 6,
-        1, 3, 7,
-        7, 5, 1,
-        3, 2, 7,
-        2, 6, 7,
-        4, 7, 6,
-        4, 5, 7
-    });
+    fVerts.reserve(std::size(hsBounds3::CornerIndices));
+    std::copy(&hsBounds3::CornerIndices[0], &hsBounds3::CornerIndices[std::size(hsBounds3::CornerIndices)], std::back_inserter(fIndices));
 }

--- a/core/PRP/Physics/plGenericPhysical.cpp
+++ b/core/PRP/Physics/plGenericPhysical.cpp
@@ -816,6 +816,6 @@ void plGenericPhysical::calcBoxBounds(size_t numPoints, const hsVector3* points)
     hsBounds3Corners corners = bounds.getCorners();
     fVerts.reserve(corners.size());
     std::copy(corners.begin(), corners.end(), std::back_inserter(fVerts));
-    fVerts.reserve(std::size(hsBounds3::CornerIndices));
-    std::copy(&hsBounds3::CornerIndices[0], &hsBounds3::CornerIndices[std::size(hsBounds3::CornerIndices)], std::back_inserter(fIndices));
+    fVerts.reserve(hsBounds3::CornerIndices.size());
+    std::copy(hsBounds3::CornerIndices.begin(), hsBounds3::CornerIndices.end(), std::back_inserter(fIndices));
 }

--- a/core/PRP/Physics/plGenericPhysical.cpp
+++ b/core/PRP/Physics/plGenericPhysical.cpp
@@ -816,4 +816,18 @@ void plGenericPhysical::calcBoxBounds(size_t numPoints, const hsVector3* points)
     hsBounds3Corners corners = bounds.getCorners();
     fVerts.reserve(corners.size());
     std::copy(corners.begin(), corners.end(), std::back_inserter(fVerts));
+    fIndices.insert(fIndices.end(), {
+        0, 2, 1,
+        1, 2, 3,
+        0, 1, 4,
+        1, 5, 4,
+        0, 4, 2,
+        2, 4, 6,
+        1, 3, 7,
+        7, 5, 1,
+        3, 2, 7,
+        2, 6, 7,
+        4, 7, 6,
+        4, 5, 7
+    });
 }

--- a/core/PRP/Region/hsBounds.cpp
+++ b/core/PRP/Region/hsBounds.cpp
@@ -64,6 +64,21 @@ void hsBounds::IPrcParse(const pfPrcTag* tag)
 
 
 /* hsBounds3 */
+const unsigned int hsBounds3::CornerIndices[36] = {
+    0, 2, 1,
+    1, 2, 3,
+    0, 1, 4,
+    1, 5, 4,
+    0, 4, 2,
+    2, 4, 6,
+    1, 3, 7,
+    7, 5, 1,
+    3, 2, 7,
+    2, 6, 7,
+    4, 7, 6,
+    4, 5, 7
+};
+
 void hsBounds3::init(const hsVector3& right)
 {
     fMins = right;

--- a/core/PRP/Region/hsBounds.cpp
+++ b/core/PRP/Region/hsBounds.cpp
@@ -64,7 +64,7 @@ void hsBounds::IPrcParse(const pfPrcTag* tag)
 
 
 /* hsBounds3 */
-const unsigned int hsBounds3::CornerIndices[36] = {
+const std::array<unsigned int, 36> hsBounds3::CornerIndices = {
     0, 2, 1,
     1, 2, 3,
     0, 1, 4,

--- a/core/PRP/Region/hsBounds.h
+++ b/core/PRP/Region/hsBounds.h
@@ -88,7 +88,7 @@ public:
 
     const hsVector3& updateCenter();
 
-    static const unsigned int CornerIndices[36];
+    static const std::array<unsigned int, 36> CornerIndices;
 };
 
 

--- a/core/PRP/Region/hsBounds.h
+++ b/core/PRP/Region/hsBounds.h
@@ -87,6 +87,8 @@ public:
     void setCenter(const hsVector3& center) { fCenter = center; }
 
     const hsVector3& updateCenter();
+
+    static const unsigned int CornerIndices[36];
 };
 
 


### PR DESCRIPTION
Found this bug when exporting Ages with Korman. Apparently, the PotS client will crash if box colliders don't have both vertices AND indices (strange, I know...)