### PR TITLE
Fix incorrect terminator in pyRandomSoundModGroup getset list

### DIFF
--- a/Python/PRP/Modifier/pyRandomSoundMod.cpp
+++ b/Python/PRP/Modifier/pyRandomSoundMod.cpp
@@ -85,7 +85,7 @@ PY_PROPERTY_GETSET_DECL(RandomSoundModGroup, indices)
 
 static PyGetSetDef pyRandomSoundModGroup_GetSet[] = {
     pyRandomSoundModGroup_indices_getset,
-    nullptr
+    PY_GETSET_TERMINATOR
 };
 
 PY_PLASMA_TYPE(RandomSoundModGroup, plRandomSoundModGroup, "plRandomSoundModGroup wrapper")


### PR DESCRIPTION
This doesn't appear to break anything, but it causes several warnings to be emitted on newer GCC versions.