### PR TITLE
Automatically manage "has PermaLight/PermaProj" property when modifying PermaLight and PermaProj vectors on spans.

### DIFF
--- a/core/PRP/Geometry/plSpan.cpp
+++ b/core/PRP/Geometry/plSpan.cpp
@@ -200,3 +200,59 @@ void plSpan::IPrcParse(const pfPrcTag* tag)
         throw pfPrcTagException(__FILE__, __LINE__, tag->getName());
     }
 }
+
+void plSpan::setPermaLights(std::vector<plKey> lights)
+{
+    fPermaLights = std::move(lights);
+    if (fPermaLights.empty())
+        fProps &= ~kPropHasPermaLights;
+    else
+        fProps |= kPropHasPermaLights;
+}
+
+void plSpan::addPermaLight(plKey light)
+{
+    fPermaLights.emplace_back(std::move(light));
+    fProps |= kPropHasPermaLights;
+}
+
+void plSpan::delPermaLight(size_t idx)
+{
+    fPermaLights.erase(fPermaLights.begin() + idx);
+    if (fPermaLights.empty())
+        fProps &= ~kPropHasPermaLights;
+}
+
+void plSpan::clearPermaLights()
+{
+    fPermaLights.clear();
+    fProps &= ~kPropHasPermaLights;
+}
+
+void plSpan::setPermaProjs(std::vector<plKey> lights)
+{
+    fPermaProjs = std::move(lights);
+    if (fPermaProjs.empty())
+        fProps &= ~kPropHasPermaProjs;
+    else
+        fProps |= kPropHasPermaProjs;
+}
+
+void plSpan::addPermaProj(plKey proj)
+{
+    fPermaProjs.emplace_back(std::move(proj));
+    fProps |= kPropHasPermaProjs;
+}
+
+void plSpan::delPermaProj(size_t idx)
+{
+    fPermaProjs.erase(fPermaProjs.begin() + idx);
+    if (fPermaProjs.empty())
+        fProps &= ~kPropHasPermaProjs;
+}
+
+void plSpan::clearPermaProjs()
+{
+    fPermaProjs.clear();
+    fProps &= ~kPropHasPermaProjs;
+}

--- a/core/PRP/Geometry/plSpan.h
+++ b/core/PRP/Geometry/plSpan.h
@@ -150,17 +150,17 @@ public:
 
     const std::vector<plKey>& getPermaLights() const { return fPermaLights; }
     std::vector<plKey>& getPermaLights() { return fPermaLights; }
-    void setPermaLights(const std::vector<plKey>& lights) { fPermaLights = lights; }
-    void addPermaLight(plKey light) { fPermaLights.emplace_back(std::move(light)); }
-    void delPermaLight(size_t idx) { fPermaLights.erase(fPermaLights.begin() + idx); }
-    void clearPermaLights() { fPermaLights.clear(); }
+    void setPermaLights(std::vector<plKey> lights);
+    void addPermaLight(plKey light);
+    void delPermaLight(size_t idx);
+    void clearPermaLights();
 
     const std::vector<plKey>& getPermaProjs() const { return fPermaProjs; }
     std::vector<plKey>& getPermaProjs() { return fPermaProjs; }
-    void setPermaProjs(const std::vector<plKey>& lights) { fPermaProjs = lights; }
-    void addPermaProj(plKey proj) { fPermaProjs.emplace_back(std::move(proj)); }
-    void delPermaProj(size_t idx) { fPermaProjs.erase(fPermaProjs.begin() + idx); }
-    void clearPermaProjs() { fPermaProjs.clear(); }
+    void setPermaProjs(std::vector<plKey> lights);
+    void addPermaProj(plKey proj);
+    void delPermaProj(size_t idx);
+    void clearPermaProjs();
 };
 
 #endif


### PR DESCRIPTION
Should fix #237 