### PR TITLE
Python: make pySpanTemplateVertex a value type

### DIFF
--- a/Python/PRP/Geometry/pySpanTemplate.cpp
+++ b/Python/PRP/Geometry/pySpanTemplate.cpp
@@ -66,7 +66,7 @@ PY_GETSET_GETTER_DECL(SpanTemplate, vertices)
     std::vector<plSpanTemplate::Vertex> verts = self->fThis->getVertices();
     PyObject* list = PyTuple_New(verts.size());
     for (size_t i=0; i<verts.size(); i++)
-        PyTuple_SET_ITEM(list, i, pySpanTemplateVertex_FromSpanTemplateVertex(&verts[i]));
+        PyTuple_SET_ITEM(list, i, pySpanTemplateVertex_FromSpanTemplateVertex(verts[i]));
     return list;
 }
 

--- a/Python/PRP/Geometry/pySpanTemplate.h
+++ b/Python/PRP/Geometry/pySpanTemplate.h
@@ -20,7 +20,7 @@
 #include "PyPlasma.h"
 #include <PRP/Geometry/plSpanTemplate.h>
 
-PY_WRAP_PLASMA(SpanTemplateVertex, plSpanTemplate::Vertex);
+PY_WRAP_PLASMA_VALUE(SpanTemplateVertex, plSpanTemplate::Vertex);
 PY_WRAP_PLASMA(SpanTemplate, plSpanTemplate);
 
 /* Python property helpers */

--- a/Python/PRP/Geometry/pySpanTemplateVertex.cpp
+++ b/Python/PRP/Geometry/pySpanTemplateVertex.cpp
@@ -19,9 +19,9 @@
 #include <PRP/Geometry/plSpanTemplate.h>
 #include "Math/pyGeometry3.h"
 
-PY_PLASMA_DEALLOC(SpanTemplateVertex)
+PY_PLASMA_VALUE_DEALLOC(SpanTemplateVertex)
 PY_PLASMA_EMPTY_INIT(SpanTemplateVertex)
-PY_PLASMA_NEW(SpanTemplateVertex, plSpanTemplate::Vertex)
+PY_PLASMA_VALUE_NEW(SpanTemplateVertex, plSpanTemplate::Vertex)
 
 PY_GETSET_GETTER_DECL(SpanTemplateVertex, UVWs)
 {
@@ -127,4 +127,4 @@ PY_PLASMA_TYPE_INIT(SpanTemplateVertex)
     return (PyObject*)&pySpanTemplateVertex_Type;
 }
 
-PY_PLASMA_IFC_METHODS(SpanTemplateVertex, plSpanTemplate::Vertex)
+PY_PLASMA_VALUE_IFC_METHODS(SpanTemplateVertex, plSpanTemplate::Vertex)


### PR DESCRIPTION
For some reason `pySpanTemplateVertex` (a Python reference type) sometimes becomes corrupted, which means position, normal etc get filled with junk data. I'm not sure why.
`pyGBufferVertex` which is very similar is a value type. Making `pySpanTemplateVertex` a value type solves that corruption problem on top of being more consistent. :shrug:
(`pySpanTemplateVertex` is used by cluster groups - which ZLZ can now import.)