### PR TITLE
Fix base class of `plLayerSDLAnimation`

### DIFF
--- a/Python/PRP/Surface/pyLayerSDLAnimation.cpp
+++ b/Python/PRP/Surface/pyLayerSDLAnimation.cpp
@@ -34,7 +34,7 @@ PY_PLASMA_TYPE_INIT(LayerSDLAnimation)
 {
     pyLayerSDLAnimation_Type.tp_new = pyLayerSDLAnimation_new;
     pyLayerSDLAnimation_Type.tp_getset = pyLayerSDLAnimation_GetSet;
-    pyLayerSDLAnimation_Type.tp_base = &pyLayerAnimation_Type;
+    pyLayerSDLAnimation_Type.tp_base = &pyLayerAnimationBase_Type;
     if (PyType_CheckAndReady(&pyLayerSDLAnimation_Type) < 0)
         return nullptr;
 

--- a/Python/PyHSPlasma.pyi
+++ b/Python/PyHSPlasma.pyi
@@ -3868,7 +3868,7 @@ class plLayerLinkAnimation(plLayerAnimation):
 class plLayerMovie(plLayerAnimation):
     movieName: Union[PathLike, str] = ...
 
-class plLayerSDLAnimation(plLayerAnimation):
+class plLayerSDLAnimation(plLayerAnimationBase):
     varName: str = ...
 
 class plLeafController(plController):

--- a/core/PRP/Surface/plLayerAnimation.h
+++ b/core/PRP/Surface/plLayerAnimation.h
@@ -112,7 +112,7 @@ public:
 };
 
 
-class HSPLASMA_EXPORT plLayerSDLAnimation : public plLayerAnimation
+class HSPLASMA_EXPORT plLayerSDLAnimation : public plLayerAnimationBase
 {
     CREATABLE(plLayerSDLAnimation, kLayerSDLAnimation, plLayerAnimationBase)
 


### PR DESCRIPTION
According to the MOULa source code, the correct superclass is `plLayerAnimationBase` and not `plLayerAnimation`. libHSPlasma largely seems to agree - the `CREATABLE` declaration and all of the super method calls already use `plLayerAnimationBase`. The base class declarations saying `plLayerAnimation` were probably by accident.

Someone who knows more than me about old Plasma should double-check this, but I think this change is correct for all Plasma versions - the read/write code has always used `plLayerAnimationBase` as the base class and that apparently worked fine for more than a decade.