### PR TITLE
Add missing server messages

### DIFF
--- a/net/auth/AuthMessages.cpp
+++ b/net/auth/AuthMessages.cpp
@@ -349,6 +349,14 @@ static pnNetMsgField Cli2Auth_AgeRequestEx_Fields[] = {
 };
 MAKE_NETMSG(Cli2Auth_AgeRequestEx)
 
+static pnNetMsgField Cli2Auth_ScoreGetHighScores_Fields[] = {
+    { kFieldInteger,    0, sizeof(uint32_t)   },  // Trans ID
+    { kFieldInteger,    0, sizeof(uint32_t)   },  // Age ID
+    { kFieldInteger,    0, sizeof(uint32_t)   },  // Max scores
+    { kFieldString,    64, sizeof(char16_t)   },  // Game Name
+};
+MAKE_NETMSG(Cli2Auth_ScoreGetHighScores)
+
 
 /* Server -> Client */
 static pnNetMsgField Auth2Cli_PingReply_Fields[] = {
@@ -675,6 +683,21 @@ static pnNetMsgField Auth2Cli_AgeReplyEx_Fields[] = {
 };
 MAKE_NETMSG(Auth2Cli_AgeReplyEx)
 
+static pnNetMsgField Auth2Cli_ScoreGetHighScoresReply_Fields[] = {
+    { kFieldInteger,    0, sizeof(uint32_t)   },  // Trans ID
+    { kFieldInteger,    0, sizeof(uint32_t)   },  // Result
+    { kFieldInteger,    0, sizeof(uint32_t)   },  // Score Count
+    { kFieldVarCount,   0, sizeof(uint8_t)    },  // Score Data
+    { kFieldVarPtr,     0, 0                  },
+};
+MAKE_NETMSG(Auth2Cli_ScoreGetHighScoresReply)
+
+static pnNetMsgField Auth2Cli_ServerCaps_Fields[] = {
+    { kFieldVarCount,   0, sizeof(uint8_t)    },  // Server Caps
+    { kFieldVarPtr,     0, 0                  },
+};
+MAKE_NETMSG(Auth2Cli_ServerCaps)
+
 
 const pnNetMsg* GET_Cli2Auth(uint32_t msgId)
 {
@@ -736,6 +759,7 @@ const pnNetMsg* GET_Cli2Auth(uint32_t msgId)
     };
     static const pnNetMsg* s_messagesEx[] = {
         &Cli2Auth_AgeRequestEx,
+        &Cli2Auth_ScoreGetHighScores,
     };
     if (msgId >= 0x1000)
         return (msgId < kCli2Auth_LastExMessage ? s_messagesEx[msgId & 0x0FFF] : nullptr);
@@ -798,6 +822,8 @@ const pnNetMsg* GET_Auth2Cli(uint32_t msgId)
     };
     static const pnNetMsg* s_messagesEx[] = {
         &Auth2Cli_AgeReplyEx,
+        &Auth2Cli_ScoreGetHighScoresReply,
+        &Auth2Cli_ServerCaps,
     };
     if (msgId >= 0x1000)
         return (msgId < kAuth2Cli_LastExMessage ? s_messagesEx[msgId & 0x0FFF] : nullptr);

--- a/net/auth/AuthMessages.h
+++ b/net/auth/AuthMessages.h
@@ -49,6 +49,7 @@ enum /* Client -> Server */
     kCli2Auth_ScoreGetRanks, kCli2Auth_AcctExistsRequest,
     kCli2Auth_LastMessage,
     kCli2Auth_AgeRequestEx = 0x1000,
+    kCli2Auth_ScoreGetHighScores,
     kCli2Auth_LastExMessage,
 };
 
@@ -78,6 +79,8 @@ enum /* Server -> Client */
     kAuth2Cli_ScoreGetRanksReply, kAuth2Cli_AcctExistsReply,
     kAuth2Cli_LastMessage,
     kAuth2Cli_AgeReplyEx = 0x1000,
+    kAuth2Cli_ScoreGetHighScoresReply,
+    kAuth2Cli_ServerCaps,
     kAuth2Cli_LastExMessage,
 };
 

--- a/net/auth/pnAuthClient.cpp
+++ b/net/auth/pnAuthClient.cpp
@@ -247,7 +247,8 @@ bool pnAuthClient::Dispatch::dispatch(pnSocket* sock)
         {
             size_t scoreCount = msgbuf[2].fUint;
             pnNetGameScore* scores = new pnNetGameScore[scoreCount];
-            const uint8_t* buf = msgbuf[3].fData;
+            const uint8_t* buf = msgbuf[4].fData;
+            size_t bufLen = msgbuf[3].fUint;
             for (size_t i=0; i<scoreCount; i++) {
                 scores[i].fScoreId     = NCReadBuffer<uint32_t>(buf);
                 scores[i].fOwnerId     = NCReadBuffer<uint32_t>(buf);

--- a/net/auth/pnAuthClient.cpp
+++ b/net/auth/pnAuthClient.cpp
@@ -316,6 +316,36 @@ bool pnAuthClient::Dispatch::dispatch(pnSocket* sock)
             }
         }
         break;
+    case kAuth2Cli_ScoreGetHighScoresReply:
+        {
+            size_t scoreCount = msgbuf[2].fUint;
+            pnNetGameScore* scores = new pnNetGameScore[scoreCount];
+            const uint8_t* buf = msgbuf[4].fData;
+            size_t bufLen = msgbuf[3].fUint;
+            for (size_t i=0; i<scoreCount; i++) {
+                scores[i].fScoreId     = NCReadBuffer<uint32_t>(buf);
+                scores[i].fOwnerId     = NCReadBuffer<uint32_t>(buf);
+                scores[i].fCreatedTime = NCReadBuffer<uint32_t>(buf);
+                scores[i].fGameType    = NCReadBuffer<uint32_t>(buf);
+                scores[i].fValue       = NCReadBuffer<int32_t>(buf);
+                size_t strDataSize     = NCReadBuffer<uint32_t>(buf);
+                scores[i].fGameName    = ST::string::from_utf16((const char16_t*)buf);
+                buf += strDataSize;
+            }
+            fReceiver->onScoreGetHighScoresReply(msgbuf[0].fUint, (ENetError)msgbuf[1].fUint,
+                            scoreCount, scores);
+            delete[] scores;
+        }
+        break;
+    case kAuth2Cli_ServerCaps:
+        {
+            hsRAMStream rs(PlasmaVer::pvMoul);
+            rs.copyFrom(msgbuf[1].fData, msgbuf[0].fUint);
+            hsBitVector caps;
+            caps.read(&rs);
+            fReceiver->onServerCaps(caps);
+        }
+        break;
     }
     NCFreeMessage(msgbuf, msgDesc);
     return true;
@@ -1079,6 +1109,20 @@ void pnAuthClient::propagateMessage(plCreatable* pCre)
     NCFreeMessage(msg, desc);
 }
 
+uint32_t pnAuthClient::sendScoreGetHighScores(uint32_t ageId, uint32_t maxScores, const ST::string &gameName)
+{
+    const pnNetMsg* desc = GET_Cli2Auth(kCli2Auth_ScoreGetHighScores);
+    msgparm_t* msg = NCAllocMessage(desc);
+    uint32_t transId = nextTransId();
+    msg[0].fUint = transId;
+    msg[1].fUint = ageId;
+    msg[2].fUint = maxScores;
+    msg[3].fString = NCCopyString(gameName);
+    fSock->sendMsg(msg, desc);
+    NCFreeMessage(msg, desc);
+    return transId;
+}
+
 void pnAuthClient::onPingReply(uint32_t transId, uint32_t pingTimeMs)
 {
     plDebug::Warning("Warning: Ignoring Auth2Cli_PingReply");
@@ -1331,4 +1375,14 @@ void pnAuthClient::onScoreGetRanksReply(uint32_t transId, ENetError result,
 void pnAuthClient::onPropagateMessage(plCreatable* msg)
 {
     plDebug::Warning("Warning: Ignoring Auth2Cli_PropagateBuffer");
+}
+
+void pnAuthClient::onScoreGetHighScoresReply(uint32_t transId, ENetError result, uint32_t score_count, const pnNetGameScore* scores)
+{
+    plDebug::Warning("Warning: Ignoring Auth2Cli_ScoreGetHighScoresReply");
+}
+
+void pnAuthClient::onServerCaps(const hsBitVector& caps)
+{
+    plDebug::Warning("Warning: Ignoring Auth2Cli_ServerCaps");
 }

--- a/net/auth/pnAuthClient.h
+++ b/net/auth/pnAuthClient.h
@@ -132,6 +132,7 @@ public:
     uint32_t sendScoreGetRanks(uint32_t ownerId, uint32_t group, uint32_t parent,
                 const ST::string& gameName, uint32_t timePeriod, uint32_t numResults,
                 uint32_t pageNumber, uint32_t sortDesc);
+    uint32_t sendScoreGetHighScores(uint32_t ageId, uint32_t maxScores, const ST::string &gameName);
     void propagateMessage(plCreatable* msg);
 
     /* Incoming Protocol - To be implemented by subclasses */
@@ -205,6 +206,8 @@ public:
     virtual void onScoreGetRanksReply(uint32_t transId, ENetError result,
                     size_t count, const pnNetGameRank* ranks);
     virtual void onPropagateMessage(plCreatable* msg);
+    virtual void onScoreGetHighScoresReply(uint32_t transId, ENetError result, uint32_t score_count, const pnNetGameScore* scores);
+    virtual void onServerCaps(const hsBitVector& caps);
 
 protected:
     pnRC4Socket* fSock;


### PR DESCRIPTION
libhsplasmanet is missing three messages from H-uru/Plasma: kCli2Auth_ScoreGetHighScores, kAuth2Cli_ScoreGetHighScoresReply and kAuth2Cli_ServerCaps. The later one in particular prevents it from connecting to dirtsand servers, breaking tools like MoulKI. This MR implements all three, which fixes the issue.