### PR TITLE
Add convert helper for `plKey::getObj()`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 project(libhsplasma)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)

--- a/core/PRP/KeyedObject/plKey.h
+++ b/core/PRP/KeyedObject/plKey.h
@@ -21,6 +21,7 @@
 #include <cstddef>
 #include <functional>
 #include <list>
+#include <type_traits>
 
 #define GET_KEY_OBJECT(key, classname) \
     ((key.Exists() && key.isLoaded()) \
@@ -138,10 +139,32 @@ public:
     const plUoid& getUoid() const { return fUoid; }
 
     /** Returns a pointer to the object referenced by this key */
-    class hsKeyedObject* getObj() { return fObjPtr; }
+    template<typename _KeyedObjT = class hsKeyedObject>
+    _KeyedObjT* getObj(bool requireValid = true)
+    {
+        static_assert(
+            std::is_base_of_v<class hsKeyedObject, _KeyedObjT>,
+            "Cannot convert to a type that does not derive from hsKeyedObject"
+        );
+        // If they just want the KeyedObject, avoid calling all the convert functions.
+        if constexpr (std::is_same_v<class hsKeyedObject, _KeyedObjT>)
+            return fObjPtr;
+        return _KeyedObjT::Convert(fObjPtr, requireValid);
+    }
 
     /** Returns a const pointer to the object referenced by this key */
-    const class hsKeyedObject* getObj() const { return fObjPtr; }
+    template<typename _KeyedObjT = class hsKeyedObject>
+    const _KeyedObjT* getObj(bool requireValid = true) const
+    {
+        static_assert(
+            std::is_base_of_v<class hsKeyedObject, _KeyedObjT>,
+            "Cannot convert to a type that does not derive from hsKeyedObject"
+        );
+        // If they just want the KeyedObject, avoid calling all the convert functions.
+        if constexpr (std::is_same_v<class hsKeyedObject, _KeyedObjT>)
+            return fObjPtr;
+        return _KeyedObjT::Convert(fObjPtr, requireValid);
+    }
 
     /** Sets the object referenced by this key. */
     void setObj(class hsKeyedObject* obj);

--- a/core/PRP/Object/plSceneObject.cpp
+++ b/core/PRP/Object/plSceneObject.cpp
@@ -154,7 +154,7 @@ void plSceneObject::delModifier(size_t idx)
         if (key->getObj()->isStub()) {
             plDebug::Warning("WARNING:  Removing STUB modifier from SceneObject");
         } else {
-            plModifier* mod = plModifier::Convert(key->getObj());
+            plModifier* mod = key->getObj<plModifier>();
             mod->removeTarget(getKey());
         }
     }
@@ -169,7 +169,7 @@ void plSceneObject::clearModifiers()
                 plDebug::Warning("WARNING:  Removing STUB modifier from SceneObject");
                 continue;
             }
-            plModifier* mod = plModifier::Convert(key->getObj(), false);
+            plModifier* mod = key->getObj<plModifier>(false);
             mod->removeTarget(getKey());
         }
     }

--- a/core/PRP/Surface/plLayerInterface.cpp
+++ b/core/PRP/Surface/plLayerInterface.cpp
@@ -57,7 +57,7 @@ plKey plLayerInterface::getBottomOfStack() const
             // What use is returning an unloaded bottom layer?
             break;
         }
-        const plLayerInterface* underLay = plLayerInterface::Convert(bottom->fUnderLay->getObj(), false);
+        const plLayerInterface* underLay = bottom->fUnderLay->getObj<plLayerInterface>(false);
         if (underLay == nullptr)
             break;
         bottom = underLay;

--- a/core/ResManager/plResManager.cpp
+++ b/core/ResManager/plResManager.cpp
@@ -145,14 +145,6 @@ void plResManager::PrcWriteKey(pfPrcHelper* prc, hsKeyedObject* ko)
     PrcWriteKey(prc, ko->getKey());
 }
 
-hsKeyedObject* plResManager::getObject(const plKey& key)
-{
-    plKey fk = keys.findKey(key);
-    if (!fk.Exists())
-        return nullptr;
-    return fk->getObj();
-}
-
 plPageInfo* plResManager::ReadPage(const ST::string& filename, bool stub)
 {
     bool packed = true;
@@ -744,7 +736,7 @@ plSceneNode* plResManager::getSceneNode(const plLocation& loc)
     std::vector<plKey> kList = keys.getKeys(loc, kSceneNode);
     if (kList.empty())
         return nullptr;
-    return plSceneNode::Convert(kList[0]->getObj());
+    return kList[0]->getObj<plSceneNode>();
 }
 
 std::vector<plLocation> plResManager::getLocations()

--- a/core/ResManager/plResManager.h
+++ b/core/ResManager/plResManager.h
@@ -177,7 +177,14 @@ public:
      * the key's internal object pointer.
      * \sa plKeyData::getObj()
      */
-    class hsKeyedObject* getObject(const plKey& key);
+    template<typename _KeyedObjectT = class hsKeyedObject>
+    _KeyedObjectT* getObject(const plKey& key, bool requireValid = true)
+    {
+        plKey fk = keys.findKey(key);
+        if (!fk.Exists())
+            return nullptr;
+        return fk->getObj<_KeyedObjectT>(requireValid);
+    }
 
     /** Returns the total number of keys registered for the specified plLocation */
     unsigned int countKeys(const plLocation& loc) { return keys.countKeys(loc); }


### PR DESCRIPTION
This adds a friendly template parameter to `plKey::getObj()` and `plResManager::getObject()` to automatically call
`plKeyedFoo::Convert()` for you for ease of use. The easiest way to implement this was by bumping our minimum requirement to C++17. We don't *have* to stay on C++14 any more because Korman uses a custom Blender build that no longer relies on Visual Studio 2013.