### PR TITLE
Fix plLayerAnimationBase::getRuntimeCtl().

### DIFF
--- a/core/PRP/Surface/plLayerAnimation.h
+++ b/core/PRP/Surface/plLayerAnimation.h
@@ -49,7 +49,7 @@ protected:
 
 public:
     plController* getPreshadeCtl() const { return fPreshadeColorCtl; }
-    plController* getRuntimeCtl() const { return fSpecularColorCtl; }
+    plController* getRuntimeCtl() const { return fRuntimeColorCtl; }
     plController* getAmbientCtl() const { return fAmbientColorCtl; }
     plController* getSpecularCtl() const { return fSpecularColorCtl; }
     plController* getOpacityCtl() const { return fOpacityCtl; }


### PR DESCRIPTION
Way too much time was spent trying to figure out why runtime animation were "empty".