### PR TITLE
Fix for PyInit_PyHSPlasma visibility on Py <3.9

### DIFF
--- a/Python/Module.cpp
+++ b/Python/Module.cpp
@@ -455,6 +455,10 @@ static void initPyHSPlasma_Constants(PyObject* module)
     PyModule_AddIntConstant(module, "KEY_UNMAPPED", KEY_UNMAPPED);
 }
 
+#if !defined(_WIN32) && ((PY_MAJOR_VERSION == 3) && (PY_MINOR_VERSION < 9))
+PyMODINIT_FUNC PyInit_PyHSPlasma() __attribute__((visibility("default")));
+#endif
+
 PyMODINIT_FUNC PyInit_PyHSPlasma()
 {
     PyObject* module = PyModule_Create(&PyHSPlasma_Module);


### PR DESCRIPTION
libHSPlasma has been configured to use proper symbol visibility, which has resulted in all of the PyHSPlasma symbols being marked hidden.
`PyMODINIT_FUNC` on Python 3.9+ has been updated to include visibility annotations, but on earlier versions it is missing.

I've confirmed this is working for me when building for Python 3.7.

Closes #248 