### PR TITLE
Add ResMgr option to preserve Object IDs

### DIFF
--- a/Tools/src/prcc.cpp
+++ b/Tools/src/prcc.cpp
@@ -27,9 +27,10 @@ static void doHelp(const char* exename)
     ST::printf("Usage: {} infile [options]\n", exename);
     puts("");
     puts("Options:");
-    puts("\t-o file  Write output to `file`");
-    puts("\t-v ver   Select output version (prime, pots, moul, eoa, hex, universal)");
-    puts("\t--help   Display this help and then exit");
+    puts("\t-o file     Write output to `file`");
+    puts("\t-v ver      Select output version (prime, pots, moul, eoa, hex, universal)");
+    puts("\t--keep-ids  Preserve the object IDs in the prc file");
+    puts("\t--help      Display this help and then exit");
     puts("");
 }
 
@@ -37,6 +38,7 @@ int main(int argc, char* argv[])
 {
     ST::string inputFile, outputFile;
     PlasmaVer outVer = PlasmaVer::pvUnknown;
+    bool keepIDs = false;
 
     if (argc == 1) {
         doHelp(argv[0]);
@@ -64,6 +66,8 @@ int main(int argc, char* argv[])
                 ST::printf(stderr, "Error: unrecognized version: {}\n", ver);
                 return 1;
             }
+        } else if (strcmp(argv[i], "--keep-ids") == 0) {
+            keepIDs = true;
         } else if (strcmp(argv[i], "-?") == 0 || strcmp(argv[i], "--help") == 0) {
             doHelp(argv[0]);
             return 0;
@@ -82,8 +86,7 @@ int main(int argc, char* argv[])
     }
 
     plDebug::Init(plDebug::kDLAll);
-    plResManager rm;
-    rm.setVer(outVer, true);
+    plResManager rm(outVer, keepIDs);
     hsFileStream S;
     if (!S.open(inputFile, fmRead)) {
         fputs("Error opening input file\n", stderr);

--- a/Tools/src/prcdc.cpp
+++ b/Tools/src/prcdc.cpp
@@ -127,8 +127,7 @@ int main(int argc, char* argv[])
     }
 
     plDebug::Init(plDebug::kDLAll);
-    plResManager rm;
-    rm.setVer(inVer, true);
+    plResManager rm(inVer, true);
 
     hsFileStream out;
     out.open(outputFile, fmCreate);

--- a/core/PRP/KeyedObject/plUoid.cpp
+++ b/core/PRP/KeyedObject/plUoid.cpp
@@ -136,6 +136,10 @@ void plUoid::prcParse(const pfPrcTag* tag)
     loadMask.prcParse(tag);
     cloneID = tag->getParam("CloneID", "0").to_uint();
     clonePlayerID = tag->getParam("ClonePlayerID", "0").to_uint();
+
+    unsigned int oid = tag->getParam("ObjID", "0").to_uint();
+    if (oid != 0)
+        objID = oid;
 }
 
 ST::string plUoid::toString() const

--- a/core/ResManager/plResManager.h
+++ b/core/ResManager/plResManager.h
@@ -65,6 +65,7 @@ protected:
     LoadProgressCallback progressFunc;
     PageUnloadCallback pageUnloadFunc;
     bool mustStub;
+    bool preserveIDs;
 
 private:
     unsigned int ReadKeyring(hsStream* S, const plLocation& loc);
@@ -82,8 +83,8 @@ public:
      * ReadPage() or ReadAge()
      * \sa setVer(), getVer()
      */
-    plResManager(PlasmaVer pv = PlasmaVer::pvUnknown)
-        : fPlasmaVer(PlasmaVer::pvUnknown), mustStub(false)
+    plResManager(PlasmaVer pv = PlasmaVer::pvUnknown, bool preserveObjIDs = false)
+        : fPlasmaVer(PlasmaVer::pvUnknown), mustStub(), preserveIDs(preserveObjIDs)
     {
         setVer(pv);
     }


### PR DESCRIPTION
After several attempts to address issues around Object ID mismatches, we've adopted a stance of libHSPlasma reassigning all Object IDs on read. This generally works okay (with caveats around cross-page references) but causes problems if you're wanting to round-trip data through libHSPlasma without modifying it.

This adds a `preserveObjectIDs()` method to plResManager that tells it not to change object IDs when reading. This is **not safe** if you are adding or removing any objects from the PRP file, but should be safe if you're only wanting to edit some object data.

This also sets up the `prcdc` tool to always dump out the original Object IDs to get an accurate view of the data.

When running `prcc` to compile from PRC files, there's a new `--keep-ids` option to use the object ID values as read from the PRC. This enables us to round-trip through `prcdc`/`prcc` without renumbering all the data, which should help us to track down any PRC parsing issues.