### PR TITLE
Fix a crash in prpmod.

### DIFF
--- a/Tools/src/prpmod.cpp
+++ b/Tools/src/prpmod.cpp
@@ -204,7 +204,7 @@ int main(int argc, char* argv[])
         }
 
         if (cre) {
-            hsKeyedObject* kobj = hsKeyedObject::Convert(cre);
+            hsKeyedObject* kobj = hsKeyedObject::Convert(cre, false);
             if (kobj == nullptr) {
                 ST::printf(stderr, "Creatable '{}' is not a keyed object\n",
                            plFactory::ClassName(cre->ClassIndex()));


### PR DESCRIPTION
If someone gives us a `plCreatable` that isn't an `hsKeyedObject`, we will crash instead of printing out the error message because `hsKeyedObject::Convert(pCre)` will throw an exception. Change that to the non-throwing version.