### PR TITLE
Never, never, never sort the keys during a page write.

### DIFF
--- a/core/ResManager/plResManager.cpp
+++ b/core/ResManager/plResManager.cpp
@@ -244,9 +244,6 @@ void plResManager::WritePage(hsStream* S, plPageInfo* page)
     std::vector<short> types = keys.getTypes(page->getLocation());
     page->setClassList(types);
 
-    if (preserveIDs)
-        keys.sortKeys(page->getLocation());
-
     page->write(S);
     page->setDataStart(S->pos());
     page->setNumObjects(WriteObjects(S, page->getLocation()));


### PR DESCRIPTION
Reordering keys during write causes ObjIDs to be invalidated by writing pages out. This means that users of tools like PRPShop have to click save on specific PRP files in specific orders. For more information, see pull request #218. The issue fixed here was introduced in ba1d890.