### PR TITLE
Dependency cleanups for downstream consumers.

### DIFF
--- a/Tools/CMakeLists.txt
+++ b/Tools/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 macro(plasma_tool NAME)
     add_executable(${NAME} src/${NAME}.cpp)
-    target_link_libraries(${NAME} HSPlasma ${STRING_THEORY_LIBRARIES})
+    target_link_libraries(${NAME} PRIVATE HSPlasma)
     install(TARGETS ${NAME} RUNTIME DESTINATION bin)
 endmacro(plasma_tool)
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -802,8 +802,14 @@ add_library(HSPlasma
             ${SQUISH_SOURCES}
 )
 target_link_libraries(HSPlasma
-                      JPEG::JPEG PNG::PNG string_theory Threads::Threads ZLIB::ZLIB
-                      $<$<AND:$<BOOL:${ENABLE_PHYSX}>,$<BOOL:${PHYSX_FOUND}>>:${PHYSX_COOKING_LIBRARY}>
+                      PUBLIC
+                        string_theory
+                        Threads::Threads
+                      PRIVATE
+                        JPEG::JPEG
+                        PNG::PNG
+                        ZLIB::ZLIB
+                        $<$<AND:$<BOOL:${ENABLE_PHYSX}>,$<BOOL:${PHYSX_FOUND}>>:${PHYSX_COOKING_LIBRARY}>
 )
 
 target_include_directories(HSPlasma PUBLIC

--- a/core/HSPlasmaConfig.cmake.in
+++ b/core/HSPlasmaConfig.cmake.in
@@ -1,9 +1,12 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(ZLIB)
-find_dependency(JPEG)
-find_dependency(PNG)
+if(NOT "@BUILD_SHARED_LIBS@")
+    find_dependency(ZLIB)
+    find_dependency(JPEG)
+    find_dependency(PNG)
+endif()
+find_dependency(string_theory CONFIG)
 find_dependency(Threads)
 
 include(${CMAKE_CURRENT_LIST_DIR}/HSPlasma-targets.cmake)

--- a/net/CMakeLists.txt
+++ b/net/CMakeLists.txt
@@ -94,9 +94,11 @@ add_library(HSPlasmaNet
             ${PN_SOURCES}       ${PN_HEADERS}
 )
 target_link_libraries(HSPlasmaNet
-                      HSPlasma string_theory
-                      $<$<NOT:$<PLATFORM_ID:SunOS>>:OpenSSL::Crypto>
-                      $<$<PLATFORM_ID:Windows>:ws2_32>
+                      PUBLIC
+                        HSPlasma
+                      PRIVATE
+                        $<$<NOT:$<PLATFORM_ID:SunOS>>:OpenSSL::Crypto>
+                        $<$<PLATFORM_ID:Windows>:ws2_32>
 )
 
 target_include_directories(HSPlasmaNet PUBLIC

--- a/net/HSPlasmaNetConfig.cmake.in
+++ b/net/HSPlasmaNetConfig.cmake.in
@@ -2,7 +2,9 @@
 
 include(CMakeFindDependencyMacro)
 find_dependency(HSPlasma CONFIG)
-find_dependency(OpenSSL)
+if(NOT "@BUILD_SHARED_LIBS@")
+    find_dependency(OpenSSL)
+endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/HSPlasmaNet-targets.cmake)
 


### PR DESCRIPTION
If we're building shared libraries (eg HSPlasma.dll and HSPlasmaNet.dll), then downstream users don't need to link against or even know about libraries used internally, such as zlib, png, etc. This fixes our CMake package config files to only search for those dependencies if the downstream user needs to link against them due to building HSPlasma as a static library.

Further, add a missing search for the string_theory library config module.