### PR TITLE
Remove a couple of unnecessary copy constructors/operators.

### DIFF
--- a/core/Debug/hsExceptions.hpp
+++ b/core/Debug/hsExceptions.hpp
@@ -31,12 +31,6 @@ public:
     inline hsException(const char* file, unsigned long line) HS_NOEXCEPT
         : fWhat("Undefined Plasma Exception"), fFile(file), fLine(line) { }
 
-    inline hsException& operator=(const hsException& other) HS_NOEXCEPT
-    {
-        fWhat = other.fWhat;
-        return *this;
-    }
-
     inline const char* what() const HS_NOEXCEPT HS_OVERRIDE { return fWhat.c_str(); }
     inline const char* File() const HS_NOEXCEPT { return fFile; }
     inline unsigned long Line() const HS_NOEXCEPT { return fLine; }

--- a/core/PRP/Geometry/plCullPoly.h
+++ b/core/PRP/Geometry/plCullPoly.h
@@ -38,9 +38,6 @@ protected:
 
 public:
     plCullPoly() : fFlags(kNone), fDist(), fRadius() { }
-    plCullPoly(const plCullPoly& init)
-        : fFlags(init.fFlags), fVerts(init.fVerts), fNorm(init.fNorm),
-          fCenter(init.fCenter), fDist(init.fDist), fRadius(init.fRadius) { }
 
     void read(hsStream* S);
     void write(hsStream* S);


### PR DESCRIPTION
Clang (rightfully) warns when a class has a copy constructor but no copy `operator=()` or vice versa.  In these specific cases, the default generated version is sufficient (and for the case of `hsException`, the manually specified version missed copying some fields).