### PR TITLE
Improve C types used in pyStream.

### DIFF
--- a/Python/Stream/pyStream.cpp
+++ b/Python/Stream/pyStream.cpp
@@ -44,12 +44,12 @@ PY_METHOD_VA(Stream, seek,
     "Params: position\n"
     "Seeks to the specified position within the stream")
 {
-    int32_t pos;
-    if (!PyArg_ParseTuple(args, "i", &pos)) {
-        PyErr_SetString(PyExc_TypeError, "seek expects an int");
+    uint32_t pos;
+    if (!PyArg_ParseTuple(args, "I", &pos)) {
+        PyErr_SetString(PyExc_TypeError, "seek expects an unsigned int");
         return nullptr;
     }
-    self->fThis->seek((uint32_t)pos);
+    self->fThis->seek(pos);
     Py_RETURN_NONE;
 }
 
@@ -58,8 +58,8 @@ PY_METHOD_VA(Stream, skip,
     "Skips `count` bytes within the stream")
 {
     uint32_t count;
-    if (!PyArg_ParseTuple(args, "i", &count)) {
-        PyErr_SetString(PyExc_TypeError, "skip expects an int");
+    if (!PyArg_ParseTuple(args, "I", &count)) {
+        PyErr_SetString(PyExc_TypeError, "skip expects an unsigned int");
         return nullptr;
     }
     self->fThis->skip(count);
@@ -88,8 +88,8 @@ PY_METHOD_VA(Stream, read,
     "Params: size\n"
     "Reads `size` bytes and returns a binary string with the data")
 {
-    int size;
-    if (!PyArg_ParseTuple(args, "i", &size)) {
+    Py_ssize_t size;
+    if (!PyArg_ParseTuple(args, "n", &size)) {
         PyErr_SetString(PyExc_TypeError, "read expects an int");
         return nullptr;
     }


### PR DESCRIPTION
The impetus of this change is a Korman error posted in discord:

<img width="1080" height="600" alt="image" src="https://github.com/user-attachments/assets/2b508149-212f-40bd-b279-4d2847660fa1" />

The Python code in question is:
```python
        if flags[_HeaderBits.index_pos]:
            index_pos = stream.readInt()
            self._read_index(index_pos, stream)
```
```python
    def _read_index(self, index_pos, stream):
        stream.seek(index_pos)
        assert stream.read(4) == _INDEX_MAGICK
```

It's difficult to ascertain how we could be sending the wrong type in to `stream.seek()` if it's literally an integer we read from the file. Unless the type conversion code itself is incorrect. As I learned in H-uru/Plasma#1893, Python can be picky about signed/unsigned mismatches. I don't know for certain that this is the root cause of the problem that the user reported, but it clearly needs to be addressed.