### PR TITLE
Pots boxphys offcentered vertices

### DIFF
--- a/core/PRP/Geometry/plDrawableSpans.cpp
+++ b/core/PRP/Geometry/plDrawableSpans.cpp
@@ -18,6 +18,7 @@
 #include "Debug/plDebug.h"
 #include "Util/hsRadixSort.h"
 #include <algorithm>
+#include <memory>
 
 /* plDISpanIndex */
 plDISpanIndex& plDISpanIndex::operator=(const plDISpanIndex& cpy) {

--- a/core/PRP/Geometry/plDrawableSpans.cpp
+++ b/core/PRP/Geometry/plDrawableSpans.cpp
@@ -528,10 +528,16 @@ void plDrawableSpans::calcBounds()
         hsBounds3Ext world;
 
         world.setFlags(hsBounds3Ext::kAxisAligned);
+        hsVector3* localPoints = new hsVector3[verts.size()];
+        hsVector3* worldPoints = new hsVector3[verts.size()];
         for (size_t j = 0; j < verts.size(); j++) {
-            loc += verts[j].fPos;
-            world += fIcicles[i]->getLocalToWorld().multPoint(verts[j].fPos);
+            localPoints[j] = verts[j].fPos;
+            worldPoints[j] = fIcicles[i]->getLocalToWorld().multPoint(verts[j].fPos);
         }
+        loc.setFromPoints(verts.size(), localPoints);
+        world.setFromPoints(verts.size(), worldPoints);
+        delete[] localPoints;
+        delete[] worldPoints;
         loc.unalign();
 
         fIcicles[i]->setLocalBounds(loc);

--- a/core/PRP/Geometry/plDrawableSpans.cpp
+++ b/core/PRP/Geometry/plDrawableSpans.cpp
@@ -528,16 +528,14 @@ void plDrawableSpans::calcBounds()
         hsBounds3Ext world;
 
         world.setFlags(hsBounds3Ext::kAxisAligned);
-        hsVector3* localPoints = new hsVector3[verts.size()];
-        hsVector3* worldPoints = new hsVector3[verts.size()];
+        auto localPoints = std::make_unique<hsVector3[]>(verts.size());
+        auto worldPoints = std::make_unique<hsVector3[]>(verts.size());
         for (size_t j = 0; j < verts.size(); j++) {
             localPoints[j] = verts[j].fPos;
             worldPoints[j] = fIcicles[i]->getLocalToWorld().multPoint(verts[j].fPos);
         }
-        loc.setFromPoints(verts.size(), localPoints);
-        world.setFromPoints(verts.size(), worldPoints);
-        delete[] localPoints;
-        delete[] worldPoints;
+        loc.setFromPoints(verts.size(), localPoints.get());
+        world.setFromPoints(verts.size(), worldPoints.get());
         loc.unalign();
 
         fIcicles[i]->setLocalBounds(loc);

--- a/core/PRP/Geometry/plDrawableSpans.h
+++ b/core/PRP/Geometry/plDrawableSpans.h
@@ -27,6 +27,7 @@
 #include "plGeometrySpan.h"
 #include <vector>
 #include <list>
+#include <memory>
 
 class PLASMA_DLL plDISpanIndex
 {

--- a/core/PRP/Geometry/plDrawableSpans.h
+++ b/core/PRP/Geometry/plDrawableSpans.h
@@ -27,7 +27,6 @@
 #include "plGeometrySpan.h"
 #include <vector>
 #include <list>
-#include <memory>
 
 class PLASMA_DLL plDISpanIndex
 {

--- a/core/PRP/Physics/plGenericPhysical.cpp
+++ b/core/PRP/Physics/plGenericPhysical.cpp
@@ -804,8 +804,10 @@ void plGenericPhysical::calcBoxBounds(size_t numPoints, const hsVector3* points)
     fVerts.clear();
 
     hsBounds3Ext bounds;
-    bounds.setMins(points[0]);
-    bounds.setMaxs(points[0]);
+    if (numPoints > 0) {
+        bounds.setMins(points[0]);
+        bounds.setMaxs(points[0]);
+    }
     for (size_t i = 0; i < numPoints; ++i)
         bounds += points[i];
     bounds.unalign();

--- a/core/PRP/Physics/plGenericPhysical.cpp
+++ b/core/PRP/Physics/plGenericPhysical.cpp
@@ -790,8 +790,7 @@ void plGenericPhysical::setTMDBuffer(size_t tmdSize, const unsigned char* tmdBuf
 void plGenericPhysical::calcSphereBounds(size_t numPoints, const hsVector3* points)
 {
     hsBounds3 bounds;
-    for (size_t i = 0; i < numPoints; ++i)
-        bounds += points[i];
+    bounds.setFromPoints(numPoints, points);
 
     hsVector3 distance = (bounds.getMaxs() - bounds.getMins()) * .5f;
     fRadius = std::max(distance.X, std::max(distance.Y, distance.Z));
@@ -804,12 +803,7 @@ void plGenericPhysical::calcBoxBounds(size_t numPoints, const hsVector3* points)
     fVerts.clear();
 
     hsBounds3Ext bounds;
-    if (numPoints > 0) {
-        bounds.setMins(points[0]);
-        bounds.setMaxs(points[0]);
-    }
-    for (size_t i = 0; i < numPoints; ++i)
-        bounds += points[i];
+    bounds.setFromPoints(numPoints, points);
     bounds.unalign();
 
     // PhysX and ODE can do true boxes

--- a/core/PRP/Physics/plGenericPhysical.cpp
+++ b/core/PRP/Physics/plGenericPhysical.cpp
@@ -804,6 +804,8 @@ void plGenericPhysical::calcBoxBounds(size_t numPoints, const hsVector3* points)
     fVerts.clear();
 
     hsBounds3Ext bounds;
+    bounds.setMins(points[0]);
+    bounds.setMaxs(points[0]);
     for (size_t i = 0; i < numPoints; ++i)
         bounds += points[i];
     bounds.unalign();

--- a/core/PRP/Region/hsBounds.cpp
+++ b/core/PRP/Region/hsBounds.cpp
@@ -176,6 +176,16 @@ hsBounds3Corners hsBounds3::getCorners() const
     return corners;
 }
 
+void hsBounds3::setFromPoints(unsigned int numPoints, const hsVector3* points)
+{
+    if (numPoints > 0) {
+        setMins(points[0]);
+        setMaxs(points[0]);
+    }
+    for (size_t i = 0; i < numPoints; ++i)
+        (*this) += points[i];
+}
+
 const hsVector3& hsBounds3::updateCenter()
 {
     fCenter.X = (fMins.X + fMaxs.X) / 2.0f;

--- a/core/PRP/Region/hsBounds.cpp
+++ b/core/PRP/Region/hsBounds.cpp
@@ -65,18 +65,18 @@ void hsBounds::IPrcParse(const pfPrcTag* tag)
 
 /* hsBounds3 */
 const std::array<unsigned int, 36> hsBounds3::CornerIndices = {
-    0, 2, 1,
-    1, 2, 3,
-    0, 1, 4,
-    1, 5, 4,
-    0, 4, 2,
-    2, 4, 6,
-    1, 3, 7,
-    7, 5, 1,
-    3, 2, 7,
-    2, 6, 7,
-    4, 7, 6,
-    4, 5, 7
+    0, 1, 2,
+    1, 3, 2,
+    0, 4, 1,
+    1, 4, 5,
+    0, 2, 4,
+    2, 6, 4,
+    1, 7, 3,
+    7, 1, 5,
+    3, 7, 2,
+    2, 7, 6,
+    4, 6, 7,
+    4, 7, 5
 };
 
 void hsBounds3::init(const hsVector3& right)

--- a/core/PRP/Region/hsBounds.cpp
+++ b/core/PRP/Region/hsBounds.cpp
@@ -178,10 +178,8 @@ hsBounds3Corners hsBounds3::getCorners() const
 
 void hsBounds3::setFromPoints(size_t numPoints, const hsVector3* points)
 {
-    if (numPoints > 0) {
-        setMins(points[0]);
-        setMaxs(points[0]);
-    }
+    setMins(points[0]);
+    setMaxs(points[0]);
     for (size_t i = 0; i < numPoints; ++i)
         (*this) += points[i];
 }

--- a/core/PRP/Region/hsBounds.cpp
+++ b/core/PRP/Region/hsBounds.cpp
@@ -176,7 +176,7 @@ hsBounds3Corners hsBounds3::getCorners() const
     return corners;
 }
 
-void hsBounds3::setFromPoints(unsigned int numPoints, const hsVector3* points)
+void hsBounds3::setFromPoints(size_t numPoints, const hsVector3* points)
 {
     if (numPoints > 0) {
         setMins(points[0]);

--- a/core/PRP/Region/hsBounds.h
+++ b/core/PRP/Region/hsBounds.h
@@ -86,7 +86,7 @@ public:
     void setMaxs(const hsVector3& maxs) { fMaxs = maxs; }
     void setCenter(const hsVector3& center) { fCenter = center; }
 
-    void setFromPoints(unsigned int numPoints, const hsVector3* points);
+    void setFromPoints(size_t numPoints, const hsVector3* points);
     const hsVector3& updateCenter();
 
     static const std::array<unsigned int, 36> CornerIndices;

--- a/core/PRP/Region/hsBounds.h
+++ b/core/PRP/Region/hsBounds.h
@@ -86,6 +86,7 @@ public:
     void setMaxs(const hsVector3& maxs) { fMaxs = maxs; }
     void setCenter(const hsVector3& center) { fCenter = center; }
 
+    void setFromPoints(unsigned int numPoints, const hsVector3* points);
     const hsVector3& updateCenter();
 
     static const std::array<unsigned int, 36> CornerIndices;


### PR DESCRIPTION
PotS box bounds again. Generating the vertices/indices creates a box with face normals pointing inwards. Apparently doesn't bother PotS, but looks ugly once reimported in Blender. Fixed by reordering face indices.

Additionally, the algorithm to calculate corner vertices didn't support boxes that didn't encompass the world origin `(0, 0, 0)` due to a small initialization error, which resulted in one of the corner being placed at world origin. This fixes that too.

(If you want to see the wrongly generated vertices without this fix, paste the following code in a Python terminal. The generated box will be wrongly sized to encompass world origin.)
```
import PyHSPlasma as pl
gp = pl.plGenericPhysical()
gp.calcBoxBounds([pl.hsVector3(-1, -1, -1), pl.hsVector3(-.5,-.5, -.5)])
print(gp.verts)
```