### PR TITLE
Fix macOS CI.

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        compiler: [gcc, clang]
+        compiler: [clang]
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies


### PR DESCRIPTION
gcc on ARM macOS seems to be crapping all over itself inside standard headers. Ain't nobody got time fo'dat, so just remove it.