### PR TITLE
Add missing functions to read PNGs and JPGs.

### DIFF
--- a/core/PRP/Surface/plMipmap.cpp
+++ b/core/PRP/Surface/plMipmap.cpp
@@ -632,7 +632,7 @@ size_t plMipmap::GetUncompressedSize(size_t level) const
     return lvl.fHeight * lvl.fWidth * (fPixelSize / 8);
 }
 
-void plMipmap::DecompressImage(size_t level, void* dest, size_t size)
+void plMipmap::DecompressImage(size_t level, void* dest, size_t size) const
 {
     const LevelData& lvl = fLevelData[level];
 

--- a/core/PRP/Surface/plMipmap.h
+++ b/core/PRP/Surface/plMipmap.h
@@ -110,7 +110,7 @@ public:
     bool isAlphaJPEG() const { return !fJAlphaCache.empty(); }
 
     size_t GetUncompressedSize(size_t level) const;
-    void DecompressImage(size_t level, void* dest, size_t size);
+    void DecompressImage(size_t level, void* dest, size_t size) const;
     void CompressImage(size_t level, void* src, size_t size, BlockQuality quality = kBlockQualityNormal);
 };
 

--- a/core/Util/plJPEG.cpp
+++ b/core/Util/plJPEG.cpp
@@ -281,16 +281,16 @@ plMipmap* plJPEG::DecompressJPEG(hsStream* S)
     RAII_JSAMPROW<1> jbuffer(row_stride);
 
     // Start with a reasonable size for the buffer
-    auto buffer = new std::vector<uint8_t>(ji.dinfo.output_width * ji.dinfo.output_height * ji.dinfo.out_color_components);
+    std::vector<uint8_t> buffer(ji.dinfo.output_width * ji.dinfo.output_height * ji.dinfo.out_color_components);
 
     size_t offs = 0;
     while (ji.dinfo.output_scanline < ji.dinfo.output_height) {
-        while (offs + out_stride > buffer->capacity()) {
-            buffer->reserve(buffer->capacity() + INPUT_BUF_SIZE);
+        while (offs + out_stride > buffer.capacity()) {
+            buffer.reserve(buffer.capacity() + INPUT_BUF_SIZE);
         }
         jpeg_read_scanlines(&ji.dinfo, jbuffer.data, 1);
         for (size_t x = 0; x < ji.dinfo.output_width; x++) {
-            memcpy(((unsigned char*)buffer->data()) + offs + (x * 4),
+            memcpy(((unsigned char*)buffer.data()) + offs + (x * 4),
                 jbuffer.data[0] + (x * ji.dinfo.out_color_components),
                 ji.dinfo.out_color_components);
         }
@@ -298,12 +298,11 @@ plMipmap* plJPEG::DecompressJPEG(hsStream* S)
     }
 
     jpeg_finish_decompress(&ji.dinfo);
-    buffer->shrink_to_fit();
+    buffer.shrink_to_fit();
 
     plMipmap* newMipmap = new plMipmap(ji.dinfo.output_width, ji.dinfo.output_height, 1, plMipmap::kUncompressed, plMipmap::kRGB8888);
-    newMipmap->setImageData(buffer->data(), buffer->size());
+    newMipmap->setImageData(buffer.data(), buffer.size());
 
-    delete buffer;
     return newMipmap;
 }
 

--- a/core/Util/plJPEG.cpp
+++ b/core/Util/plJPEG.cpp
@@ -117,13 +117,13 @@ GLOBAL(void) jpeg_hsStream_src(j_decompress_ptr dinfo, hsStream* S)
 #define OUTPUT_BUF_SIZE  4096
 
 /* hsStream JPEG destination -- modelled after IJG's stdio dest */
-typedef struct
+struct jpeg_hsStream_destination
 {
     struct jpeg_destination_mgr pub;
     hsStream* stream;
     JOCTET* buffer;
     boolean start_of_stream;
-} jpeg_hsStream_destination;
+};
 
 METHODDEF(void) init_hsStream_destination(j_compress_ptr cinfo)
 {
@@ -161,11 +161,11 @@ GLOBAL(void) jpeg_hsStream_dest(j_compress_ptr cinfo, hsStream* S)
 
     if (cinfo->dest == nullptr) {
         cinfo->dest = (struct jpeg_destination_mgr*)
-            (*cinfo->mem->alloc_small)((j_common_ptr)cinfo, JPOOL_PERMANENT,
+            cinfo->mem->alloc_small((j_common_ptr)cinfo, JPOOL_PERMANENT,
                 sizeof(jpeg_hsStream_destination));
         dest = (jpeg_hsStream_destination*)cinfo->dest;
         dest->buffer = (JOCTET*)
-            (*cinfo->mem->alloc_small)((j_common_ptr)cinfo, JPOOL_PERMANENT,
+            cinfo->mem->alloc_small((j_common_ptr)cinfo, JPOOL_PERMANENT,
                 OUTPUT_BUF_SIZE * sizeof(JOCTET));
     }
 
@@ -290,7 +290,7 @@ plMipmap* plJPEG::DecompressJPEG(hsStream* S)
         }
         jpeg_read_scanlines(&ji.dinfo, jbuffer.data, 1);
         for (size_t x = 0; x < ji.dinfo.output_width; x++) {
-            memcpy(((unsigned char*)buffer.data()) + offs + (x * 4),
+            memcpy(buffer.data() + offs + (x * 4),
                 jbuffer.data[0] + (x * ji.dinfo.out_color_components),
                 ji.dinfo.out_color_components);
         }

--- a/core/Util/plJPEG.h
+++ b/core/Util/plJPEG.h
@@ -17,7 +17,8 @@
 #ifndef _PLJPEG_H
 #define _PLJPEG_H
 
-#include "PRP/Surface/plMipmap.h"
+#include "PlasmaDefs.h"
+#include "Debug/hsExceptions.hpp"
 
 extern "C" {
 #include <jpeglib.h>
@@ -36,6 +37,9 @@ public:
 };
 
 
+class hsStream;
+class plMipmap;
+
 class HSPLASMA_EXPORT plJPEG
 {
 private:
@@ -46,6 +50,9 @@ private:
 public:
     /* Read JPEG file from stream into buffer as bitmap data. */
     static void DecompressJPEG(hsStream* S, void* buf, size_t size);
+
+    /* Read JPEG file from stream directly into a plMipmap. */
+    static plMipmap* DecompressJPEG(hsStream* S);
 
     /* Write JPEG file to stream from bitmap data buffer. */
     static void CompressJPEG(hsStream* S, void* buf, size_t size,

--- a/core/Util/plJPEG.h
+++ b/core/Util/plJPEG.h
@@ -44,8 +44,12 @@ private:
     jpeg_error_mgr jerr;
 
 public:
+    /* Read JPEG file from stream into buffer as bitmap data. */
     static void DecompressJPEG(hsStream* S, void* buf, size_t size);
-    static void CompressJPEG(hsStream* S, void* buf, size_t size);
+
+    /* Write JPEG file to stream from bitmap data buffer. */
+    static void CompressJPEG(hsStream* S, void* buf, size_t size,
+                             uint32_t width, uint32_t height, uint32_t bpp);
 
 private:
     plJPEG();

--- a/core/Util/plPNG.cpp
+++ b/core/Util/plPNG.cpp
@@ -195,7 +195,7 @@ plMipmap* plPNG::DecompressPNG(hsStream* S)
     newMipmap = new plMipmap(pngWidth, pngHeight, 1, plMipmap::kUncompressed, plMipmap::kRGB8888);
     
     char* destp = (char*)newMipmap->getImageData();
-    png_bytep* row_ptrs = new png_bytep[pngHeight];
+    auto row_ptrs = std::make_unique<png_bytep[]>(pngHeight);
     const unsigned int stride = pngWidth * depth * channels / 8;
 
     //  Assign row pointers to the appropriate locations in the newly-created Mipmap
@@ -203,12 +203,11 @@ plMipmap* plPNG::DecompressPNG(hsStream* S)
         row_ptrs[i] = (png_bytep)destp + (i * stride);
     }
 
-    png_read_image(pngReader, row_ptrs);
+    png_read_image(pngReader, row_ptrs.get());
     png_read_end(pngReader, endInfo);
     
     //  Clean up allocated structs
     png_destroy_read_struct(&pngReader, &pngInfo, &endInfo);
-    delete[] row_ptrs;
 
     return newMipmap;
 }

--- a/core/Util/plPNG.cpp
+++ b/core/Util/plPNG.cpp
@@ -194,7 +194,7 @@ plMipmap* plPNG::DecompressPNG(hsStream* S)
     /// Construct a new mipmap to hold everything
     newMipmap = new plMipmap(pngWidth, pngHeight, 1, plMipmap::kUncompressed, plMipmap::kRGB8888);
     
-    char* destp = (char*)newMipmap->getImageData();
+    char* destp = static_cast<char *>(newMipmap->getImageData());
     auto row_ptrs = std::make_unique<png_bytep[]>(pngHeight);
     const unsigned int stride = pngWidth * depth * channels / 8;
 

--- a/core/Util/plPNG.cpp
+++ b/core/Util/plPNG.cpp
@@ -16,6 +16,7 @@
 
 #include "plPNG.h"
 #include "Debug/plDebug.h"
+#include "PRP/Surface/plMipmap.h"
 
 #include <memory>
 
@@ -118,6 +119,98 @@ void plPNG::DecompressPNG(hsStream* S, void* buf, size_t size)
     png_read_end(pngReader, endInfo);
     
     png_destroy_read_struct(&pngReader, &pngInfo, &endInfo);
+}
+
+plMipmap* plPNG::DecompressPNG(hsStream* S)
+{
+    plMipmap* newMipmap = nullptr;
+    
+    png_structp pngReader;
+    png_infop pngInfo;
+    png_infop endInfo;
+    
+    png_byte sig[PNG_SIG_LENGTH];
+    S->read(sizeof(sig), sig);
+    if (!png_check_sig(sig, PNG_SIG_LENGTH))
+        throw hsPNGException(__FILE__, __LINE__, "Invalid PNG header");
+
+    pngReader = png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
+    if (!pngReader)
+        throw hsPNGException(__FILE__, __LINE__, "Error initializing PNG reader");
+
+    pngInfo = png_create_info_struct(pngReader);
+    if (!pngInfo) {
+        png_destroy_read_struct(&pngReader, nullptr, nullptr);
+        throw hsPNGException(__FILE__, __LINE__, "Error initializing PNG info structure");
+    }
+
+    endInfo = png_create_info_struct(pngReader);
+    if (!endInfo) {
+        png_destroy_read_struct(&pngReader, &pngInfo, nullptr);
+        throw hsPNGException(__FILE__, __LINE__, "Error initializing PNG info structure");
+    }
+
+    png_set_read_fn(pngReader, (png_voidp)S, &pl_png_read);
+    png_set_sig_bytes(pngReader, PNG_SIG_LENGTH);
+    
+    png_read_info(pngReader, pngInfo);
+    png_uint_32 pngWidth  = png_get_image_width(pngReader, pngInfo);
+    png_uint_32 pngHeight = png_get_image_height(pngReader, pngInfo);
+    png_uint_32 depth     = png_get_bit_depth(pngReader, pngInfo);
+    png_uint_32 channels  = png_get_channels(pngReader, pngInfo);
+    png_uint_32 colorType = png_get_color_type(pngReader, pngInfo);
+
+    // Convert input to RGB
+    switch (colorType) {
+    case PNG_COLOR_TYPE_PALETTE:
+        png_set_palette_to_rgb(pngReader);
+        channels = 3;
+        break;
+
+    case PNG_COLOR_TYPE_GRAY:
+        if (depth < 8)
+            png_set_expand_gray_1_2_4_to_8(pngReader);
+        depth = 8;
+        break;
+
+    default:
+        /* Already RGB - nothing to do */
+        break;
+    }
+
+    if (png_get_valid(pngReader, pngInfo, PNG_INFO_tRNS)) {
+        // Convert 1-bit alpha to 8-bit alpha if necessary
+        png_set_tRNS_to_alpha(pngReader);
+        channels += 1;
+    } else if (channels == 3) {
+        // Add opaque alpha channel
+        png_set_filler(pngReader, 0xFF, PNG_FILLER_AFTER);
+        channels += 1;
+    }
+
+    // Plasma uses BGR for DirectX
+    png_set_bgr(pngReader);
+    
+    /// Construct a new mipmap to hold everything
+    newMipmap = new plMipmap(pngWidth, pngHeight, 1, plMipmap::kUncompressed, plMipmap::kRGB8888);
+    
+    char* destp = (char*)newMipmap->getImageData();
+    png_bytep* row_ptrs = new png_bytep[pngHeight];
+    const unsigned int stride = pngWidth * depth * channels / 8;
+
+    //  Assign row pointers to the appropriate locations in the newly-created Mipmap
+    for (size_t i = 0; i < pngHeight; i++) {
+        row_ptrs[i] = (png_bytep)destp + (i * stride);
+    }
+
+    png_read_image(pngReader, row_ptrs);
+    png_read_end(pngReader, endInfo);
+    
+    //  Clean up allocated structs
+    png_destroy_read_struct(&pngReader, &pngInfo, &endInfo);
+    delete[] row_ptrs;
+
+    return newMipmap;
 }
 
 void plPNG::CompressPNG(hsStream* S, const void* buf, size_t size,

--- a/core/Util/plPNG.h
+++ b/core/Util/plPNG.h
@@ -37,7 +37,10 @@ public:
 class HSPLASMA_EXPORT plPNG
 {
 public:
+    /* Read PNG file from stream into buffer as bitmap data. */
     static void DecompressPNG(hsStream* S, void* buf, size_t size);
+
+    /* Write PNG file to stream from bitmap data buffer. */
     static void CompressPNG(hsStream* S, const void* buf, size_t size,
                             uint32_t width, uint32_t height, int pixelSize);
 

--- a/core/Util/plPNG.h
+++ b/core/Util/plPNG.h
@@ -17,7 +17,8 @@
 #ifndef _PLPNG_H
 #define _PLPNG_H
 
-#include "PRP/Surface/plMipmap.h"
+#include "PlasmaDefs.h"
+#include "Debug/hsExceptions.hpp"
 
 #include <png.h>
 
@@ -34,11 +35,17 @@ public:
 };
 
 
+class hsStream;
+class plMipmap;
+
 class HSPLASMA_EXPORT plPNG
 {
 public:
     /* Read PNG file from stream into buffer as bitmap data. */
     static void DecompressPNG(hsStream* S, void* buf, size_t size);
+
+    /* Read PNG file from stream directly into a plMipmap. */
+    static plMipmap* DecompressPNG(hsStream* S);
 
     /* Write PNG file to stream from bitmap data buffer. */
     static void CompressPNG(hsStream* S, const void* buf, size_t size,


### PR DESCRIPTION
This adds the previously-unimplemented JPEG writer, as well as two new functions to read PNG and JPG files directly into a plMipmap.  The existing readers were intended to be used only when reading from a data stream where the size of the buffer is already known by the calling function, and as such are inconvenient when reading directly from a file.

Depends on #127.