### PR TITLE
Fix some Mipmap PRC annoyances.

### DIFF
--- a/core/PRP/Surface/plMipmap.cpp
+++ b/core/PRP/Surface/plMipmap.cpp
@@ -283,7 +283,10 @@ void plMipmap::IPrcWrite(pfPrcHelper* prc)
         prc->closeTag();    // JPEG
     } else {
         prc->writeSimpleTag("DDS");
-        prc->writeHexStream(fTotalSize, fImageData);
+        if (!prc->isExcluded(pfPrcHelper::kExcludeTextureData))
+            prc->writeHexStream(fTotalSize, fImageData);
+        else
+            prc->writeComment("Texture data excluded");
         prc->closeTag();
     }
 }

--- a/core/PRP/Surface/plMipmap.cpp
+++ b/core/PRP/Surface/plMipmap.cpp
@@ -281,8 +281,15 @@ void plMipmap::IPrcWrite(pfPrcHelper* prc)
         }
 
         prc->closeTag();    // JPEG
-    } else {
+    } else if (fCompressionType == kDirectXCompression) {
         prc->writeSimpleTag("DDS");
+        if (!prc->isExcluded(pfPrcHelper::kExcludeTextureData))
+            prc->writeHexStream(fTotalSize, fImageData);
+        else
+            prc->writeComment("Texture data excluded");
+        prc->closeTag();
+    } else {
+        prc->writeSimpleTag("ImageData");
         if (!prc->isExcluded(pfPrcHelper::kExcludeTextureData))
             prc->writeHexStream(fTotalSize, fImageData);
         else


### PR DESCRIPTION
- Fixes DDS, uncompressed, and PNG image data leaking into PRC when I said I don't want it.
- Fixes uncompressed and PNG image data being dumped into a "DDS" tag. Those images aren't DDS. DDS has certain implications in Plasma that are totally invalid with the other image types. Don't mislabel them.