### PR TITLE
Improve PRP read performance.

### DIFF
--- a/core/ResManager/plKeyCollector.cpp
+++ b/core/ResManager/plKeyCollector.cpp
@@ -44,7 +44,7 @@ plKeyCollector::~plKeyCollector()
 plKey plKeyCollector::findKey(const plKey& match)
 {
     plKey key;
-    std::vector<plKey> kList = getKeys(match->getLocation(), match->getType());
+    const auto& kList = keys[match->getLocation()][match->getType()];
     for (unsigned int i=0; i < kList.size(); i++) {
         if (*kList[i] == *match) {
             key = kList[i];

--- a/core/Stream/pfSizedStream.cpp
+++ b/core/Stream/pfSizedStream.cpp
@@ -41,7 +41,7 @@ void pfSizedStream::seek(uint32_t pos)
     }
 
     fBase->seek(fBegin + pos);
-    fPos = std::min(pos, fLength);
+    fPos = pos > fLength ? fLength : pos;
 }
 
 void pfSizedStream::skip(int32_t count)

--- a/core/Stream/pfSizedStream.cpp
+++ b/core/Stream/pfSizedStream.cpp
@@ -41,7 +41,7 @@ void pfSizedStream::seek(uint32_t pos)
     }
 
     fBase->seek(fBegin + pos);
-    fPos = pos > fLength ? fLength : pos;
+    fPos = pos;
 }
 
 void pfSizedStream::skip(int32_t count)

--- a/core/Stream/pfSizedStream.h
+++ b/core/Stream/pfSizedStream.h
@@ -19,20 +19,21 @@
 
 #include "hsStream.h"
 
-class PLASMA_DLL pfSizedStream : public hsStream
+class PLASMA_DLL pfSizedStream HS_FINAL : public hsStream
 {
 private:
     hsStream* fBase;
     uint32_t fLength; //!< the length of the substream - not the end position of it!
     uint32_t fBegin;
+    uint32_t fPos;
 
 public:
     pfSizedStream(hsStream* S, uint32_t len);
     ~pfSizedStream() { } // Do NOT free fBase!!!
 
     uint32_t size() const HS_OVERRIDE { return fLength; }
-    uint32_t pos() const HS_OVERRIDE { return fBase->pos() - fBegin; }
-    bool eof() const HS_OVERRIDE { return fBase->eof() || pos() == fLength; }
+    uint32_t pos() const HS_OVERRIDE { return fPos; }
+    bool eof() const HS_OVERRIDE { return fPos == fLength || fBase->eof(); }
 
     void seek(uint32_t pos) HS_OVERRIDE;
     void skip(int32_t count) HS_OVERRIDE;


### PR DESCRIPTION
I tested this by loading the Garrison.age from MOULa. In the beginning, loading Garrison took approximately 34 seconds. After these changes, the time is down to approximately 6.5 seconds to load the Age. The major improvement comes from bypassing many calls to `ftell()`, which tank the performance on Windows. The downside is that this makes `pfSizedStream` a bit less flexible in that it assumes that it owns the underlying base stream and no one else will touch it while it lives.

Benchmark tool I used can be found [here](https://github.com/Hoikas/libhsplasma_bench).