### PR TITLE
Fix Linux CI dependencies

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -6,6 +6,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libjpeg-turbo8-dev libpng-dev
       - name: Build string_theory
         run: |
           mkdir -p build_deps && cd build_deps


### PR DESCRIPTION
On ubuntu-24.04 images (which will soon be ubuntu-latest), it seems we need to explicitly install libpng and libjpeg-turbo