### PR TITLE
Drop support for Python 2.x and 3.0-3.1

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -4,9 +4,6 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python_ver: [2.7, 3.6]
     steps:
       - uses: actions/checkout@v1
       - name: Build string_theory
@@ -21,6 +18,5 @@ jobs:
         run: |
           mkdir build && cd build
           cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/build_deps/prefix" \
-            -DPython_ADDITIONAL_VERSIONS=${{ matrix.python_ver }} -DENABLE_PYTHON=ON \
-            -DENABLE_TOOLS=ON -DENABLE_NET=ON -DENABLE_PHYSX=OFF ..
+            -DENABLE_PYTHON=ON -DENABLE_TOOLS=ON -DENABLE_NET=ON -DENABLE_PHYSX=OFF ..
           make -j2

--- a/Python/Math/pyMatrix44.cpp
+++ b/Python/Math/pyMatrix44.cpp
@@ -402,7 +402,6 @@ PY_PLASMA_TYPE_INIT(Matrix44)
     pyMatrix44_Type.tp_as_mapping = &pyMatrix44_As_Mapping;
     pyMatrix44_Type.tp_methods = pyMatrix44_Methods;
     pyMatrix44_Type.tp_getset = pyMatrix44_GetSet;
-    pyMatrix44_Type.tp_flags |= Py_TPFLAGS_CHECKTYPES;
     if (PyType_CheckAndReady(&pyMatrix44_Type) < 0)
         return nullptr;
 

--- a/Python/Math/pyQuat.cpp
+++ b/Python/Math/pyQuat.cpp
@@ -219,7 +219,6 @@ PY_PLASMA_TYPE_INIT(Quat)
     pyQuat_Type.tp_as_number = &pyQuat_As_Number;
     pyQuat_Type.tp_methods = pyQuat_Methods;
     pyQuat_Type.tp_getset = pyQuat_GetSet;
-    pyQuat_Type.tp_flags |= Py_TPFLAGS_CHECKTYPES;
     if (PyType_CheckAndReady(&pyQuat_Type) < 0)
         return nullptr;
 

--- a/Python/Math/pyVector3.cpp
+++ b/Python/Math/pyVector3.cpp
@@ -243,7 +243,6 @@ PY_PLASMA_TYPE_INIT(Vector3)
     pyVector3_Type.tp_as_number = &pyVector3_As_Number;
     pyVector3_Type.tp_methods = pyVector3_Methods;
     pyVector3_Type.tp_getset = pyVector3_GetSet;
-    pyVector3_Type.tp_flags |= Py_TPFLAGS_CHECKTYPES;
     if (PyType_CheckAndReady(&pyVector3_Type) < 0)
         return nullptr;
 

--- a/Python/Module.cpp
+++ b/Python/Module.cpp
@@ -221,7 +221,6 @@ static PyMethodDef PyHSPlasma_Methods[] = {
     PY_METHOD_TERMINATOR
 };
 
-#if PY_MAJOR_VERSION >= 3
 static PyModuleDef PyHSPlasma_Module = {
     PyModuleDef_HEAD_INIT,      /* m_base */
     "PyHSPlasma",               /* m_name */
@@ -233,7 +232,6 @@ static PyModuleDef PyHSPlasma_Module = {
     nullptr,                    /* m_clear */
     nullptr,                    /* m_free */
 };
-#endif
 
 static void initPyHSPlasma_Constants(PyObject* module)
 {
@@ -455,18 +453,10 @@ static void initPyHSPlasma_Constants(PyObject* module)
     PyModule_AddIntConstant(module, "KEY_UNMAPPED", KEY_UNMAPPED);
 }
 
-#if PY_MAJOR_VERSION >= 3
 PyMODINIT_FUNC PyInit_PyHSPlasma()
 {
     PyObject* module = PyModule_Create(&PyHSPlasma_Module);
 
-#else
-PyMODINIT_FUNC initPyHSPlasma()
-{
-    PyObject* module = Py_InitModule3("PyHSPlasma", PyHSPlasma_Methods,
-                                      "libHSPlasma Python Interface Module");
-
-#endif
     initPyHSPlasma_Constants(module);
 
     /* Debug */
@@ -921,7 +911,5 @@ PyMODINIT_FUNC initPyHSPlasma()
     PyModule_AddObject(module, "plRideAnimatedPhysMsg", Init_pyRideAnimatedPhysMsg_Type());
     PyModule_AddObject(module, "plSimSuppressMsg", Init_pySimSuppressMsg_Type());
 
-#if PY_MAJOR_VERSION >= 3
     return module;
-#endif
 }

--- a/Python/PRP/Animation/pyLineFollowMod.h
+++ b/Python/PRP/Animation/pyLineFollowMod.h
@@ -26,13 +26,13 @@ PY_WRAP_PLASMA(RailCameraMod, plRailCameraMod)
 /* Python property helpers */
 inline PyObject* pyPlasma_convert(plLineFollowMod::FollowMode value)
 {
-    return PyInt_FromLong((long)value);
+    return PyLong_FromLong((long)value);
 }
 
 template <>
 inline int pyPlasma_check<plLineFollowMod::FollowMode>(PyObject* value)
 {
-    return PyAnyInt_Check(value);
+    return PyLong_Check(value);
 }
 
 template <>

--- a/Python/PRP/Avatar/pyAGAnim.h
+++ b/Python/PRP/Avatar/pyAGAnim.h
@@ -26,13 +26,13 @@ PY_WRAP_PLASMA(AgeGlobalAnim, class plAgeGlobalAnim);
 /* Python property helpers */
 inline PyObject* pyPlasma_convert(plAGAnim::BodyUsage value)
 {
-    return PyInt_FromLong((long)value);
+    return PyLong_FromLong((long)value);
 }
 
 template <>
 inline int pyPlasma_check<plAGAnim::BodyUsage>(PyObject* value)
 {
-    return PyAnyInt_Check(value);
+    return PyLong_Check(value);
 }
 
 template <>

--- a/Python/PRP/Avatar/pyClothingItem.h
+++ b/Python/PRP/Avatar/pyClothingItem.h
@@ -23,13 +23,13 @@
 PY_WRAP_PLASMA(ClothingItem, class plClothingItem)
 
 /* Python property helpers */
-inline PyObject* pyPlasma_convert(plClothingItem::Tilesets value) { return PyInt_FromLong((long)value); }
-inline PyObject* pyPlasma_convert(plClothingItem::Types value) { return PyInt_FromLong((long)value); }
-inline PyObject* pyPlasma_convert(plClothingItem::Groups value) { return PyInt_FromLong((long)value); }
+inline PyObject* pyPlasma_convert(plClothingItem::Tilesets value) { return PyLong_FromLong((long)value); }
+inline PyObject* pyPlasma_convert(plClothingItem::Types value) { return PyLong_FromLong((long)value); }
+inline PyObject* pyPlasma_convert(plClothingItem::Groups value) { return PyLong_FromLong((long)value); }
 
-template <> inline int pyPlasma_check<plClothingItem::Tilesets>(PyObject* value) { return PyAnyInt_Check(value); }
-template <> inline int pyPlasma_check<plClothingItem::Types>(PyObject* value) { return PyAnyInt_Check(value); }
-template <> inline int pyPlasma_check<plClothingItem::Groups>(PyObject* value) { return PyAnyInt_Check(value); }
+template <> inline int pyPlasma_check<plClothingItem::Tilesets>(PyObject* value) { return PyLong_Check(value); }
+template <> inline int pyPlasma_check<plClothingItem::Types>(PyObject* value) { return PyLong_Check(value); }
+template <> inline int pyPlasma_check<plClothingItem::Groups>(PyObject* value) { return PyLong_Check(value); }
 
 template <> inline plClothingItem::Tilesets pyPlasma_get(PyObject* value) { return (plClothingItem::Tilesets)PyLong_AsLong(value); }
 template <> inline plClothingItem::Types pyPlasma_get(PyObject* value) { return (plClothingItem::Types)PyLong_AsLong(value); }

--- a/Python/PRP/Avatar/pyMultistageBehMod.h
+++ b/Python/PRP/Avatar/pyMultistageBehMod.h
@@ -26,23 +26,24 @@ PY_WRAP_PLASMA(AnimStage, class plAnimStage);
 /* Python property helpers */
 inline PyObject* pyPlasma_convert(plAnimStage::PlayType value)
 {
-    return PyInt_FromLong((long)value);
+    return PyLong_FromLong((long)value);
 }
 
 inline PyObject* pyPlasma_convert(plAnimStage::AdvanceType value)
 {
-    return PyInt_FromLong((long)value);
+    return PyLong_FromLong((long)value);
 }
 
 template <>
-inline int pyPlasma_check<plAnimStage::PlayType>(PyObject* value) {
-    return PyAnyInt_Check(value);
+inline int pyPlasma_check<plAnimStage::PlayType>(PyObject* value)
+{
+    return PyLong_Check(value);
 }
 
 template <>
 inline int pyPlasma_check<plAnimStage::AdvanceType>(PyObject* value)
 {
-    return PyAnyInt_Check(value);
+    return PyLong_Check(value);
 }
 
 template <>

--- a/Python/PRP/GUI/pyGUIPopUpMenu.h
+++ b/Python/PRP/GUI/pyGUIPopUpMenu.h
@@ -23,9 +23,9 @@
 PY_WRAP_PLASMA(GUIPopUpMenu, class pfGUIPopUpMenu)
 
 /* Python property helpers */
-inline PyObject* pyPlasma_convert(pfGUIPopUpMenu::Alignment value) { return PyInt_FromLong((long)value); }
+inline PyObject* pyPlasma_convert(pfGUIPopUpMenu::Alignment value) { return PyLong_FromLong((long)value); }
 
-template <> inline int pyPlasma_check<pfGUIPopUpMenu::Alignment>(PyObject* value) { return PyAnyInt_Check(value); }
+template <> inline int pyPlasma_check<pfGUIPopUpMenu::Alignment>(PyObject* value) { return PyLong_Check(value); }
 
 template <> inline pfGUIPopUpMenu::Alignment pyPlasma_get(PyObject* value) { return (pfGUIPopUpMenu::Alignment)PyLong_AsLong(value); }
 

--- a/Python/PRP/Message/pySoundMsg.h
+++ b/Python/PRP/Message/pySoundMsg.h
@@ -25,13 +25,13 @@ PY_WRAP_PLASMA(SoundMsg, class plSoundMsg);
 /* Python property helpers */
 inline PyObject* pyPlasma_convert(plSoundMsg::FadeType value)
 {
-    return PyInt_FromLong((long)value);
+    return PyLong_FromLong((long)value);
 }
 
 template <>
 inline int pyPlasma_check<plSoundMsg::FadeType>(PyObject* value)
 {
-    return PyAnyInt_Check(value);
+    return PyLong_Check(value);
 }
 
 template <>

--- a/Python/PRP/Modifier/pyFollowMod.h
+++ b/Python/PRP/Modifier/pyFollowMod.h
@@ -25,13 +25,13 @@ PY_WRAP_PLASMA(FollowMod, class plFollowMod);
 /* Python property helpers */
 inline PyObject* pyPlasma_convert(plFollowMod::FollowLeaderType value)
 {
-    return PyInt_FromLong((long)value);
+    return PyLong_FromLong((long)value);
 }
 
 template <>
 inline int pyPlasma_check<plFollowMod::FollowLeaderType>(PyObject* value)
 {
-    return PyAnyInt_Check(value);
+    return PyLong_Check(value);
 }
 
 template <>

--- a/Python/PRP/Physics/pyPhysical.h
+++ b/Python/PRP/Physics/pyPhysical.h
@@ -29,13 +29,13 @@ PyObject* Init_pySimDefs_Type();
 /* Python property helpers */
 inline PyObject* pyPlasma_convert(plSimDefs::Bounds value)
 {
-    return PyInt_FromLong((long)value);
+    return PyLong_FromLong((long)value);
 }
 
 template <>
 inline int pyPlasma_check<plSimDefs::Bounds>(PyObject* value)
 {
-    return PyAnyInt_Check(value);
+    return PyLong_Check(value);
 }
 
 template <>

--- a/Python/PRP/Region/pyBounds.cpp
+++ b/Python/PRP/Region/pyBounds.cpp
@@ -26,7 +26,7 @@ PY_PLASMA_VALUE_NEW(Bounds, hsBounds)
 PY_METHOD_NOARGS(Bounds, ClassName,
     "Returns the RTTI Class name of this Bounds object")
 {
-    return PyString_FromString(self->fThis->ClassName());
+    return pyPlasma_convert(self->fThis->ClassName());
 }
 
 PY_METHOD_VA(Bounds, read,

--- a/Python/PRP/Surface/pyShader.h
+++ b/Python/PRP/Surface/pyShader.h
@@ -26,13 +26,13 @@ PY_WRAP_PLASMA(Shader, class plShader);
 /* Python property helpers */
 inline PyObject* pyPlasma_convert(plShader::plShaderID value)
 {
-    return PyInt_FromLong((long)value);
+    return PyLong_FromLong((long)value);
 }
 
 template <>
 inline int pyPlasma_check<plShader::plShaderID>(PyObject* value)
 {
-    return PyAnyInt_Check(value);
+    return PyLong_Check(value);
 }
 
 template <>

--- a/Python/PyPlasma.cpp
+++ b/Python/PyPlasma.cpp
@@ -18,11 +18,6 @@
 #include <string_theory/stdio>
 #include <unordered_set>
 
-PyObject* PyString_FromSTString(const ST::string& str)
-{
-    return PyString_FromStringAndSize(str.c_str(), str.size());
-}
-
 PyObject* PyUnicode_FromSTString(const ST::string& str)
 {
     return PyUnicode_DecodeUTF8(str.c_str(), str.size(), nullptr);
@@ -46,7 +41,6 @@ ST::string PyAnyString_AsSTString(PyObject* str)
 
 int PyAnyString_PathDecoder(PyObject* obj, void* str)
 {
-#if (PY_MAJOR_VERSION > 3) || ((PY_MAJOR_VERSION == 3) && (PY_MINOR_VERSION >= 2))
     PyObject* fsConvert;
     if (PyUnicode_FSDecoder(obj, &fsConvert)) {
         *((ST::string*)str) = PyAnyString_AsSTString(fsConvert);
@@ -54,13 +48,6 @@ int PyAnyString_PathDecoder(PyObject* obj, void* str)
         return 1;
     }
     return 0;
-#else
-    if (PyAnyString_Check(obj)) {
-        *((ST::string*)str) = PyAnyString_AsSTString(obj);
-        return 1;
-    }
-    return 0;
-#endif
 }
 
 int PyType_CheckAndReady(PyTypeObject* type)

--- a/Python/PyPlasma.h
+++ b/Python/PyPlasma.h
@@ -53,7 +53,7 @@ struct pySequenceFastRef
     PyObject* get(Py_ssize_t idx) { return PySequence_Fast_GET_ITEM(fObj, idx); }
 };
 
-#if (PY_MAJOR_VERSION < 3) || ((PY_MAJOR_VERSION == 3) && (PY_MINOR_VERSION < 3))
+#if (PY_MAJOR_VERSION < 3) || ((PY_MAJOR_VERSION == 3) && (PY_MINOR_VERSION < 2))
     #error Your Python version is too old.  Only 3.2 and later are supported
 #endif
 

--- a/Python/SDL/pySDL.h
+++ b/Python/SDL/pySDL.h
@@ -26,9 +26,9 @@ PY_WRAP_PLASMA(VarDescriptor, class plVarDescriptor);
 PY_WRAP_PLASMA(StateDescriptor, class plStateDescriptor);
 
 /* Python property helpers */
-inline PyObject* pyPlasma_convert(plVarDescriptor::Type value) { return PyInt_FromLong((long)value); }
+inline PyObject* pyPlasma_convert(plVarDescriptor::Type value) { return PyLong_FromLong((long)value); }
 
-template <> inline int pyPlasma_check<plVarDescriptor::Type>(PyObject* value) { return PyAnyInt_Check(value); }
+template <> inline int pyPlasma_check<plVarDescriptor::Type>(PyObject* value) { return PyLong_Check(value); }
 
 template <> inline plVarDescriptor::Type pyPlasma_get(PyObject* value) { return (plVarDescriptor::Type)PyLong_AsLong(value); }
 

--- a/Python/SDL/pySDLMgr.cpp
+++ b/Python/SDL/pySDLMgr.cpp
@@ -86,7 +86,7 @@ PY_GETSET_GETTER_DECL(SDLMgr, descriptorNames)
     auto descs = self->fThis->GetDescriptorNames();
     PyObject* tup = PyTuple_New(descs.size());
     for (size_t i = 0; i < descs.size(); ++i)
-        PyTuple_SET_ITEM(tup, i, PyString_FromSTString(descs[i]));
+        PyTuple_SET_ITEM(tup, i, PyUnicode_FromSTString(descs[i]));
     return tup;
 }
 

--- a/Python/SDL/pyStateDescriptor.cpp
+++ b/Python/SDL/pyStateDescriptor.cpp
@@ -24,7 +24,7 @@ PY_PLASMA_NEW(StateDescriptor, plStateDescriptor)
 
 PY_PLASMA_REPR_DECL(StateDescriptor)
 {
-    return PyString_FromSTString(ST::format("<plStateDescriptor '{}'>", self->fThis->getName()));
+    return PyUnicode_FromSTString(ST::format("<plStateDescriptor '{}'>", self->fThis->getName()));
 }
 
 PY_PLASMA_LENGTH_DECL(StateDescriptor)
@@ -84,7 +84,7 @@ PY_PLASMA_ASS_SUBSCRIPT_DECL(StateDescriptor)
 
 PY_PLASMA_STR_DECL(StateDescriptor)
 {
-    return PyString_FromSTString(self->fThis->getName());
+    return PyUnicode_FromSTString(self->fThis->getName());
 }
 
 PY_METHOD_VA(StateDescriptor, addVariable,

--- a/Python/SDL/pyVarDescriptor.cpp
+++ b/Python/SDL/pyVarDescriptor.cpp
@@ -24,12 +24,12 @@ PY_PLASMA_NEW(VarDescriptor, plVarDescriptor)
 
 PY_PLASMA_REPR_DECL(VarDescriptor)
 {
-    return PyString_FromSTString(ST::format("<plVarDescriptor '{}'>", self->fThis->getName()));
+    return PyUnicode_FromSTString(ST::format("<plVarDescriptor '{}'>", self->fThis->getName()));
 }
 
 PY_PLASMA_STR_DECL(VarDescriptor)
 {
-    return PyString_FromSTString(self->fThis->getName());
+    return PyUnicode_FromSTString(self->fThis->getName());
 }
 
 PY_PROPERTY(ST::string, VarDescriptor, name, getName, setName);

--- a/Python/Stream/pyStream.h
+++ b/Python/Stream/pyStream.h
@@ -28,13 +28,13 @@ PY_WRAP_PLASMA(RAMStream, class hsRAMStream);
 /* Python property helpers */
 inline PyObject* pyPlasma_convert(const PlasmaVer& value)
 {
-    return PyInt_FromLong((long)(int)value);
+    return PyLong_FromLong((long)(int)value);
 }
 
 template <>
 inline int pyPlasma_check<PlasmaVer>(PyObject* value)
 {
-    return PyAnyInt_Check(value);
+    return PyLong_Check(value);
 }
 
 template <>

--- a/Python/Vault/pyServerGuid.cpp
+++ b/Python/Vault/pyServerGuid.cpp
@@ -80,7 +80,7 @@ PY_PLASMA_ASS_SUBSCRIPT_DECL(ServerGuid)
 
 PY_PLASMA_STR_DECL(ServerGuid)
 {
-    return PyAnyString_FromSTString(self->fThis->toString());
+    return PyUnicode_FromSTString(self->fThis->toString());
 }
 
 PY_PLASMA_RICHCOMPARE_DECL(ServerGuid)

--- a/Python/Vault/pyVaultAgeLinkNode.cpp
+++ b/Python/Vault/pyVaultAgeLinkNode.cpp
@@ -23,8 +23,9 @@ PY_PROPERTY(int, VaultAgeLinkNode, volatile, getVolatile, setVolatile)
 
 PY_GETSET_GETTER_DECL(VaultAgeLinkNode, spawnPoints)
 {
-    return PyString_FromStringAndSize((const char*)self->fThis->getSpawnPoints().getData(),
-                                      self->fThis->getSpawnPoints().getSize());
+    return PyUnicode_DecodeUTF8((const char*)self->fThis->getSpawnPoints().getData(),
+                                self->fThis->getSpawnPoints().getSize(),
+                                nullptr);
 }
 
 PY_GETSET_SETTER_DECL(VaultAgeLinkNode, spawnPoints)

--- a/Python/Vault/pyVaultTextNoteNode.cpp
+++ b/Python/Vault/pyVaultTextNoteNode.cpp
@@ -24,8 +24,9 @@ PY_PROPERTY(ST::string, VaultTextNoteNode, noteTitle, getNoteTitle, setNoteTitle
 
 PY_GETSET_GETTER_DECL(VaultTextNoteNode, noteContents)
 {
-    return PyString_FromStringAndSize((const char*)self->fThis->getNoteContents().getData(),
-                                      self->fThis->getNoteContents().getSize());
+    return PyUnicode_DecodeUTF8((const char*)self->fThis->getNoteContents().getData(),
+                                self->fThis->getNoteContents().getSize(),
+                                nullptr);
 }
 
 PY_GETSET_SETTER_DECL(VaultTextNoteNode, noteContents)

--- a/Python/scripts/prp-checkfiles.py
+++ b/Python/scripts/prp-checkfiles.py
@@ -32,7 +32,8 @@ def readObjects(location):
     data = []
     # read all the objects
     for type in rm.getTypes(location):
-        while len(data) <= type: data.append({}) # fill array
+        while len(data) <= type:
+            data.append({}) # fill array
         for key in rm.getKeys(location, type):
             if key.exists() and key.isLoaded():
                 data[type][key.name] = key.object.stub.getData()
@@ -40,24 +41,25 @@ def readObjects(location):
 
 
 def checkObjectsEqual(objs1, objs2, ignorePhysics):
-    if len(objs1) != len(objs2): raise Exception('Number of types changed')
+    if len(objs1) != len(objs2):
+        raise Exception('Number of types changed')
     for type in range(0, len(objs1)):
         typeName = PyHSPlasma.plFactory.ClassName(type, rm.getVer())
         # compare the objects of this type
         for name in objs1[type].keys():
             if not name in objs2[type].keys():
-                print 'Type [%04X]%s, object %s missing' % (type, typeName, name)
+                print('Type [%04X]%s, object %s missing' % (type, typeName, name))
             if ignorePhysics and type == PyHSPlasma.plFactory.kGenericPhysical: continue
             obj1 = objs1[type][name]
             obj2 = objs2[type][name]
             if len(obj1) != len(obj2):
-                print 'Type [%04X]%s, object %s changed changed size (%d => %d)' % (type, typeName, name, len(obj1), len(obj2))
+                print('Type [%04X]%s, object %s changed changed size (%d => %d)' % (type, typeName, name, len(obj1), len(obj2)))
             if obj1 != obj2:
-                print 'Type [%04X]%s, object %s changed but stay same size' % (type, typeName, name)
+                print('Type [%04X]%s, object %s changed but stay same size' % (type, typeName, name))
         # check if something got added
         for name in objs2[type].keys():
             if not name in objs1[type].keys():
-                print 'Type [%04X]%s, object %s added' % (type, typeName, name)
+                print('Type [%04X]%s, object %s added' % (type, typeName, name))
 
 
 def compareFiles(file1, file2, ignorePhysics):
@@ -126,6 +128,6 @@ for files in args:
                     raise Exception("Unable to completely load age "+age.name+": Can't find page "+str(loc))
             rm.UnloadAge(age.name)
         else:
-            print "Error: Unknown file type!";
+            print("Error: Unknown file type!")
 overprint("Done!")
 sys.stdout.write("\n")

--- a/Python/scripts/prp-extractobject.py
+++ b/Python/scripts/prp-extractobject.py
@@ -24,14 +24,14 @@ import sys
 import PyHSPlasma
 
 if len(sys.argv) != 5:
-    print "Usage: %s filename typename objectname outfile" % sys.argv[0]
+    print("Usage: %s filename typename objectname outfile" % sys.argv[0])
     sys.exit(0)
 
 rm = PyHSPlasma.plResManager()
 page = rm.ReadPage(sys.argv[1], True)
 type = PyHSPlasma.plFactory.ClassIndex(sys.argv[2])
 if type < 0:
-    print "Type '%s' is invalid" % sys.argv[2]
+    print("Type '%s' is invalid" % sys.argv[2])
     sys.exit(1)
 keys = rm.getKeys(page.location, type)
 
@@ -43,8 +43,8 @@ for key in keys:
     f = open(sys.argv[4], 'w')
     f.write(data)
     f.close()
-    print "Data successfully written to %s" % sys.argv[4]
+    print("Data successfully written to %s" % sys.argv[4])
     sys.exit(0)
 
-print "Could not find object %s of type %s" % (sys.argv[3], sys.argv[2])
+print("Could not find object %s of type %s" % (sys.argv[3], sys.argv[2]))
 sys.exit(1)

--- a/Python/scripts/prp-listobjects.py
+++ b/Python/scripts/prp-listobjects.py
@@ -23,7 +23,7 @@
 import PyHSPlasma, sys
 
 if not len(sys.argv) in [2, 3]:
-    print "Usage: %s filename [typename]" % sys.argv[0]
+    print("Usage: %s filename [typename]" % sys.argv[0])
     sys.exit(0)
 
 rm = PyHSPlasma.plResManager()
@@ -33,9 +33,9 @@ if len(sys.argv) <= 2: # default to scene objects
 else:
     type = PyHSPlasma.plFactory.ClassIndex(sys.argv[2])
     if type < 0:
-        print "Type '%s' is invalid" % sys.argv[2]
+        print("Type '%s' is invalid" % sys.argv[2])
         sys.exit(1)
 keys = rm.getKeys(page.location, type)
 
 for key in keys:
-    print key.name
+    print(key.name)

--- a/Python/scripts/sounddecompress.py
+++ b/Python/scripts/sounddecompress.py
@@ -33,9 +33,6 @@
         (Override base Uru and output directory only)
 """
 
-
-from __future__ import print_function
-
 import os
 import sys
 import glob
@@ -114,9 +111,12 @@ def getDecompressQueue(datadir):
                             else:
                                 channelOptions = {}
 
-                            if (soundBuffer.flags & soundBuffer.kOnlyRightChannel): channel = channelOptions["Right"] = True
-                            if (soundBuffer.flags & soundBuffer.kOnlyLeftChannel): channel = channelOptions["Left"] = True
-                            if channelOptions == {}: channelOptions["Both"] = True
+                            if (soundBuffer.flags & soundBuffer.kOnlyRightChannel):
+                                channel = channelOptions["Right"] = True
+                            if (soundBuffer.flags & soundBuffer.kOnlyLeftChannel):
+                                channel = channelOptions["Left"] = True
+                            if channelOptions == {}:
+                                channelOptions["Both"] = True
 
                             if not (soundBuffer.flags & soundBuffer.kStreamCompressed):
                                 queue[soundBuffer.fileName] = channelOptions
@@ -202,9 +202,9 @@ def writeQueueToXML(outfile):
             sfNode = root.createElement("soundfile")
             sfNode.setAttribute("name", soundfile)
             coNode = root.createElement("channeloutputs")
-            coNode.setAttribute("stereo", str(queue[soundfile].has_key("Both") and queue[soundfile]["Both"]))
-            coNode.setAttribute("left", str(queue[soundfile].has_key("Left") and queue[soundfile]["Left"]))
-            coNode.setAttribute("right", str(queue[soundfile].has_key("Right") and queue[soundfile]["Right"]))
+            coNode.setAttribute("stereo", str("Both" in queue[soundfile] and queue[soundfile]["Both"]))
+            coNode.setAttribute("left", str("Left" in queue[soundfile] and queue[soundfile]["Left"]))
+            coNode.setAttribute("right", str("Right" in queue[soundfile] and queue[soundfile]["Right"]))
             sfNode.appendChild(coNode)
             root.documentElement.appendChild(sfNode)
 

--- a/Python/scripts/tracekey.py
+++ b/Python/scripts/tracekey.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with HSPlasma.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import print_function
 from PyHSPlasma import *
 import sys
 

--- a/Python/scripts/wxSoundDecompress.py
+++ b/Python/scripts/wxSoundDecompress.py
@@ -441,7 +441,7 @@ class BuildQueueThread(threading.Thread):
                                     channel = channelOptions["Right"] = True
                                 if (soundBuffer.flags & soundBuffer.kOnlyLeftChannel):
                                     channel = channelOptions["Left"] = True
-                                if channelOptions == {}:
+                                if not channelOptions:
                                     channelOptions["Both"] = True
 
                                 if not (soundBuffer.flags & soundBuffer.kStreamCompressed):

--- a/Python/scripts/wxSoundDecompress.py
+++ b/Python/scripts/wxSoundDecompress.py
@@ -437,9 +437,12 @@ class BuildQueueThread(threading.Thread):
                                 else:
                                     channelOptions = {}
 
-                                if (soundBuffer.flags & soundBuffer.kOnlyRightChannel): channel = channelOptions["Right"] = True
-                                if (soundBuffer.flags & soundBuffer.kOnlyLeftChannel): channel = channelOptions["Left"] = True
-                                if channelOptions == {}: channelOptions["Both"] = True
+                                if (soundBuffer.flags & soundBuffer.kOnlyRightChannel):
+                                    channel = channelOptions["Right"] = True
+                                if (soundBuffer.flags & soundBuffer.kOnlyLeftChannel):
+                                    channel = channelOptions["Left"] = True
+                                if channelOptions == {}:
+                                    channelOptions["Both"] = True
 
                                 if not (soundBuffer.flags & soundBuffer.kStreamCompressed):
                                     self._queue[soundBuffer.fileName] = channelOptions

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For libHSPlasmaNet
 
 For PyHSPlasma
 
-- [Python 2.6+ or 3.0+](http://www.python.org/)
+- [Python 3.2+](http://www.python.org/)
 
 You will also need CMake and a C++ compiler with at least some C++11 support.
 The following compiler versions are currently supported (others may work,

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,12 +8,12 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
       VisualStudioVersion: 12.0
       CMAKE_GENERATOR: Visual Studio 12 2013
-      PYTHON_PREFIX: C:\Python27
-      CMAKE_PARAMS: -DPYTHON_INCLUDE_DIR=C:/Python27/include
-        -DPYTHON_LIBRARY=C:/Python27/libs/python27.lib
-        -DPYTHON_EXECUTABLE=C:/Python27/python.exe
+      PYTHON_PREFIX: C:\Python34
+      CMAKE_PARAMS: -DPYTHON_INCLUDE_DIR=C:/Python34/include
+        -DPYTHON_LIBRARY=C:/Python34/libs/python34.lib
+        -DPYTHON_EXECUTABLE=C:/Python34/python.exe
       PREFIX_TARGET: vc2013-x86-static
-      DIST_SUFFIX: '%PREFIX_TARGET%-py27'
+      DIST_SUFFIX: '%PREFIX_TARGET%-py34'
 
 before_build:
   # Download prefix libs


### PR DESCRIPTION
Drop support for Python versions prior to 3.2, which simplifies the bindings a bit.

This also ports the included scripts to Python 3.x syntax, although the script changes are not tested.