### PR TITLE
Use namespaces for exported targets.

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -831,7 +831,10 @@ install(TARGETS HSPlasma
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib
 )
-install(EXPORT HSPlasma-targets DESTINATION share/cmake/HSPlasma)
+install(EXPORT HSPlasma-targets
+        DESTINATION share/cmake/HSPlasma
+        NAMESPACE HSPlasma::
+)
 
 include(CMakePackageConfigHelpers)
 configure_package_config_file(HSPlasmaConfig.cmake.in

--- a/core/HSPlasmaConfig.cmake.in
+++ b/core/HSPlasmaConfig.cmake.in
@@ -10,3 +10,5 @@ include(${CMAKE_CURRENT_LIST_DIR}/HSPlasma-targets.cmake)
 
 check_required_components("HSPlasma")
 set_and_check(HSPlasma_INCLUDE_DIRS "${PACKAGE_PREFIX_DIR}/include/HSPlasma")
+
+add_library(HSPlasma ALIAS HSPlasma::HSPlasma)

--- a/net/CMakeLists.txt
+++ b/net/CMakeLists.txt
@@ -117,7 +117,10 @@ install(TARGETS HSPlasmaNet
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib
 )
-install(EXPORT HSPlasmaNet-targets DESTINATION share/cmake/HSPlasmaNet)
+install(EXPORT HSPlasmaNet-targets
+        DESTINATION share/cmake/HSPlasmaNet
+        NAMESPACE HSPlasma::
+)
 
 include(CMakePackageConfigHelpers)
 configure_package_config_file(HSPlasmaNetConfig.cmake.in

--- a/net/HSPlasmaNetConfig.cmake.in
+++ b/net/HSPlasmaNetConfig.cmake.in
@@ -10,4 +10,6 @@ check_required_components("HSPlasmaNet")
 set_and_check(HSPlasmaNet_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/include/HSPlasmaNet")
 
 set(HSPlasmaNet_INCLUDE_DIRS ${HSPlasmaNet_INCLUDE_DIR} ${HSPlasma_INCLUDE_DIRS})
-set(HSPlasmaNet_LIBRARIES HSPlasmaNet HSPlasma)
+set(HSPlasmaNet_LIBRARIES HSPlasma::HSPlasmaNet HSPlasma::HSPlasma)
+
+add_library(HSPlasmaNet ALIAS HSPlasma::HSPlasmaNet)


### PR DESCRIPTION
There is a major GOTCHA for exported targets. If an imported library is namespaced (eg `HSPlasma::HSPlasma`), CMake will ensure that the library exists when it is used in a call to `target_link_libraries()`. If an imported library is *not* namespaced (eg `HSPlasma`), then, if the target doesn't exist, CMake will simply pass that library name to the linker and hope for the best. This can lead to confusing errors where, when a non-namespaced imported target is used, configuration can "succeed" but HSPlasma is not actually found correctly. The error doesn't actually emerge until the downstream project attempts to link against the nonexistent HSPlasma.

This change allows downstream users to link against `HSPlasma::HSPlasma` and get a free configure-time check that libHSPlasma has been properly found. An `ALIAS` has been added for the old exported target names to ensure backwards compatibility.