### PR TITLE
Fix `plLocation` equality/comparison operators being inconsistent with each other

### DIFF
--- a/core/Math/hsGeometry3.h
+++ b/core/Math/hsGeometry3.h
@@ -47,10 +47,7 @@ struct HSPLASMA_EXPORT hsVector3
     }
 
     /** Returns true if the values of the vectors are non-identical */
-    bool operator!=(const hsVector3& other) const
-    {
-        return (X != other.X) || (Y != other.Y) || (Z != other.Z);
-    }
+    bool operator!=(const hsVector3& other) const { return !operator==(other); }
 
     /** Reads the vector from a stream */
     void read(hsStream* S);

--- a/core/Math/hsMatrix44.h
+++ b/core/Math/hsMatrix44.h
@@ -45,6 +45,7 @@ public:
     float operator()(int y, int x) const { return data[y+(x*4)]; }
     float& operator()(int y, int x) { return data[y+(x*4)]; }
     bool operator==(const hsMatrix44& other) const;
+    bool operator!=(const hsMatrix44& other) const { return !operator==(other); }
     const float* glMatrix() const { return data; }
 
     hsMatrix44 operator*(const hsMatrix44& right) const;

--- a/core/Math/hsQuat.h
+++ b/core/Math/hsQuat.h
@@ -34,10 +34,7 @@ struct HSPLASMA_EXPORT hsQuat
         return (X == other.X) && (Y == other.Y) && (Z == other.Z) && (W == other.W);
     }
 
-    bool operator!=(const hsQuat& other) const
-    {
-        return (X != other.X) || (Y != other.Y) || (Z != other.Z) || (W != other.W);
-    }
+    bool operator!=(const hsQuat& other) const { return !operator==(other); }
 
     hsQuat operator+(const hsQuat& rt) const
     {

--- a/core/PRP/KeyedObject/plKey.h
+++ b/core/PRP/KeyedObject/plKey.h
@@ -83,6 +83,8 @@ public:
      */
     bool operator==(const plKeyData& other) const { return (fUoid == other.fUoid); }
 
+    bool operator!=(const plKeyData& other) const { return !operator==(other); }
+
     /**
      * Read a key directly from the key index of a PRP file.  This will
      * include the file offset and size where the hsKeyedObject is stored.

--- a/core/PRP/KeyedObject/plKey.h
+++ b/core/PRP/KeyedObject/plKey.h
@@ -347,10 +347,10 @@ public:
     bool operator==(const plKeyData* other) const { return fKeyData == other; }
 
     /** Returns true if the keys point to different plKeyData structures */
-    bool operator!=(const plKey& other) const { return fKeyData != other.fKeyData; }
+    bool operator!=(const plKey& other) const { return !operator==(other); }
 
     /** Returns true if this key's plKeyData is NOT 'other' */
-    bool operator!=(const plKeyData* other) const { return fKeyData != other; }
+    bool operator!=(const plKeyData* other) const { return !operator==(other); }
 
     /** Provides sorting functionality for STL containers */
     bool operator<(const plKey& other) const

--- a/core/PRP/KeyedObject/plKey.h
+++ b/core/PRP/KeyedObject/plKey.h
@@ -81,7 +81,7 @@ public:
      * equivalent.  This basically just calls the == operator on the
      * plUoid (so storage information is not compared).
      */
-    bool operator==(plKeyData& other) const { return (fUoid == other.fUoid); }
+    bool operator==(const plKeyData& other) const { return (fUoid == other.fUoid); }
 
     /**
      * Read a key directly from the key index of a PRP file.  This will

--- a/core/PRP/KeyedObject/plLocation.cpp
+++ b/core/PRP/KeyedObject/plLocation.cpp
@@ -23,12 +23,6 @@ bool plLocation::operator==(const plLocation& other) const
             && fSeqPrefix == other.fSeqPrefix && fFlags == other.fFlags);
 }
 
-bool plLocation::operator!=(const plLocation& other) const
-{
-    return (fState != other.fState || fPageNum != other.fPageNum
-            || fSeqPrefix != other.fSeqPrefix || fFlags != other.fFlags);
-}
-
 bool plLocation::operator<(const plLocation& other) const
 {
     if (fState != other.fState) {

--- a/core/PRP/KeyedObject/plLocation.cpp
+++ b/core/PRP/KeyedObject/plLocation.cpp
@@ -36,6 +36,11 @@ bool plLocation::operator<(const plLocation& other) const
     }
 }
 
+bool plLocation::isSamePage(const plLocation& other) const
+{
+    return fState == other.fState && fSeqPrefix == other.fSeqPrefix && fPageNum == other.fPageNum;
+}
+
 void plLocation::parse(unsigned int id)
 {
     if (id == 0xFFFFFFFF) {

--- a/core/PRP/KeyedObject/plLocation.cpp
+++ b/core/PRP/KeyedObject/plLocation.cpp
@@ -20,7 +20,7 @@
 bool plLocation::operator==(const plLocation& other) const
 {
     return (fState == other.fState && fPageNum == other.fPageNum
-            && fSeqPrefix == other.fSeqPrefix);
+            && fSeqPrefix == other.fSeqPrefix && fFlags == other.fFlags);
 }
 
 bool plLocation::operator!=(const plLocation& other) const
@@ -31,9 +31,15 @@ bool plLocation::operator!=(const plLocation& other) const
 
 bool plLocation::operator<(const plLocation& other) const
 {
-    if (fSeqPrefix == other.fSeqPrefix)
+    if (fState != other.fState) {
+        return fState < other.fState;
+    } else if (fSeqPrefix != other.fSeqPrefix) {
+        return fSeqPrefix < other.fSeqPrefix;
+    } else if (fPageNum != other.fPageNum) {
         return fPageNum < other.fPageNum;
-    return fSeqPrefix < other.fSeqPrefix;
+    } else {
+        return fFlags < other.fFlags;
+    }
 }
 
 void plLocation::parse(unsigned int id)

--- a/core/PRP/KeyedObject/plLocation.h
+++ b/core/PRP/KeyedObject/plLocation.h
@@ -53,7 +53,7 @@ public:
     void setVer(PlasmaVer pv) { fVer = pv; }
 
     bool operator==(const plLocation& other) const;
-    bool operator!=(const plLocation& other) const;
+    bool operator!=(const plLocation& other) const { return !operator==(other); }
     bool operator<(const plLocation& other) const;
 
     void parse(unsigned int id);

--- a/core/PRP/KeyedObject/plLocation.h
+++ b/core/PRP/KeyedObject/plLocation.h
@@ -56,6 +56,9 @@ public:
     bool operator!=(const plLocation& other) const { return !operator==(other); }
     bool operator<(const plLocation& other) const;
 
+    /** Compare two locations only by their state and sequence number, ignoring flags. */
+    bool isSamePage(const plLocation& other) const;
+
     void parse(unsigned int id);
     unsigned int unparse() const;
 

--- a/core/ResManager/plResManager.cpp
+++ b/core/ResManager/plResManager.cpp
@@ -273,7 +273,7 @@ plPageInfo* plResManager::FindPage(const plLocation& loc)
 {
     std::vector<plPageInfo*>::iterator pi = pages.begin();
     while (pi != pages.end()) {
-        if ((*pi)->getLocation() == loc)
+        if ((*pi)->getLocation().isSamePage(loc))
             return *pi;
         pi++;
     }
@@ -282,16 +282,16 @@ plPageInfo* plResManager::FindPage(const plLocation& loc)
 
 void plResManager::UnloadPage(const plLocation& loc)
 {
-    // Make a copy, in case someone passed us the page's getLocation() reference
-    plLocation pageLoc = loc;
-
     for (auto it = pages.begin(); it != pages.end(); it++) {
-        if ((*it)->getLocation() == loc) {
+        if ((*it)->getLocation().isSamePage(loc)) {
+            // Copy the location so we can still use it
+            // after the plPageInfo has been deleted.
+            plLocation foundLocation = (*it)->getLocation();
             if (pageUnloadFunc)
-                pageUnloadFunc(loc);
+                pageUnloadFunc(foundLocation);
             delete *it;
             pages.erase(it);
-            keys.delAll(pageLoc);
+            keys.delAll(foundLocation);
             break;
         }
     }

--- a/core/Sys/hsColor.cpp
+++ b/core/Sys/hsColor.cpp
@@ -49,11 +49,6 @@ bool hsColorRGBA::operator==(const hsColorRGBA& other) const
     return (r == other.r) && (g == other.g) && (b == other.b) && (a == other.a);
 }
 
-bool hsColorRGBA::operator!=(const hsColorRGBA& other) const
-{
-    return (r != other.r) || (g != other.g) || (b != other.b) || (a != other.a);
-}
-
 void hsColorRGBA::read(hsStream* S)
 {
     r = S->readFloat();
@@ -111,11 +106,6 @@ void hsColorRGBA::prcParse(const pfPrcTag* tag)
 bool hsColor32::operator==(const hsColor32& other) const
 {
     return (color == other.color);
-}
-
-bool hsColor32::operator!=(const hsColor32& other) const
-{
-    return (color != other.color);
 }
 
 void hsColor32::read32(hsStream* S)

--- a/core/Sys/hsColor.h
+++ b/core/Sys/hsColor.h
@@ -45,7 +45,7 @@ public:
     void set(const hsColorRGBA& init);
 
     bool operator==(const hsColorRGBA& other) const;
-    bool operator!=(const hsColorRGBA& other) const;
+    bool operator!=(const hsColorRGBA& other) const { return !operator==(other); }
 
     void read(hsStream* S);
     void write(hsStream* S);
@@ -74,7 +74,7 @@ public:
         : b(blue), g(green), r(red), a(alpha) { }
 
     bool operator==(const hsColor32& other) const;
-    bool operator!=(const hsColor32& other) const;
+    bool operator!=(const hsColor32& other) const { return !operator==(other); }
 
     void read32(hsStream* S);
     void write32(hsStream* S);

--- a/core/Sys/plUnifiedTime.cpp
+++ b/core/Sys/plUnifiedTime.cpp
@@ -151,11 +151,6 @@ bool plUnifiedTime::operator==(const plUnifiedTime& other)
     return (fSecs == other.fSecs && fMicros == other.fMicros);
 }
 
-bool plUnifiedTime::operator!=(const plUnifiedTime& other)
-{
-    return (fSecs != other.fSecs || fMicros != other.fMicros);
-}
-
 bool plUnifiedTime::operator<(const plUnifiedTime& other)
 {
     if (fSecs < other.fSecs)

--- a/core/Sys/plUnifiedTime.h
+++ b/core/Sys/plUnifiedTime.h
@@ -63,7 +63,7 @@ public:
     plUnifiedTime& operator+=(const plUnifiedTime& other);
     plUnifiedTime& operator-=(const plUnifiedTime& other);
     bool operator==(const plUnifiedTime& other);
-    bool operator!=(const plUnifiedTime& other);
+    bool operator!=(const plUnifiedTime& other) { return !operator==(other); }
     bool operator<(const plUnifiedTime& other);
     bool operator>(const plUnifiedTime& other);
     bool operator<=(const plUnifiedTime& other);

--- a/core/Sys/plUuid.cpp
+++ b/core/Sys/plUuid.cpp
@@ -35,13 +35,6 @@ bool plUuid::operator==(const plUuid& other) const
     return (memcmp(fData4, other.fData4, sizeof(fData4)) == 0);
 }
 
-bool plUuid::operator!=(const plUuid& other) const
-{
-    if (fData1 == other.fData1 || fData2 == other.fData2 || fData3 == other.fData3)
-        return false;
-    return (memcmp(fData4, other.fData4, sizeof(fData4)) != 0);
-}
-
 void plUuid::read(hsStream* S)
 {
     fData1 = S->readInt();

--- a/core/Sys/plUuid.h
+++ b/core/Sys/plUuid.h
@@ -53,7 +53,7 @@ public:
     bool operator==(const plUuid& other) const;
 
     /** Returns true if the two UUIDs are non-identical. */
-    bool operator!=(const plUuid& other) const;
+    bool operator!=(const plUuid& other) const { return !operator==(other); }
 
     /** Read the UUID from a stream */
     void read(hsStream* S);

--- a/core/Util/hsBitVector.h
+++ b/core/Util/hsBitVector.h
@@ -69,6 +69,8 @@ public:
         /** Comparison operator */
         bool operator==(bool value) const;
 
+        bool operator!=(bool value) const { return !operator==(value); }
+
         /** Assignment operator -- modifies the hsBitVector */
         Bit& operator=(bool value);
     };

--- a/core/Util/plMD5.cpp
+++ b/core/Util/plMD5.cpp
@@ -61,11 +61,6 @@ bool plMD5Hash::operator==(const plMD5Hash& cmp) const
     return memcmp(fHash, cmp.fHash, sizeof(fHash)) == 0;
 }
 
-bool plMD5Hash::operator!=(const plMD5Hash& cmp) const
-{
-    return memcmp(fHash, cmp.fHash, sizeof(fHash)) != 0;
-}
-
 ST::string plMD5Hash::toHex() const
 {
     // Little-endian byte order

--- a/core/Util/plMD5.h
+++ b/core/Util/plMD5.h
@@ -29,7 +29,7 @@ public:
     plMD5Hash();
     plMD5Hash(const char* hex) { fromHex(hex); }
     bool operator==(const plMD5Hash& cmp) const;
-    bool operator!=(const plMD5Hash& cmp) const;
+    bool operator!=(const plMD5Hash& cmp) const { return !operator==(cmp); }
 
     ST::string toHex() const;
     void fromHex(const char* hex);

--- a/net/auth/pnVaultNode.h
+++ b/net/auth/pnVaultNode.h
@@ -127,6 +127,7 @@ struct HSPLASMANET_EXPORT pnVaultNodeRef
     void read(const unsigned char* buffer);
     void write(unsigned char* buffer);
     bool operator==(const pnVaultNodeRef& ref) const;
+    bool operator!=(const pnVaultNodeRef& ref) const { return !operator==(ref); }
 };
 
 #endif

--- a/net/crypt/pnBigInteger.cpp
+++ b/net/crypt/pnBigInteger.cpp
@@ -104,16 +104,6 @@ bool pnBigInteger::operator==(unsigned int num) const
     return BN_is_word(fValue, num) != 0;
 }
 
-bool pnBigInteger::operator!=(const pnBigInteger& num) const
-{
-    return BN_cmp(fValue, num.fValue) != 0;
-}
-
-bool pnBigInteger::operator!=(unsigned int num) const
-{
-    return BN_is_word(fValue, num) == 0;
-}
-
 bool pnBigInteger::operator<(const pnBigInteger& num) const
 {
     return BN_cmp(fValue, num.fValue) < 0;

--- a/net/crypt/pnBigInteger.h
+++ b/net/crypt/pnBigInteger.h
@@ -49,8 +49,8 @@ public:
     // Comparison
     bool operator==(const pnBigInteger& num) const;
     bool operator==(unsigned int num) const;
-    bool operator!=(const pnBigInteger& num) const;
-    bool operator!=(unsigned int num) const;
+    bool operator!=(const pnBigInteger& num) const { return !operator==(num); }
+    bool operator!=(unsigned int num) const { return !operator==(num); }
     bool operator<(const pnBigInteger& num) const;
     bool operator<(unsigned int num) const;
     bool operator>(const pnBigInteger& num) const;


### PR DESCRIPTION
In the current code, the `==`, `!=`, and `<` operators for `plLocation` all look at different combinations of fields. In particular, `==` doesn't look at `fFlags` even though `!=` does, and `<` doesn't look at `fFlags` or `fState`. This PR makes all three operators consistent with each other.

These buggy implementations led to some bad behavior when editing a PRP's flags in PrpShop, which seems to be fixed with this PR. This *hopefully* fixes the problems that @TheScarFr had when trying to change a PRP from reserved to non-reserved (I'm not completely sure, because I couldn't reproduce the bug exactly).

Apparently the buggy code has been this way for over 15 years? This seems really bad! I'm surprised that this hasn't caused any other problems with PRP edits before.

While I was here, I also replaced *all* `operator!=` implementations with `return !operator==(other);` to prevent any future inconsistencies between `==` and `!=`, and added `operator!=` overloads to classes that only defined `operator==`.