### PR TITLE
Don't touch my `CMAKE_` settings!

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
 project(libhsplasma)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
 
@@ -26,8 +23,6 @@ endif()
 
 if(APPLE)
     add_definitions("-DMACOSX")
-    set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++11")
-    set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
 endif()
 
 if(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,35 +1,30 @@
 cmake_minimum_required(VERSION 3.12)
 project(libhsplasma)
 
-set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
-
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 option(ENABLE_SSE2 "Build with SSE2 CPU instructions" ON)
 
-set(CMAKE_C_FLAGS_DEBUG "-DDEBUG ${CMAKE_C_FLAGS_DEBUG}")
-set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG ${CMAKE_CXX_FLAGS_DEBUG}")
+# There are lots of variants of Clang, so just match it instead
+# of trying to hardwire them all in a generator expression.
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR
         CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
-    set(WARNING_FLAGS "-Wall -Wextra -Wno-unused-parameter")
-    set(CMAKE_CXX_FLAGS "${WARNING_FLAGS} ${CMAKE_CXX_FLAGS}")
-    set(CMAKE_C_FLAGS "${WARNING_FLAGS} ${CMAKE_C_FLAGS}")
-    if(ENABLE_SSE2)
-        set(CMAKE_CXX_FLAGS "-msse2 ${CMAKE_CXX_FLAGS}")
-        set(CMAKE_C_FLAGS "-msse2 ${CMAKE_C_FLAGS}")
-    endif()
+    set(COMPILER_USES_GCC_FLAGS TRUE)
 endif()
 
-if(APPLE)
-    add_definitions("-DMACOSX")
-endif()
-
-if(MSVC)
-    add_definitions("-D_CRT_SECURE_NO_WARNINGS")
-    set(CMAKE_CXX_FLAGS "/bigobj /wd4996 /wd4244 /wd4251 /wd4351 ${CMAKE_CXX_FLAGS}")
-    set(CMAKE_C_FLAGS "/wd4996 /wd4244 /wd4251 /wd4351 ${CMAKE_C_FLAGS}")
-endif()
+add_library(HSPlasmaCompilerInterface INTERFACE)
+target_compile_definitions(HSPlasmaCompilerInterface
+    INTERFACE
+        $<$<CONFIG:Debug>:DEBUG>
+        $<$<CXX_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS>
+        $<$<BOOL:${APPLE}>:MACOSX>
+)
+target_compile_options(HSPlasmaCompilerInterface
+    INTERFACE
+        $<$<CXX_COMPILER_ID:MSVC>:/bigobj /wd4996 /wd4244 /wd4251 /wd4351>
+        $<$<BOOL:${COMPILER_USES_GCC_FLAGS}>:-Wall -Wextra -Wno-unused-parameter>
+        $<$<AND:$<BOOL:${ENABLE_SSE2}>,$<BOOL:${COMPILER_USES_GCC_FLAGS}>>:-msse2>
+)
 
 # Turn everything on by default
 option(ENABLE_PYTHON "Build HSPlasma Python integration" ON)

--- a/Python/CMakeLists.txt
+++ b/Python/CMakeLists.txt
@@ -8,20 +8,6 @@ if (NOT "${PYTHONLIBS_VERSION_STRING_FILTERED}" STREQUAL "${PYTHON_VERSION_STRIN
     message(FATAL_ERROR "Versions of Python libraries (${PYTHONLIBS_VERSION_STRING_FILTERED}) and Python interpreter (${PYTHON_VERSION_STRING_FILTERED}) do not match. Please configure the paths manually.")
 endif()
 
-if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
-    set(CMAKE_CXX_FLAGS "-fno-strict-aliasing ${CMAKE_CXX_FLAGS}")
-    set(CMAKE_C_FLAGS "-fno-strict-aliasing ${CMAKE_C_FLAGS}")
-endif()
-
-if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.0)
-        # GCC 8 adds a warning that prevents us from using Python's C API
-        # in the "usual" way -- disable it for now.
-        set(CMAKE_CXX_FLAGS "-Wno-cast-function-type ${CMAKE_CXX_FLAGS}")
-        set(CMAKE_C_FLAGS "-Wno-cast-function-type ${CMAKE_C_FLAGS}")
-    endif()
-endif()
-
 include_directories(${PYTHON_INCLUDE_DIRS})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
@@ -762,9 +748,27 @@ add_library(PyHSPlasma SHARED
             ${VAULT_SOURCES}        ${VAULT_HEADERS}
             ${PYTHON_SOURCES}       ${PYTHON_HEADERS}
 )
+set_target_properties(PyHSPlasma PROPERTIES
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN TRUE
+)
 
-target_link_libraries(PyHSPlasma HSPlasma ${PYTHON_LIBRARIES})
+target_link_libraries(PyHSPlasma
+    PUBLIC
+        HSPlasma
+        ${PYTHON_LIBRARIES}
+    PRIVATE
+        HSPlasmaCompilerInterface
+)
 set_target_properties(PyHSPlasma PROPERTIES PREFIX "")
+
+target_compile_options(PyHSPlasma
+    PRIVATE
+        $<$<BOOL:${COMPILER_USES_GCC_FLAGS}>:-fno-strict-aliasing>
+        # GCC 8 adds a warning that prevents us from using Python's C API
+        # in the "usual" way -- disable it for now.
+        $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_GREATER:$<CXX_COMPILER_VERSION>,8.0>>:-Wno-cast-function-type>
+)
 
 if(NOT WIN32)
     set_target_properties(PyHSPlasma PROPERTIES

--- a/Tools/CMakeLists.txt
+++ b/Tools/CMakeLists.txt
@@ -1,13 +1,11 @@
 try_compile(DIRENT_IS_CONST ${PROJECT_BINARY_DIR}
             ${PROJECT_SOURCE_DIR}/cmake/check_dirent.cpp
             OUTPUT_VARIABLE OUTPUT)
-if(DIRENT_IS_CONST)
-    add_definitions("-DDIRENT_IS_CONST")
-endif()
 
 macro(plasma_tool NAME)
     add_executable(${NAME} src/${NAME}.cpp)
-    target_link_libraries(${NAME} HSPlasma ${STRING_THEORY_LIBRARIES})
+    target_compile_definitions(${NAME} PRIVATE $<$<BOOL:${DIRENT_IS_CONST}>:DIRENT_IS_CONST>)
+    target_link_libraries(${NAME} PRIVATE HSPlasma HSPlasmaCompilerInterface)
     install(TARGETS ${NAME} RUNTIME DESTINATION bin)
 endmacro(plasma_tool)
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -803,6 +803,7 @@ target_link_libraries(HSPlasma
                       JPEG::JPEG PNG::PNG string_theory Threads::Threads ZLIB::ZLIB
                       $<$<AND:$<BOOL:${ENABLE_PHYSX}>,$<BOOL:${PHYSX_FOUND}>>:${PHYSX_COOKING_LIBRARY}>
 )
+target_compile_features(HSPlasma PUBLIC cxx_std_14)
 
 target_include_directories(HSPlasma PUBLIC
                            $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -799,9 +799,20 @@ add_library(HSPlasma
             ${RIJNDAEL_SOURCES}
             ${SQUISH_SOURCES}
 )
+set_target_properties(HSPlasma PROPERTIES
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN TRUE
+)
 target_link_libraries(HSPlasma
-                      JPEG::JPEG PNG::PNG string_theory Threads::Threads ZLIB::ZLIB
-                      $<$<AND:$<BOOL:${ENABLE_PHYSX}>,$<BOOL:${PHYSX_FOUND}>>:${PHYSX_COOKING_LIBRARY}>
+    PUBLIC
+        string_theory
+        Threads::Threads
+    PRIVATE
+        HSPlasmaCompilerInterface
+        JPEG::JPEG
+        $<$<AND:$<BOOL:${ENABLE_PHYSX}>,$<BOOL:${PHYSX_FOUND}>>:${PHYSX_COOKING_LIBRARY}>
+        PNG::PNG
+        ZLIB::ZLIB
 )
 target_compile_features(HSPlasma PUBLIC cxx_std_14)
 

--- a/core/HSPlasmaConfig.cmake.in
+++ b/core/HSPlasmaConfig.cmake.in
@@ -6,6 +6,7 @@ if(NOT @BUILD_SHARED_LIBS@)
     find_dependency(JPEG)
     find_dependency(PNG)
 endif()
+find_dependency(string_theory CONFIG)
 find_dependency(Threads)
 
 include(${CMAKE_CURRENT_LIST_DIR}/HSPlasma-targets.cmake)

--- a/core/HSPlasmaConfig.cmake.in
+++ b/core/HSPlasmaConfig.cmake.in
@@ -1,9 +1,11 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(ZLIB)
-find_dependency(JPEG)
-find_dependency(PNG)
+if(NOT @BUILD_SHARED_LIBS@)
+    find_dependency(ZLIB)
+    find_dependency(JPEG)
+    find_dependency(PNG)
+endif()
 find_dependency(Threads)
 
 include(${CMAKE_CURRENT_LIST_DIR}/HSPlasma-targets.cmake)

--- a/net/CMakeLists.txt
+++ b/net/CMakeLists.txt
@@ -93,10 +93,17 @@ add_library(HSPlasmaNet
             ${PN_GATE_SOURCES}  ${PN_GATE_HEADERS}
             ${PN_SOURCES}       ${PN_HEADERS}
 )
+set_target_properties(HSPlasmaNet PROPERTIES
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN TRUE
+)
 target_link_libraries(HSPlasmaNet
-                      HSPlasma string_theory
-                      $<$<NOT:$<PLATFORM_ID:SunOS>>:OpenSSL::Crypto>
-                      $<$<PLATFORM_ID:Windows>:ws2_32>
+    PUBLIC
+        HSPlasma
+    PRIVATE
+        HSPlasmaCompilerInterface
+        $<$<NOT:$<PLATFORM_ID:SunOS>>:OpenSSL::Crypto>
+        $<$<PLATFORM_ID:Windows>:ws2_32>
 )
 
 target_include_directories(HSPlasmaNet PUBLIC

--- a/net/HSPlasmaNetConfig.cmake.in
+++ b/net/HSPlasmaNetConfig.cmake.in
@@ -2,7 +2,9 @@
 
 include(CMakeFindDependencyMacro)
 find_dependency(HSPlasma CONFIG)
-find_dependency(OpenSSL)
+if(NOT @BUILD_SHARED_LIBS@)
+    find_dependency(OpenSSL)
+endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/HSPlasmaNet-targets.cmake)
 


### PR DESCRIPTION
Many `CMAKE_` variables are considered to be user-facing settings. It's OK to set default values for these inside the project, but we have been using them to set values required to compile HSPlasma. This is problematic if someone wants to, for example, use [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html) to include HSPlasma as a first class citizen of their project (ie as a subproject). Specifically the old `set(CMAKE_CXX_STANDARD 14)` line would blow away any setting of the default C++ standard. This is not a good UX, so this pull requests removes all `CMAKE_` forced settings into target properties as expected in "modern" CMake.

As bonuses, this corrects some unnecessary virality of our 3rd party dependencies and fixes an issue with string_theory not being pulled in by consumers.