### PR TITLE
Use Win32 API in `hsFileStream`.

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -811,9 +811,14 @@ target_include_directories(HSPlasma PUBLIC
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libhsplasma.pc.in.cmake ${CMAKE_CURRENT_BINARY_DIR}/libhsplasma.pc @ONLY)
 
-# Too many ODR violations in squish
+# Skip unity building source files where that would be a bad idea:
+# - Squish has too many ODR violations to practically fix.
+# - hsFileStream uses Windows.h on Windows, so avoid spreading that disease.
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.16)
-    set_property(SOURCE ${SQUISH_SOURCES} PROPERTY SKIP_UNITY_BUILD_INCLUSION TRUE)
+    set_property(SOURCE
+        ${SQUISH_SOURCES} Stream/hsStream.cpp
+        PROPERTY SKIP_UNITY_BUILD_INCLUSION TRUE
+    )
 endif()
 
 include(GenerateExportHeader)

--- a/core/Stream/hsStream.cpp
+++ b/core/Stream/hsStream.cpp
@@ -21,7 +21,7 @@
 #include "Sys/Platform.h"
 #include "Debug/plDebug.h"
 
-#ifdef WIN32
+#ifdef _WIN32
     #define WIN32_LEAN_AND_MEAN
     #define NOMINMAX
     #include <windows.h>
@@ -353,7 +353,7 @@ void hsStream::writeLine(const ST::string& ln, bool winEOL)
 /* hsFileStream */
 bool hsFileStream::FileExists(const ST::string& file)
 {
-#ifdef WIN32
+#ifdef _WIN32
     HANDLE eFile = CreateFileW(file.to_wchar().data(), GENERIC_READ,
         FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
     if (eFile == INVALID_HANDLE_VALUE)

--- a/core/Stream/hsStream.cpp
+++ b/core/Stream/hsStream.cpp
@@ -21,6 +21,12 @@
 #include "Sys/Platform.h"
 #include "Debug/plDebug.h"
 
+#ifdef WIN32
+    #define WIN32_LEAN_AND_MEAN
+    #define NOMINMAX
+    #include <windows.h>
+#endif
+
 static const int eoaStrKey[8] = {'m','y','s','t','n','e','r','d'};
 
 /* hsStream */
@@ -347,15 +353,58 @@ void hsStream::writeLine(const ST::string& ln, bool winEOL)
 /* hsFileStream */
 bool hsFileStream::FileExists(const ST::string& file)
 {
+#ifdef WIN32
+    HANDLE eFile = CreateFileW(file.to_wchar().data(), GENERIC_READ,
+        FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (eFile == INVALID_HANDLE_VALUE)
+        return false;
+    CloseHandle(eFile);
+    return true;
+#else
     FILE* eFile = fopen(file.c_str(), "rb");
     bool exist = (eFile != nullptr);
     if (exist)
         fclose(eFile);
     return exist;
+#endif
 }
 
 bool hsFileStream::open(const ST::string& file, FileMode mode)
 {
+#ifdef WIN32
+    DWORD access, disposition;
+    switch (mode) {
+    case FileMode::fmRead:
+        access = GENERIC_READ;
+        disposition = OPEN_EXISTING;
+        break;
+    case FileMode::fmWrite:
+        access = GENERIC_WRITE;
+        disposition = OPEN_ALWAYS;
+        break;
+    case FileMode::fmCreate:
+        access = GENERIC_WRITE;
+        disposition = CREATE_ALWAYS;
+        break;
+    case FileMode::fmReadWrite:
+        access = GENERIC_READ | GENERIC_WRITE;
+        disposition = OPEN_EXISTING;
+        break;
+    default:
+        throw hsBadParamException(__FILE__, __LINE__, "Invalid mode");
+    }
+
+    F = CreateFileW(file.to_wchar().data(), access, FILE_SHARE_READ, nullptr, disposition, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (F == INVALID_HANDLE_VALUE) {
+        F = nullptr;
+        if (mode == fmRead || mode == fmReadWrite)
+            throw hsFileReadException(__FILE__, __LINE__, "File does not exist");
+        return false;
+    }
+
+    fm = mode;
+    return true;
+#else
     const char* fms;
     switch (mode) {
     case fmRead:
@@ -381,13 +430,19 @@ bool hsFileStream::open(const ST::string& file, FileMode mode)
     } else if (mode == fmRead || mode == fmReadWrite) {
         throw hsFileReadException(__FILE__, __LINE__, "File does not exist");
     }
+#endif
     return false;
 }
 
 void hsFileStream::close()
 {
-    if (F)
+    if (F) {
+#ifdef WIN32
+        CloseHandle(F);
+#else
         fclose(F);
+#endif
+    }
     F = nullptr;
 }
 
@@ -395,10 +450,15 @@ uint32_t hsFileStream::size() const
 {
     if (F == nullptr)
         return 0;
+
+#ifdef WIN32
+    DWORD sz = GetFileSize(F, nullptr);
+#else
     unsigned int p = ftell(F);
     fseek(F, 0, SEEK_END);
     unsigned int sz = ftell(F);
     fseek(F, p, SEEK_SET);
+#endif
     return sz;
 }
 
@@ -406,58 +466,92 @@ uint32_t hsFileStream::pos() const
 {
     if (F == nullptr)
         return 0;
+#ifdef WIN32
+    return SetFilePointer(F, 0, nullptr, FILE_CURRENT);
+#else
     return ftell(F);
+#endif
 }
 
 bool hsFileStream::eof() const
 {
     if (F == nullptr)
         return true;
+
+#ifdef WIN32
+    return pos() == size();
+#else
     int c = fgetc(F);
     ungetc(c, F);
     return (c == EOF);
+#endif
 }
 
 void hsFileStream::seek(uint32_t pos)
 {
     if (F == nullptr)
         return;
+#ifdef WIN32
+    SetFilePointer(F, pos, nullptr, FILE_BEGIN);
+#else
     fseek(F, pos, SEEK_SET);
+#endif
 }
 
 void hsFileStream::skip(int32_t count)
 {
     if (F == nullptr)
         return;
+#ifdef WIN32
+    SetFilePointer(F, count, nullptr, FILE_CURRENT);
+#else
     fseek(F, count, SEEK_CUR);
+#endif
 }
 
 void hsFileStream::fastForward()
 {
     if (F == nullptr)
         return;
+#ifdef WIN32
+    SetFilePointer(F, 0, nullptr, FILE_END);
+#else
     fseek(F, 0, SEEK_END);
+#endif
 }
 
 void hsFileStream::rewind()
 {
     if (F == nullptr)
         return;
+#ifdef WIN32
+    SetFilePointer(F, 0, nullptr, FILE_BEGIN);
+#else
     fseek(F, 0, SEEK_SET);
+#endif
 }
 
 void hsFileStream::flush()
 {
     if (F == nullptr)
         return;
+#ifdef WIN32
+    FlushFileBuffers(F);
+#else
     fflush(F);
+#endif
 }
 
 size_t hsFileStream::read(size_t size, void* buf)
 {
     if (F == nullptr || fm == fmWrite || fm == fmCreate)
         throw hsFileReadException(__FILE__, __LINE__);
+#ifdef WIN32
+    DWORD nread = 0;
+    ReadFile(F, buf, size, &nread, nullptr);
+#else
     size_t nread = fread(buf, 1, size, F);
+#endif
     if (nread != size) {
         throw hsFileReadException(__FILE__, __LINE__,
                          ST::format("Read past end of file: {} bytes requested, {} available",
@@ -470,7 +564,13 @@ size_t hsFileStream::write(size_t size, const void* buf)
 {
     if (F == nullptr || fm == fmRead)
         throw hsFileWriteException(__FILE__, __LINE__);
+#ifdef WIN32
+    DWORD nwrite = 0;
+    WriteFile(F, buf, size, &nwrite, nullptr);
+    return nwrite;
+#else
     return fwrite(buf, 1, size, F);
+#endif
 }
 
 time_t hsFileStream::getModTime() const
@@ -478,7 +578,13 @@ time_t hsFileStream::getModTime() const
     if (F == nullptr)
         return 0;
 
+#ifdef WIN32
+    FILETIME modTime;
+    GetFileTime(F, nullptr, nullptr, &modTime);
+    return ((time_t)modTime.dwHighDateTime << 32) | modTime.dwLowDateTime;
+#else
     struct stat stbuf;
     fstat(fileno(F), &stbuf);
     return stbuf.st_mtime;
+#endif
 }

--- a/core/Stream/hsStream.h
+++ b/core/Stream/hsStream.h
@@ -87,8 +87,8 @@ public:
 
 class HSPLASMA_EXPORT hsFileStream : public hsStream {
 protected:
-#ifdef WIN32
-    void* F;
+#ifdef _WIN32
+    /* HANDLE */ void* F;
 #else
     FILE* F;
 #endif

--- a/core/Stream/hsStream.h
+++ b/core/Stream/hsStream.h
@@ -88,7 +88,7 @@ public:
 class HSPLASMA_EXPORT hsFileStream : public hsStream {
 protected:
 #ifdef WIN32
-    HANDLE F;
+    void* F;
 #else
     FILE* F;
 #endif

--- a/core/Stream/hsStream.h
+++ b/core/Stream/hsStream.h
@@ -87,7 +87,11 @@ public:
 
 class HSPLASMA_EXPORT hsFileStream : public hsStream {
 protected:
+#ifdef WIN32
+    HANDLE F;
+#else
     FILE* F;
+#endif
     FileMode fm;
 
 public:

--- a/core/Sys/Platform.h
+++ b/core/Sys/Platform.h
@@ -110,10 +110,6 @@ inline double ENDSWAPD(double val)
     #define PATHSEPSTR "/"
 #endif
 
-#ifdef WIN32
-    typedef void* HANDLE;
-#endif
-
 enum plKeyDef
 {
     KEY_A = 'A', KEY_B, KEY_C, KEY_D, KEY_E, KEY_F, KEY_G, KEY_H, KEY_I, KEY_J,

--- a/core/Sys/Platform.h
+++ b/core/Sys/Platform.h
@@ -110,6 +110,10 @@ inline double ENDSWAPD(double val)
     #define PATHSEPSTR "/"
 #endif
 
+#ifdef WIN32
+    typedef void* HANDLE;
+#endif
+
 enum plKeyDef
 {
     KEY_A = 'A', KEY_B, KEY_C, KEY_D, KEY_E, KEY_F, KEY_G, KEY_H, KEY_I, KEY_J,


### PR DESCRIPTION
When developing Korman's "Test Age" feature, I noticed a curious bug that I could never quite understand. The feature basically uses `hsFileStream` to modify the TPotS vault.dat, then launches Uru. Occassionally, however, Uru would act as if the changes to the vault were not made - but according to VaultShop, the changes were present! I discovered that adding [a small sleep](https://github.com/H-uru/korman/blob/1e198a1cfe725bceaa090ee3f910608cce97f1e9/korman/plasma_launcher.py#L177:L178) between writing vault.dat and launching Uru made the process slightly more reliable, but still not 100%.

As it turns out, the C file API in Windows is evidentally vulnerable to race conditions where changes are not flushed out as expected. I'm not mthe only one to discover this problem: https://twitter.com/jonathan_blow/status/1417544504916135936