### PR TITLE
Fix and test unity builds

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -7,10 +7,10 @@ jobs:
     strategy:
       matrix:
         platform:
-          - { image: windows-2019, generator: Visual Studio 16 2019, cmake-arch: Win32, arch: x86, python: 3.9, str: windows-x86-v142 }
-          - { image: windows-2019, generator: Visual Studio 16 2019, cmake-arch: x64, arch: x64, python: 3.8, str: windows-x64-v142 }
-          - { image: windows-2016, generator: Visual Studio 15 2017, cmake-arch: Win32, arch: x86, python: 3.7, str: windows-x86-v141 }
-          - { image: windows-2016, generator: Visual Studio 15 2017, cmake-arch: x64, arch: x64, python: 3.6, str: windows-x64-v141 }
+          - { image: windows-2019, generator: Visual Studio 16 2019, cmake-arch: Win32, arch: x86, python: 3.9, unity: ON, str: windows-x86-v142 }
+          - { image: windows-2019, generator: Visual Studio 16 2019, cmake-arch: x64, arch: x64, python: 3.8, unity: OFF, str: windows-x64-v142 }
+          - { image: windows-2016, generator: Visual Studio 15 2017, cmake-arch: Win32, arch: x86, python: 3.7, unity: OFF, str: windows-x86-v141 }
+          - { image: windows-2016, generator: Visual Studio 15 2017, cmake-arch: x64, arch: x64, python: 3.6, unity: ON, str: windows-x64-v141 }
     env:
       VCPKG_BINARY_SOURCES: 'clear'
 
@@ -52,6 +52,7 @@ jobs:
             -G "${{ matrix.platform.generator }}" -A "${{ matrix.platform.cmake-arch }}" `
             -DCMAKE_TOOLCHAIN_FILE="${{ github.workspace }}"/vcpkg/scripts/buildsystems/vcpkg.cmake `
             -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/build/install" `
+            -DCMAKE_UNITY_BUILD=${{ matrix.platform.unity }} `
             -DVCPKG_TARGET_TRIPLET=${{ matrix.platform.arch }}-windows-static-md `
             -DPYTHON_EXECUTABLE="${{ env.pythonLocation }}/python.exe" `
             -DPYTHON_LIBRARY="${{ env.pythonLocation }}/libs/python$("${{ matrix.platform.python }}".replace('.', '')).lib" `

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.7)
 project(libhsplasma)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/Python/Sys/pyColor.h
+++ b/Python/Sys/pyColor.h
@@ -15,6 +15,7 @@
  */
 
 #ifndef _PYCOLOR_H
+#define _PYCOLOR_H
 
 #include "PyPlasma.h"
 #include <Sys/hsColor.h>

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -814,6 +814,11 @@ target_include_directories(HSPlasma PUBLIC
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libhsplasma.pc.in.cmake ${CMAKE_CURRENT_BINARY_DIR}/libhsplasma.pc @ONLY)
 
+# Too many ODR violations in squish
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.16)
+    set_property(SOURCE ${SQUISH_SOURCES} PROPERTY SKIP_UNITY_BUILD_INCLUSION TRUE)
+endif()
+
 # Package Installation
 install(TARGETS HSPlasma
         EXPORT HSPlasma-targets

--- a/core/Math/hsMatrix33.cpp
+++ b/core/Math/hsMatrix33.cpp
@@ -91,3 +91,5 @@ void hsMatrix33::prcParse(const pfPrcTag* tag)
     if (*iter++ != "]")
         throw pfPrcParseException(__FILE__, __LINE__, "hsMatrix33 Format error");
 }
+
+#undef DATA

--- a/core/Math/hsMatrix44.cpp
+++ b/core/Math/hsMatrix44.cpp
@@ -389,3 +389,5 @@ ST::string hsMatrix44::toString() const
         DATA(2, 0), DATA(2, 1), DATA(2, 2), DATA(2, 3),
         DATA(3, 0), DATA(3, 1), DATA(3, 2), DATA(3, 3));
 }
+
+#undef DATA

--- a/core/PRP/Message/plConsoleMsg.h
+++ b/core/PRP/Message/plConsoleMsg.h
@@ -14,8 +14,8 @@
  * along with HSPlasma.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _PLENABLEMSG_H
-#define _PLENABLEMSG_H
+#ifndef _PLCONSOLEMSG_H
+#define _PLCONSOLEMSG_H
 
 #include "plMessage.h"
 

--- a/core/PRP/Physics/plPXPhysical.h
+++ b/core/PRP/Physics/plPXPhysical.h
@@ -14,6 +14,9 @@
  * along with HSPlasma.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef _PLPXPHYSICAL_H
+#define _PLPXPHYSICAL_H
+
 /* The enumerations in this file are internal use ONLY.
  * Do NOT include this file in your own code!
  */
@@ -135,3 +138,5 @@ private:
     static void readSuffix(hsStream* S);
     static void skipMaxDependantList(hsStream*S, unsigned int size);
 };
+
+#endif

--- a/core/PRP/Surface/plLayer.h
+++ b/core/PRP/Surface/plLayer.h
@@ -15,6 +15,7 @@
  */
 
 #ifndef _PLLAYER_H
+#define _PLLAYER_H
 
 #include "plLayerInterface.h"
 

--- a/core/Util/plMD5.h
+++ b/core/Util/plMD5.h
@@ -14,6 +14,9 @@
  * along with HSPlasma.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef _PLMD5HASH_H
+#define _PLMD5HASH_H
+
 #include "Stream/hsStream.h"
 #include <string_theory/string>
 
@@ -52,3 +55,5 @@ private:
     plMD5();
     void processBlock(const unsigned char* block);
 };
+
+#endif

--- a/net/auth/AuthMessages.h
+++ b/net/auth/AuthMessages.h
@@ -14,6 +14,9 @@
  * along with HSPlasma.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef _AUTHMESSAGES_H
+#define _AUTHMESSAGES_H
+
 #include "../pnNetMsg.h"
 
 enum /* Client -> Server */
@@ -80,3 +83,5 @@ enum /* Server -> Client */
 
 PLASMANET_DLL const pnNetMsg* GET_Cli2Auth(uint32_t msgId);
 PLASMANET_DLL const pnNetMsg* GET_Auth2Cli(uint32_t msgId);
+
+#endif

--- a/net/file/FileMessages.h
+++ b/net/file/FileMessages.h
@@ -14,6 +14,9 @@
  * along with HSPlasma.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef _FILEMESSAGES_H
+#define _FILEMESSAGES_H
+
 enum /* Client -> Server */
 {
     kCli2File_PingRequest = 0,
@@ -32,3 +35,5 @@ enum /* Server -> Client */
     kFile2Cli_ManifestReply = 20,
     kFile2Cli_FileDownloadReply = 21,
 };
+
+#endif

--- a/net/game/GameMessages.h
+++ b/net/game/GameMessages.h
@@ -14,6 +14,9 @@
  * along with HSPlasma.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef _GAMEMESSAGES_H
+#define _GAMEMESSAGES_H
+
 #include "../pnNetMsg.h"
 
 enum /* Client -> Server */
@@ -30,3 +33,5 @@ enum /* Server -> Client */
 
 PLASMANET_DLL const pnNetMsg* GET_Cli2Game(uint32_t msgId);
 PLASMANET_DLL const pnNetMsg* GET_Game2Cli(uint32_t msgId);
+
+#endif

--- a/net/gate/GateKeeperMessages.h
+++ b/net/gate/GateKeeperMessages.h
@@ -14,6 +14,9 @@
  * along with HSPlasma.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef _GATEKEEPERMESSAGES_H
+#define _GATEKEEPERMESSAGES_H
+
 #include "../pnNetMsg.h"
 
 enum /* Client -> Server */
@@ -30,3 +33,5 @@ enum /* Server -> Client */
 
 PLASMANET_DLL const pnNetMsg* GET_Cli2GateKeeper(uint32_t msgId);
 PLASMANET_DLL const pnNetMsg* GET_GateKeeper2Cli(uint32_t msgId);
+
+#endif


### PR DESCRIPTION
Unity builds bring the MSBuild time to build all of libHSPlasma down to 2m 7s on my machine. The majority of the issues uncovered are faulty (or missing) include guards.