### PR TITLE
Improve hsQuat initialization.

### DIFF
--- a/Python/Math/pyQuat.cpp
+++ b/Python/Math/pyQuat.cpp
@@ -24,7 +24,7 @@ PY_PLASMA_VALUE_DEALLOC(Quat)
 
 PY_PLASMA_INIT_DECL(Quat)
 {
-    float x = 0.0f, y = 0.0f, z = 0.0f, w = 0.0f;
+    float x = 0.0f, y = 0.0f, z = 0.0f, w = 1.0f;
     PyObject* init = nullptr;
     static char* kwlist[] = { _pycs("X"), _pycs("Y"), _pycs("Z"), _pycs("W"), nullptr };
     static char* kwlist2[] = { _pycs("quat"), nullptr };

--- a/core/Math/hsQuat.h
+++ b/core/Math/hsQuat.h
@@ -23,7 +23,7 @@ struct HSPLASMA_EXPORT hsQuat
 {
     float X, Y, Z, W;
 
-    hsQuat() : X(), Y(), Z(), W() { }
+    hsQuat() : X(), Y(), Z(), W(1.f) { }
     hsQuat(float _x, float _y, float _z, float _w) : X(_x), Y(_y), Z(_z), W(_w) { }
     hsQuat(float rad, const hsVector3& axis);
 


### PR DESCRIPTION
We prefer to initialize things to a state that is somewhat valid. Therefore, initialize to an identity quaternion instead of a zero (read: illegal) quaternion.