### PR TITLE
Avoid WORDS_BIGENDIAN conflict with Python3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,12 @@ cmake_dependent_option(
     OFF
 )
 
+include(TestBigEndian)
+test_big_endian(BIG_ENDIAN)
+if(BIG_ENDIAN)
+    add_definitions("-DHS_BIG_ENDIAN")
+endif()
+
 set(CMAKE_C_FLAGS_DEBUG "-DDEBUG ${CMAKE_C_FLAGS_DEBUG}")
 set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG ${CMAKE_CXX_FLAGS_DEBUG}")
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR

--- a/core/Stream/hsStream.cpp
+++ b/core/Stream/hsStream.cpp
@@ -54,7 +54,7 @@ uint16_t hsStream::readShort()
 void hsStream::readShorts(size_t count, uint16_t* buf)
 {
     read(sizeof(uint16_t) * count, buf);
-#ifdef WORDS_BIGENDIAN
+#ifdef HS_BIG_ENDIAN
     for (size_t i=0; i<count; i++)
         buf[i] = LESWAP16(buf[i]);
 #endif
@@ -70,7 +70,7 @@ uint32_t hsStream::readInt()
 void hsStream::readInts(size_t count, uint32_t* buf)
 {
     read(sizeof(uint32_t) * count, buf);
-#ifdef WORDS_BIGENDIAN
+#ifdef HS_BIG_ENDIAN
     for (size_t i=0; i<count; i++)
         buf[i] = LESWAP32(buf[i]);
 #endif
@@ -220,7 +220,7 @@ void hsStream::writeShort(uint16_t v)
 
 void hsStream::writeShorts(size_t count, const uint16_t* buf)
 {
-#ifdef WORDS_BIGENDIAN
+#ifdef HS_BIG_ENDIAN
     uint16_t* swbuf = new uint16_t[count];
     for (size_t i=0; i<count; i++)
         swbuf[i] = LESWAP16(buf[i]);
@@ -239,7 +239,7 @@ void hsStream::writeInt(uint32_t v)
 
 void hsStream::writeInts(size_t count, const uint32_t* buf)
 {
-#ifdef WORDS_BIGENDIAN
+#ifdef HS_BIG_ENDIAN
     uint32_t* swbuf = new uint32_t[count];
     for (size_t i=0; i<count; i++)
         swbuf[i] = LESWAP32(buf[i]);

--- a/core/Sys/Platform.h
+++ b/core/Sys/Platform.h
@@ -71,11 +71,7 @@ inline double ENDSWAPD(double val)
     return conv.fv;
 }
 
-#if defined(MACOSX) && defined(__BIG_ENDIAN__)
-    #define WORDS_BIGENDIAN
-#endif
-
-#ifdef WORDS_BIGENDIAN
+#ifdef HS_BIG_ENDIAN
     #define LESWAP16(val) ENDSWAP16(val)
     #define BESWAP16(val) (val)
     #define LESWAP32(val) ENDSWAP32(val)


### PR DESCRIPTION
Python uses the same macro name internally, and this results in compiler warnings about redefining it. Since we're updating this, we might as well move to using CMake's endianness detection as opposed to relying on macros being defined (or not defined) in system headers because that has proven unreliable in the past.