### PR TITLE
Remove windows-2019 runners.

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -13,8 +13,8 @@ jobs:
           - { image: windows-2022, generator: Visual Studio 17 2022, toolset: v143, cmake-arch: x64, arch: x64, python: "3.10", unity: ON, str: windows-x64-v143 }
           - { image: windows-2022, generator: Visual Studio 17 2022, toolset: v142, cmake-arch: Win32, arch: x86, python: 3.9, unity: ON, str: windows-x86-v142 }
           - { image: windows-2022, generator: Visual Studio 17 2022, toolset: v142, cmake-arch: x64, arch: x64, python: 3.8, unity: OFF, str: windows-x64-v142 }
-          - { image: windows-2022, generator: Visual Studio 17 2022, toolset: v141, cmake-arch: Win32, arch: x86, python: 3.7, unity: OFF, str: windows-x86-v141 }
-          - { image: windows-2022, generator: Visual Studio 17 2022, toolset: v141, cmake-arch: x64, arch: x64, python: 3.6, unity: ON, str: windows-x64-v141 }
+          - { image: windows-2022, generator: Visual Studio 17 2022, toolset: v142, cmake-arch: Win32, arch: x86, python: 3.7, unity: OFF, str: windows-x86-v142 }
+          - { image: windows-2022, generator: Visual Studio 17 2022, toolset: v142, cmake-arch: x64, arch: x64, python: 3.6, unity: ON, str: windows-x64-v142 }
     env:
       VCPKG_BINARY_SOURCES: 'clear'
       VCPKG_DEFAULT_HOST_TRIPLET: windows-hsplasma

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -7,6 +7,7 @@ jobs:
     strategy:
       matrix:
         platform:
+          - { image: windows-2022, generator: Visual Studio 17 2022, toolset: v143, cmake-arch: x64, arch: x64, python: "3.13", unity: OFF, str: windows-x64-v143 }
           - { image: windows-2022, generator: Visual Studio 17 2022, toolset: v143, cmake-arch: x64, arch: x64, python: "3.12", unity: ON, str: windows-x64-v143 }
           - { image: windows-2022, generator: Visual Studio 17 2022, toolset: v143, cmake-arch: x64, arch: x64, python: "3.11", unity: ON, str: windows-x64-v143 }
           - { image: windows-2022, generator: Visual Studio 17 2022, toolset: v143, cmake-arch: x64, arch: x64, python: "3.10", unity: ON, str: windows-x64-v143 }

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -10,11 +10,10 @@ jobs:
           - { image: windows-2022, generator: Visual Studio 17 2022, toolset: v143, cmake-arch: x64, arch: x64, python: "3.12", unity: ON, str: windows-x64-v143 }
           - { image: windows-2022, generator: Visual Studio 17 2022, toolset: v143, cmake-arch: x64, arch: x64, python: "3.11", unity: ON, str: windows-x64-v143 }
           - { image: windows-2022, generator: Visual Studio 17 2022, toolset: v143, cmake-arch: x64, arch: x64, python: "3.10", unity: ON, str: windows-x64-v143 }
-          - { image: windows-2019, generator: Visual Studio 16 2019, toolset: v142, cmake-arch: Win32, arch: x86, python: 3.9, unity: ON, str: windows-x86-v142 }
-          - { image: windows-2019, generator: Visual Studio 16 2019, toolset: v142, cmake-arch: x64, arch: x64, python: 3.8, unity: OFF, str: windows-x64-v142 }
-          # The windows-2016 image with VS 2017 is going the way of the dodo, so just use VS2019 with the 2017 compiler.
-          - { image: windows-2019, generator: Visual Studio 16 2019, toolset: v141, cmake-arch: Win32, arch: x86, python: 3.7, unity: OFF, str: windows-x86-v141 }
-          - { image: windows-2019, generator: Visual Studio 16 2019, toolset: v141, cmake-arch: x64, arch: x64, python: 3.6, unity: ON, str: windows-x64-v141 }
+          - { image: windows-2022, generator: Visual Studio 17 2022, toolset: v142, cmake-arch: Win32, arch: x86, python: 3.9, unity: ON, str: windows-x86-v142 }
+          - { image: windows-2022, generator: Visual Studio 17 2022, toolset: v142, cmake-arch: x64, arch: x64, python: 3.8, unity: OFF, str: windows-x64-v142 }
+          - { image: windows-2022, generator: Visual Studio 17 2022, toolset: v141, cmake-arch: Win32, arch: x86, python: 3.7, unity: OFF, str: windows-x86-v141 }
+          - { image: windows-2022, generator: Visual Studio 17 2022, toolset: v141, cmake-arch: x64, arch: x64, python: 3.6, unity: ON, str: windows-x64-v141 }
     env:
       VCPKG_BINARY_SOURCES: 'clear'
       VCPKG_DEFAULT_HOST_TRIPLET: windows-hsplasma


### PR DESCRIPTION
The windows-2019 runner was removed from GHA about a month ago. Also, we need to test against at least Python 3.13.