### PR TITLE
Revert "Use Win32 API in `hsFileStream`."

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -811,14 +811,9 @@ target_include_directories(HSPlasma PUBLIC
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libhsplasma.pc.in.cmake ${CMAKE_CURRENT_BINARY_DIR}/libhsplasma.pc @ONLY)
 
-# Skip unity building source files where that would be a bad idea:
-# - Squish has too many ODR violations to practically fix.
-# - hsFileStream uses Windows.h on Windows, so avoid spreading that disease.
+# Too many ODR violations in squish
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.16)
-    set_property(SOURCE
-        ${SQUISH_SOURCES} Stream/hsStream.cpp
-        PROPERTY SKIP_UNITY_BUILD_INCLUSION TRUE
-    )
+    set_property(SOURCE ${SQUISH_SOURCES} PROPERTY SKIP_UNITY_BUILD_INCLUSION TRUE)
 endif()
 
 include(GenerateExportHeader)

--- a/core/Stream/hsStream.h
+++ b/core/Stream/hsStream.h
@@ -87,11 +87,7 @@ public:
 
 class HSPLASMA_EXPORT hsFileStream : public hsStream {
 protected:
-#ifdef _WIN32
-    /* HANDLE */ void* F;
-#else
     FILE* F;
-#endif
     FileMode fm;
 
 public:


### PR DESCRIPTION
Reverts H-uru/libhsplasma#242

This causes a massive performance regression in reading PRPs:
* A quick test of loading MOULa's Ahnonay.age with a release build of libhsplasma:
  * With #242: 34sec
  * Without #242: 1.5sec

There are also reports of written PRPs containing the wrong or outdated content (see #244).

This can be re-added in the future if the issues can be resolved, but for now I'd like to get a new release of libhsplasma and PlasmaShop that fixes these regressions.