### PR TITLE
Fix handling of waveset bounding boxes.

### DIFF
--- a/core/PRP/Geometry/plDrawableSpans.cpp
+++ b/core/PRP/Geometry/plDrawableSpans.cpp
@@ -549,10 +549,10 @@ void plDrawableSpans::calcBounds()
             reboundPts[0].Z = fIcicles[i]->getWaterHeight() - kMaxWaveHeight;
             reboundPts[1].Z = fIcicles[i]->getWaterHeight() + kMaxWaveHeight;
 
-            world.setFromPoints(std::size(reboundPts), reboundPts);
+            world.setFromPoints(2, reboundPts);
             for (hsVector3& pt : reboundPts)
                 pt = fIcicles[i]->getWorldToLocal().multPoint(pt);
-            loc.setFromPoints(std::size(reboundPts), reboundPts);
+            loc.setFromPoints(2, reboundPts);
         } else {
             auto localPoints = std::make_unique<hsVector3[]>(verts.size());
             auto worldPoints = std::make_unique<hsVector3[]>(verts.size());


### PR DESCRIPTION
See CWE's `plGeometrySpans::AdjustBounds()` for the source of this change. Wavesets are flattened at runtime to the water height and are perturbed along the world Z axis. The input mesh, OTOH, conforms to the bottom of the pool. This means that if we simply spit out the bounding box of the input mesh, the resulting bounding box will be too deep in the -Z direction and not contain any of the +Z displacement needed. This means that the waveset could vanish due to culling.

NOTE: A draft because I'd like to test this change against korman.