### PR TITLE
Fix plEAXListenerMod.h to be includable from outside libHSPlasma itself

### DIFF
--- a/Python/PRP/Audio/pyEAXListenerMod.cpp
+++ b/Python/PRP/Audio/pyEAXListenerMod.cpp
@@ -19,6 +19,7 @@
 #include <PRP/Audio/plEAXListenerMod.h>
 #include "PRP/Modifier/pyModifier.h"
 #include "PRP/KeyedObject/pyKey.h"
+#include <3rdPartyLibs/AL/EFX-Util.h>
 #include <3rdPartyLibs/AL/efx-unofficial.h>
 
 PY_PLASMA_NEW(EAXListenerMod, plEAXListenerMod)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -98,6 +98,7 @@ set(PRP_AUDIO_HEADERS
     PRP/Audio/plDirectMusicSound.h
     PRP/Audio/plEAXEffects.h
     PRP/Audio/plEAXListenerMod.h
+    PRP/Audio/plEAXStructures.h
     PRP/Audio/plSound.h
     PRP/Audio/plSoundBuffer.h
     PRP/Audio/plWin32Sound.h

--- a/core/PRP/Audio/plEAXListenerMod.h
+++ b/core/PRP/Audio/plEAXListenerMod.h
@@ -17,9 +17,9 @@
 #ifndef _PLEAXLISTENERMOD_H
 #define _PLEAXLISTENERMOD_H
 
+#include "plEAXStructures.h"
 #include "PRP/Modifier/plModifier.h"
 #include "Math/hsGeometry3.h"
-#include "3rdPartyLibs/AL/EFX-Util.h"
 
 class HSPLASMA_EXPORT plEAXListenerMod : public plSingleModifier
 {

--- a/core/PRP/Audio/plEAXStructures.h
+++ b/core/PRP/Audio/plEAXStructures.h
@@ -1,0 +1,43 @@
+// Subset of 3rdPartyLibs/AL/EFX-Util.h containing only the structures
+// used in the public API of plEAXListenerMod.
+
+#ifndef EAXVECTOR_DEFINED
+#define EAXVECTOR_DEFINED
+typedef struct _EAXVECTOR
+{
+    float x;
+    float y;
+    float z;
+} EAXVECTOR;
+#endif
+
+#ifndef EAXREVERBPROPERTIES_DEFINED
+#define EAXREVERBPROPERTIES_DEFINED
+typedef struct _EAXREVERBPROPERTIES
+{
+    unsigned long ulEnvironment;
+    float flEnvironmentSize;
+    float flEnvironmentDiffusion;
+    long lRoom;
+    long lRoomHF;
+    long lRoomLF;
+    float flDecayTime;
+    float flDecayHFRatio;
+    float flDecayLFRatio;
+    long lReflections;
+    float flReflectionsDelay;
+    EAXVECTOR vReflectionsPan;
+    long lReverb;
+    float flReverbDelay;
+    EAXVECTOR vReverbPan;
+    float flEchoTime;
+    float flEchoDepth;
+    float flModulationTime;
+    float flModulationDepth;
+    float flAirAbsorptionHF;
+    float flHFReference;
+    float flLFReference;
+    float flRoomRolloffFactor;
+    unsigned long ulFlags;
+} EAXREVERBPROPERTIES, *LPEAXREVERBPROPERTIES;
+#endif


### PR DESCRIPTION
The header PRP/Audio/plEAXListenerMod.h included an EFX header from 3rdPartyLibs, which isn't part of the public libHSPlasma headers that get installed into the prefix. This made it impossible for downstream projects (e. g. PlasmaShop) to use plEAXListenerMod.h, because the required EFX header is only accessible within libHSPlasma itself.

This PR solves the issue by adding a new header plEAXStructures.h, which contains a copy of the few EAX structures needed by plEAXListenerMod.h. (This is intentionally similar to [plEAXStructures.h in H-uru/Plasma](https://github.com/H-uru/Plasma/blob/HEAD/Sources/Plasma/PubUtilLib/plAudio/plEAXStructures.h).) This header doesn't depend on the OpenAL/EFX headers and can thus be included by downstream projects, but the definitions are compatible with the real OpenAL/EFX headers, so it *should* be safe to include both at once.

Though I wonder if libHSPlasma needs to use the real OpenAL headers at all. libHSPlasma doesn't actually use the OpenAL API - it only needs a couple of EAX structure definitions and some constants. Those could be easily replicated in a custom header, perhaps with the names changed to avoid any possible conflicts with the real OpenAL headers.