### PR TITLE
Fix insidious ObjID issues.

### DIFF
--- a/core/ResManager/plKeyCollector.cpp
+++ b/core/ResManager/plKeyCollector.cpp
@@ -234,6 +234,7 @@ void plKeyCollector::ChangeLocation(const plLocation& from, const plLocation& to
             for (size_t j=0; j<keys[from][i].size(); j++) {
                 keys[to][i][begin+j] = keys[from][i][j];
                 keys[to][i][begin+j]->setLocation(to);
+                keys[to][i][begin+j]->setID(begin+j+1);
             }
         }
     }
@@ -259,5 +260,6 @@ void plKeyCollector::MoveKey(const plKey& key, const plLocation& to)
     if (keys[key->getLocation()].empty())
         keys.erase(key->getLocation());
     key->setLocation(to);
-    add(key);
+    keys[to][key->getType()].push_back(key);
+    key->setID(keys[to][key->getType()].size());
 }

--- a/core/ResManager/plKeyCollector.cpp
+++ b/core/ResManager/plKeyCollector.cpp
@@ -147,10 +147,10 @@ void plKeyCollector::reserveKeySpace(const plLocation& loc, short type, int num)
 void plKeyCollector::sortKeys(const plLocation& loc)
 {
     std::vector<short> types = getTypes(loc);
-    for (unsigned short type : types) {
+    for (short type : types) {
         std::sort(keys[loc][type].begin(), keys[loc][type].end(),
             [](const plKey& a, const plKey& b) { return a->getID() < b->getID(); });
-        for (unsigned int i = 0; i < keys[loc][type].size(); ++i) {
+        for (size_t i = 0; i < keys[loc][type].size(); ++i) {
             keys[loc][type][i]->setID(i + 1);
         }
     }

--- a/core/ResManager/plKeyCollector.cpp
+++ b/core/ResManager/plKeyCollector.cpp
@@ -147,20 +147,12 @@ void plKeyCollector::reserveKeySpace(const plLocation& loc, short type, int num)
 void plKeyCollector::sortKeys(const plLocation& loc)
 {
     std::vector<short> types = getTypes(loc);
-    std::list<plKey> sortKeys;
-    for (unsigned int i=0; i<types.size(); i++) {
-        sortKeys.clear();
-        unsigned int id = 1;
-        unsigned int nKeys = keys[loc][types[i]].size();
-        for (unsigned int j=0; j<nKeys; j++) {
-            for (unsigned int k=0; k<nKeys; k++) {
-                if (keys[loc][types[i]][k]->getID() == id) {
-                    sortKeys.push_back(keys[loc][types[i]][k]);
-                    id++;
-                }
-            }
+    for (unsigned short type : types) {
+        std::sort(keys[loc][type].begin(), keys[loc][type].end(),
+            [](const plKey& a, const plKey& b) { return a->getID() < b->getID(); });
+        for (unsigned int i = 0; i < keys[loc][type].size(); ++i) {
+            keys[loc][type][i]->setID(i + 1);
         }
-        keys[loc][types[i]] = std::vector<plKey>(sortKeys.begin(), sortKeys.end());
     }
 }
 

--- a/core/ResManager/plResManager.cpp
+++ b/core/ResManager/plResManager.cpp
@@ -632,7 +632,13 @@ unsigned int plResManager::WriteObjects(hsStream* S, const plLocation& loc)
 #endif
         for (unsigned int j=0; j<kList.size(); j++) {
             kList[j]->setFileOff(S->pos());
-            kList[j]->setID(j + 1);
+            unsigned int objID = j + 1;
+            if (kList[j]->getID() != objID) {
+                plDebug::Warning("Object ID changing ({} -> {}) during write: [{04X}]:{}",
+                                 kList[j]->getID(), objID, kList[j]->getType(),
+                                 kList[j]->getUoid().getName());
+            }
+            kList[j]->setID(objID);
             if (kList[j]->getObj()) {
                 try {
 #ifdef RMTRACE

--- a/core/ResManager/plResManager.cpp
+++ b/core/ResManager/plResManager.cpp
@@ -506,6 +506,8 @@ unsigned int plResManager::ReadKeyring(hsStream* S, const plLocation& loc)
         }
     }
 
+    keys.sortKeys(loc);
+
     return pageKeys;
 }
 


### PR DESCRIPTION
This PR is born of finding that, in certain circumstances, loading and saving the entire Kadish Age with libHSPlasma would crash CWE either on initial load or on unload. The circumstances of the load/save was effectively an arbitrarily ordered set of calls to `ReadPage()` and `WritePage()` (specifically, not using `ReadAge()`).

libHSPlasma unconditionally sets the ObjID for each keyed object when it writes that object to a PRP to `position in key collector + 1`. This reveals some assumptions:
- all PRP keyrings are maintained in order of their obj ID
- no ObjIDs are skipped in the set of objects contained in each PRP.

Unfortunately, these assumptions are demonstrably false. For example, if you open an Age in PRPShop and resave just the Textures PRP, the object IDs will change, shattering all the texture references in the PRP. This is not noticeable on an internal MOUL client, however, it very quickly becomes noticeable on an external client or with H-uru/Plasma#957 where keys are (for the most part) simply returned by ObjID and not double-checked by string name. Because the ObjIDs are not "fixed" until write-time, there is a race condition in that the Textures.prp must be saved first for all the other PRPs to get the correct ObjIDs.

This PR elects to forcibly reset the ObjIDs when a keyring is read. This is effectively the same as the previous behavior, except it removes the race condition and it catches problematic pages generated by plPageOptimizer, which can apparently have gaps in their ObjIDs. Cross-page references can still be shattered on EOA and MOUL if you're not working on (and saving) the whole Age at once, but the process is now much more resilient.

Also corrects issues where `ChangeLocation()` and `MoveKey()` did not update the ObjID.


