### PR TITLE
Fix EoA animation timing

### DIFF
--- a/core/PRP/Animation/hsKeys.cpp
+++ b/core/PRP/Animation/hsKeys.cpp
@@ -42,7 +42,7 @@ void hsKeyFrame::read(hsStream* S, unsigned int type)
             fType == kScaleKeyFrame) && ((fFlags & kBezController) != 0))
             fType++;    //  Use Bezier version
     } else if (S->getVer().isNewPlasma()) {
-        setFrame(S->readFloat());
+        setFrameTime(S->readFloat());
     } else {
         setFrame((unsigned int)S->readShort());
     }


### PR DESCRIPTION
Doobes reported that animations imported from EoA by ZLZ were too fast. Apparently this is caused by this very simple typo (confusion between frame time and frame number).

You can quickly check the current wrong behavior by viewing the PRC for any ATC anim from `Direbo_RestAge.prp` in PrpShop. Most keyframes overlap.